### PR TITLE
fix(room): remove redundant FAB that obscured send button

### DIFF
--- a/lib/features/room/room_screen.dart
+++ b/lib/features/room/room_screen.dart
@@ -112,14 +112,6 @@ class _RoomScreenState extends ConsumerState<RoomScreen> {
         leading: isDesktop ? _buildSidebarToggle() : null,
         title: _buildRoomDropdown(),
         drawer: isDesktop ? null : HistoryPanel(roomId: widget.roomId),
-        floatingActionButton: Semantics(
-          label: 'Create new thread',
-          child: FloatingActionButton(
-            tooltip: 'Create new thread',
-            onPressed: _handleNewThread,
-            child: const Icon(Icons.add),
-          ),
-        ),
       ),
       body: isDesktop ? _buildDesktopLayout(context) : const ChatPanel(),
     );
@@ -200,10 +192,5 @@ class _RoomScreenState extends ConsumerState<RoomScreen> {
         const Expanded(child: ChatPanel()),
       ],
     );
-  }
-
-  void _handleNewThread() {
-    ref.read(threadSelectionProvider.notifier).set(const NewThreadIntent());
-    // ChatPanel will create thread on first message
   }
 }

--- a/lib/shared/widgets/app_shell.dart
+++ b/lib/shared/widgets/app_shell.dart
@@ -35,7 +35,6 @@ class AppShell extends StatelessWidget {
           child: Drawer(child: HttpInspectorPanel()),
         ),
       ),
-      floatingActionButton: config.floatingActionButton,
       body: body,
     );
   }

--- a/lib/shared/widgets/shell_config.dart
+++ b/lib/shared/widgets/shell_config.dart
@@ -11,7 +11,6 @@ class ShellConfig {
     this.leading,
     this.actions = const [],
     this.drawer,
-    this.floatingActionButton,
   });
 
   /// The primary widget displayed in the AppBar.
@@ -27,7 +26,4 @@ class ShellConfig {
   /// Optional drawer for mobile navigation (e.g., thread list).
   /// Shown as leading drawer, separate from the HTTP inspector endDrawer.
   final Widget? drawer;
-
-  /// Optional floating action button for the screen.
-  final Widget? floatingActionButton;
 }

--- a/test/features/room/room_screen_test.dart
+++ b/test/features/room/room_screen_test.dart
@@ -65,24 +65,6 @@ void main() {
       expect(find.byType(ChatPanel), findsOneWidget);
       expect(find.byType(HistoryPanel), findsNothing);
     });
-
-    testWidgets('shows FAB for creating thread', (tester) async {
-      await tester.pumpWidget(
-        createTestApp(
-          home: const RoomScreen(roomId: 'general'),
-          overrides: [
-            threadsProvider('general').overrideWith((ref) async => []),
-            lastViewedThreadProvider(
-              'general',
-            ).overrideWith((ref) async => const NoLastViewed()),
-          ],
-        ),
-      );
-
-      await tester.pumpAndSettle();
-
-      expect(find.byType(FloatingActionButton), findsOneWidget);
-    });
   });
 
   group('RoomScreen sidebar toggle', () {


### PR DESCRIPTION
## Summary

- Removed the FloatingActionButton from RoomScreen that duplicated the "New Conversation" button in HistoryPanel
- Removed unused `floatingActionButton` field from ShellConfig and AppShell (YAGNI)
- Removed corresponding test for FAB existence

## Test plan

- [x] Verify "New Conversation" button in HistoryPanel still works on mobile (drawer) and desktop (sidebar)
- [x] Verify send message button is no longer obscured by FAB
- [x] All 207 tests pass
- [x] `flutter analyze --fatal-infos` reports 0 issues

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)