### PR TITLE
fix(router): redirect authenticated users from public routes to /rooms

### DIFF
--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -69,8 +69,9 @@ const _publicRoutes = {'/', '/login', '/auth/callback'};
 /// shouldn't cause navigation).
 ///
 /// Routes:
-/// - `/login` - Login screen (public)
-/// - `/` - Home screen (requires auth)
+/// - `/login` - Login screen (public, authenticated users redirect to /rooms)
+/// - `/` - Home screen (public, authenticated users redirect to /rooms)
+/// - `/auth/callback` - OAuth callback (public, authenticated users redirect to /rooms)
 /// - `/rooms` - List of rooms (requires auth)
 /// - `/rooms/:roomId` - Room with thread selection (requires auth)
 /// - `/rooms/:roomId/thread/:threadId` - Redirects to query param format

--- a/test/core/router/app_router_test.dart
+++ b/test/core/router/app_router_test.dart
@@ -176,6 +176,22 @@ void main() {
       expect(find.byType(RoomsScreen), findsOneWidget);
     });
 
+    testWidgets('redirects authenticated users from /login to /rooms', (
+      tester,
+    ) async {
+      await tester.pumpWidget(createRouterAppAt('/login'));
+      await tester.pumpAndSettle();
+      expect(find.byType(RoomsScreen), findsOneWidget);
+    });
+
+    testWidgets('redirects authenticated users from /auth/callback to /rooms', (
+      tester,
+    ) async {
+      await tester.pumpWidget(createRouterAppAt('/auth/callback'));
+      await tester.pumpAndSettle();
+      expect(find.byType(RoomsScreen), findsOneWidget);
+    });
+
     testWidgets('shows home when unauthenticated at /', (tester) async {
       await tester.pumpWidget(createRouterApp(authenticated: false));
       await tester.pumpAndSettle();
@@ -201,6 +217,16 @@ void main() {
           authenticated: false,
           noAuthMode: true,
         ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.byType(RoomsScreen), findsOneWidget);
+    });
+
+    testWidgets('redirects NoAuthRequired users from / to /rooms', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        createRouterApp(authenticated: false, noAuthMode: true),
       );
       await tester.pumpAndSettle();
       expect(find.byType(RoomsScreen), findsOneWidget);


### PR DESCRIPTION
## Summary
- Authenticated users are now redirected from any public route (/, /login, /auth/callback) to /rooms
- Previously only /login redirected authenticated users

## Design Principle
Public routes are for guests only. If you have access, you leave public routes.

## Changes
- `app_router.dart`: Changed condition from `state.matchedLocation == '/login'` to `isPublicRoute`
- Updated test router to match production public routes set
- Updated tests to expect new redirect behavior

Closes #7

## Test plan
- [x] All 639 tests pass
- [x] Coverage 85.1% (above 70% threshold)
- [x] `dart format --set-exit-if-changed .` passes
- [x] `flutter analyze --fatal-infos` passes
- [x] Web build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)