### PR TITLE
fix: remove edit button from settings screen

### DIFF
--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -10,71 +10,6 @@ import 'package:soliplex_frontend/core/providers/config_provider.dart';
 class SettingsScreen extends ConsumerWidget {
   const SettingsScreen({super.key});
 
-  Future<void> _showUrlEditDialog(
-    BuildContext context,
-    WidgetRef ref,
-    String currentUrl,
-  ) async {
-    final controller = TextEditingController(text: currentUrl);
-    final formKey = GlobalKey<FormState>();
-
-    final newUrl = await showDialog<String>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('Backend URL'),
-        content: Form(
-          key: formKey,
-          child: TextFormField(
-            controller: controller,
-            decoration: const InputDecoration(
-              labelText: 'URL',
-              hintText: 'http://localhost:8000',
-              border: OutlineInputBorder(),
-            ),
-            keyboardType: TextInputType.url,
-            autofocus: true,
-            validator: (value) {
-              if (value == null || value.trim().isEmpty) {
-                return 'Please enter a URL';
-              }
-              final trimmed = value.trim();
-              if (!trimmed.startsWith('http://') &&
-                  !trimmed.startsWith('https://')) {
-                return 'URL must start with http:// or https://';
-              }
-              return null;
-            },
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () {
-              if (formKey.currentState!.validate()) {
-                Navigator.of(context).pop(controller.text.trim());
-              }
-            },
-            child: const Text('Save'),
-          ),
-        ],
-      ),
-    );
-
-    controller.dispose();
-
-    if (newUrl != null && newUrl != currentUrl) {
-      await ref.read(configProvider.notifier).setBaseUrl(newUrl);
-      if (context.mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(const SnackBar(content: Text('Backend URL updated')));
-      }
-    }
-  }
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final config = ref.watch(configProvider);
@@ -91,8 +26,6 @@ class SettingsScreen extends ConsumerWidget {
           leading: const Icon(Icons.dns),
           title: const Text('Backend URL'),
           subtitle: Text(config.baseUrl),
-          trailing: const Icon(Icons.edit),
-          onTap: () => _showUrlEditDialog(context, ref, config.baseUrl),
         ),
         const Divider(),
         _AuthSection(authState: authState),


### PR DESCRIPTION
## Summary
- Remove backend URL edit button and dialog from settings screen
- Backend URL now displays as read-only information
- Initial URL entry remains available on home screen connection flow

Closes #34

## Test plan
- [x] Verify settings screen displays backend URL without edit icon
- [x] Verify all existing tests pass (683 tests)
- [x] Verify `dart analyze` reports 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)