### PR TITLE
chore: bump version to 0.50.2+9

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: soliplex_frontend
 description: Cross-platform Flutter frontend for Soliplex AI-powered RAG system
 publish_to: 'none'
-version: 0.50.1+8
+version: 0.50.2+9
 
 environment:
   sdk: '>=3.5.0 <4.0.0'


### PR DESCRIPTION
## Summary
- Bump app version from 0.50.1+8 to 0.50.2+9

🤖 Generated with [Claude Code](https://claude.com/claude-code)