### PR TITLE
chore: bump version to 0.50.4+11

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: soliplex_frontend
 description: Cross-platform Flutter frontend for Soliplex AI-powered RAG system
 publish_to: 'none'
-version: 0.50.3+10
+version: 0.50.4+11
 
 environment:
   sdk: '>=3.5.0 <4.0.0'


### PR DESCRIPTION
## Summary
- Bumps version from 0.50.3+10 to 0.50.4+11

## Test plan
- [ ] Verify version displays correctly in app settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)