### PR TITLE
fix: increase default API timeout to 600s

### DIFF
--- a/packages/soliplex_client/lib/src/http/dart_http_client.dart
+++ b/packages/soliplex_client/lib/src/http/dart_http_client.dart
@@ -38,7 +38,7 @@ class DartHttpClient implements SoliplexHttpClient {
   /// - [defaultTimeout]: Default timeout for requests. Defaults to 30 seconds.
   DartHttpClient({
     http.Client? client,
-    this.defaultTimeout = const Duration(seconds: 30),
+    this.defaultTimeout = const Duration(seconds: 600),
   }) : _client = client ?? http.Client();
 
   final http.Client _client;

--- a/packages/soliplex_client/lib/src/http/http_transport.dart
+++ b/packages/soliplex_client/lib/src/http/http_transport.dart
@@ -46,7 +46,7 @@ class HttpTransport {
   /// - [defaultTimeout]: Default timeout for requests (defaults to 30 seconds)
   HttpTransport({
     required SoliplexHttpClient client,
-    this.defaultTimeout = const Duration(seconds: 30),
+    this.defaultTimeout = const Duration(seconds: 600),
   }) : _client = client;
 
   final SoliplexHttpClient _client;

--- a/packages/soliplex_client_native/lib/src/clients/cupertino_http_client.dart
+++ b/packages/soliplex_client_native/lib/src/clients/cupertino_http_client.dart
@@ -37,7 +37,7 @@ class CupertinoHttpClient implements SoliplexHttpClient {
   /// - [defaultTimeout]: Default timeout for requests. Defaults to 30 seconds.
   CupertinoHttpClient({
     URLSessionConfiguration? configuration,
-    this.defaultTimeout = const Duration(seconds: 30),
+    this.defaultTimeout = const Duration(seconds: 600),
   }) : _client = CupertinoClient.fromSessionConfiguration(
           configuration ??
               URLSessionConfiguration.ephemeralSessionConfiguration(),
@@ -49,7 +49,7 @@ class CupertinoHttpClient implements SoliplexHttpClient {
   @visibleForTesting
   CupertinoHttpClient.forTesting({
     required http.Client client,
-    this.defaultTimeout = const Duration(seconds: 30),
+    this.defaultTimeout = const Duration(seconds: 600),
   }) : _client = client;
 
   final http.Client _client;

--- a/packages/soliplex_client_native/lib/src/platform/create_platform_client.dart
+++ b/packages/soliplex_client_native/lib/src/platform/create_platform_client.dart
@@ -23,7 +23,7 @@ import 'package:soliplex_client_native/src/platform/create_platform_client_stub.
 /// client.close();
 /// ```
 SoliplexHttpClient createPlatformClient({
-  Duration defaultTimeout = const Duration(seconds: 30),
+  Duration defaultTimeout = const Duration(seconds: 600),
 }) {
   return createPlatformClientImpl(defaultTimeout: defaultTimeout);
 }

--- a/packages/soliplex_client_native/lib/src/platform/create_platform_client_io.dart
+++ b/packages/soliplex_client_native/lib/src/platform/create_platform_client_io.dart
@@ -11,7 +11,7 @@ import 'package:soliplex_client_native/src/clients/cupertino_http_client.dart';
 /// Note: Falls back to [DartHttpClient] if native bindings are unavailable
 /// (e.g., in Flutter test environment).
 SoliplexHttpClient createPlatformClientImpl({
-  Duration defaultTimeout = const Duration(seconds: 30),
+  Duration defaultTimeout = const Duration(seconds: 600),
 }) {
   if (Platform.isMacOS || Platform.isIOS) {
     try {

--- a/packages/soliplex_client_native/lib/src/platform/create_platform_client_stub.dart
+++ b/packages/soliplex_client_native/lib/src/platform/create_platform_client_stub.dart
@@ -4,7 +4,7 @@ import 'package:soliplex_client/soliplex_client.dart';
 ///
 /// Returns [DartHttpClient] as the default client for web platform.
 SoliplexHttpClient createPlatformClientImpl({
-  Duration defaultTimeout = const Duration(seconds: 30),
+  Duration defaultTimeout = const Duration(seconds: 600),
 }) {
   // Web platform uses DartHttpClient
   return DartHttpClient(defaultTimeout: defaultTimeout);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: soliplex_frontend
 description: Cross-platform Flutter frontend for Soliplex AI-powered RAG system
 publish_to: 'none'
-version: 0.50.9+16
+version: 0.50.10+1
 
 environment:
   sdk: '>=3.5.0 <4.0.0'


### PR DESCRIPTION
## Summary
- Increases default HTTP timeout from 30s to 600s (10 minutes) for API requests
- Temporary fix to prevent timeouts on long-running backend operations

## Changes
**soliplex_client:**
- `DartHttpClient` - default timeout 30s → 600s
- `HttpTransport` - default timeout 30s → 600s

**soliplex_client_native:**
- `CupertinoHttpClient` - default timeout 30s → 600s
- `createPlatformClient()` factory - default timeout 30s → 600s

## Scope
All REST API calls through `SoliplexApi` now use 600s timeout.

## Not affected
These retain their explicit per-request timeouts:
| Call | Timeout |
|------|---------|
| Health check (`/api/ok`) | 5s |
| OIDC discovery | 10s |
| Token refresh | 30s |

## Test plan
- [x] `mcp__dart__analyze_files` - 0 issues
- [x] `mcp__dart__run_tests` - 772 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)