### PR TITLE
fix(config): display Soliplex consistently across all platforms

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Soliplex Frontend</string>
+	<string>Soliplex</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -17,7 +17,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>soliplex_frontend</string>
+	<string>Soliplex</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -7,7 +7,7 @@
 #include? "Local.xcconfig"
 
 // The application's name. By default this is also the title of the Flutter window.
-PRODUCT_NAME = soliplex_frontend
+PRODUCT_NAME = Soliplex
 
 // The application's bundle identifier
 PRODUCT_BUNDLE_IDENTIFIER = ai.soliplex.client

--- a/web/index.html
+++ b/web/index.html
@@ -23,13 +23,13 @@
   <!-- iOS meta tags & icons -->
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="soliplex_frontend">
+  <meta name="apple-mobile-web-app-title" content="Soliplex">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>soliplex_frontend</title>
+  <title>Soliplex</title>
   <link rel="manifest" href="manifest.json">
 </head>
 <body>

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "soliplex_frontend",
-    "short_name": "soliplex_frontend",
+    "name": "Soliplex",
+    "short_name": "Soliplex",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#0175C2",


### PR DESCRIPTION
## Summary

- Update macOS, iOS, and web config files to display "Soliplex" as the app name
- Previously showed "soliplex_frontend" or "Soliplex Frontend" inconsistently
- Android already displayed "Soliplex" correctly

## Test plan

- [x] Verify macOS app title shows "Soliplex"
- [x] Verify iOS app title shows "Soliplex"  
- [x] Verify web browser tab and PWA title show "Soliplex"

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)