### PR TITLE
feat(narrow-rag): add loading spinner to filter button and refresh to picker

### DIFF
--- a/lib/features/chat/widgets/chat_input.dart
+++ b/lib/features/chat/widgets/chat_input.dart
@@ -163,17 +163,20 @@ class _ChatInputState extends ConsumerState<ChatInput> {
     final selectedDocs = widget.selectedDocuments;
 
     // Check if room has documents for picker button state
-    // Only disable when we KNOW the room is empty (not during loading/error)
     final documentsAsync =
         hasRoom ? ref.watch(documentsProvider(roomId)) : null;
+    final isLoadingDocs = documentsAsync?.isLoading ?? false;
     final isEmptyRoom = documentsAsync?.maybeWhen(
           data: (docs) => docs.isEmpty,
           orElse: () => false,
         ) ??
         false;
-    final pickerEnabled = canSend && !isEmptyRoom;
-    final pickerTooltip =
-        isEmptyRoom ? 'No documents in this room' : 'Select document';
+    final pickerEnabled = canSend && !isEmptyRoom && !isLoadingDocs;
+    final pickerTooltip = isLoadingDocs
+        ? 'Loading documents...'
+        : isEmptyRoom
+            ? 'No documents in this room'
+            : 'Select document';
 
     final showChips = widget.showSuggestions && widget.suggestions.isNotEmpty;
 
@@ -251,9 +254,15 @@ class _ChatInputState extends ConsumerState<ChatInput> {
               // Document picker button
               if (hasRoom)
                 IconButton(
+                  key: const Key('document_picker_button'),
                   tooltip: pickerTooltip,
                   onPressed: pickerEnabled ? _showDocumentPicker : null,
-                  icon: const Icon(Icons.filter_alt),
+                  icon: isLoadingDocs
+                      ? const SizedBox.square(
+                          dimension: 18,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.filter_alt),
                 ),
               const SizedBox(width: 8),
               // Text field


### PR DESCRIPTION
## Summary

Add loading spinner to document filter button and refresh button to picker dialog.

- Show spinner on filter button while documents are loading
- Add refresh button to dialog title bar for manual cache refresh

## Problem

1. Documents are cached indefinitely by Riverpod after first fetch. When the server updates documents, users see stale data with no way to refresh except restarting the app.
2. While documents are loading, the filter button appeared enabled with no visual feedback, confusing users into thinking the room had no documents.

## Solution

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Button loading state | Spinner + disabled | Provides clear feedback that documents are being fetched |
| Loading tooltip | "Loading documents..." | Explains why button is disabled |
| Refresh placement | Dialog title bar | Keeps refresh accessible without cluttering document list |
| Refresh icon | Icons.refresh | Consistent with retry buttons elsewhere (ErrorDisplay, login) |
| Refresh mechanism | ref.invalidate() | Same pattern used for threads refresh |

## Test plan

- [x] Filter button shows spinner while documents load
- [x] Button disabled during loading with correct tooltip
- [x] Filter icon appears after loading completes
- [x] Refresh button visible in title bar when data loaded
- [x] Refresh button disabled during loading
- [x] Tapping refresh invalidates provider (triggers new fetch)
- [x] All 65 chat_input tests pass

## Visual

```text
While loading:
┌─────────────────────────────────────┐
│  [⟳]  [Type a message...     ] [➤] │  ← Spinner on filter button
└─────────────────────────────────────┘

After loading (dialog open):
┌─────────────────────────────────────┐
│ Select documents            [↻]    │  ← Refresh button in title
├─────────────────────────────────────┤
│ [🔍 Search documents...        ]   │
├─────────────────────────────────────┤
│ ☑ Document 1                       │
│ ☐ Document 2                       │
└─────────────────────────────────────┘
```