### PR TITLE
chore: add .env support for local secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Local environment configuration
+# Copy to .env and fill in your values (never commit .env)
+
+# DCM license key (optional - free tier works without it)
+# Get your key from https://dcm.dev/pricing/
+DCM_CI_KEY=your-key-here

--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,7 @@ scratchpad/*
 **/Local.xcconfig
 # Claude Code local config
 .claude/
+
+# Local environment/secrets (never commit)
+.env
+.env.local


### PR DESCRIPTION
## Summary
- Add `.env` and `.env.local` to `.gitignore`
- Add `.env.example` documenting `DCM_CI_KEY` variable

## Usage
```bash
cp .env.example .env
# Edit .env with your DCM license key
source .env && dcm check lib
```

## Test plan
- [x] `.env` file is ignored by git
- [x] `.env.example` documents available variables