### PR TITLE
fix(macos): remove keychain entitlements for unsigned debug builds

### DIFF
--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -10,9 +10,5 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
-	<key>keychain-access-groups</key>
-	<array>
-		<string>$(AppIdentifierPrefix)ai.soliplex.client</string>
-	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Remove `keychain-access-groups` from `DebugProfile.entitlements` to allow running `flutter run -d macos` without a valid Apple signing certificate

## Changes
- **DebugProfile.entitlements**: Removed keychain access groups that require proper signing

## Test plan
- [x] Run `flutter run -d macos` without signing certificate