### PR TITLE
fix(soliplex_client): create List for numeric path segments in JSON Patch

### DIFF
--- a/packages/soliplex_client/lib/src/application/json_patch.dart
+++ b/packages/soliplex_client/lib/src/application/json_patch.dart
@@ -71,7 +71,12 @@ Map<String, dynamic> _setAtPath(
   for (var i = 0; i < segments.length - 1; i++) {
     final segment = segments[i];
     if (current is Map<String, dynamic>) {
-      current[segment] ??= <String, dynamic>{};
+      if (current[segment] == null) {
+        final nextSegment = segments[i + 1];
+        final nextIsArrayIndex =
+            int.tryParse(nextSegment) != null || nextSegment == '-';
+        current[segment] = nextIsArrayIndex ? <dynamic>[] : <String, dynamic>{};
+      }
       current = current[segment];
     } else if (current is List) {
       final index = int.tryParse(segment);

--- a/packages/soliplex_client/test/application/json_patch_test.dart
+++ b/packages/soliplex_client/test/application/json_patch_test.dart
@@ -258,6 +258,39 @@ void main() {
       });
     });
 
+    group('intermediate container creation', () {
+      test('creates List when path segment is followed by numeric index', () {
+        final state = <String, dynamic>{};
+        final operations = [
+          {
+            'op': 'add',
+            'path': '/haiku.rag.chat/qa_history/0',
+            'value': {'question': 'Q1'},
+          },
+        ];
+
+        final result = applyJsonPatch(state, operations);
+
+        final haikuRagChat = result['haiku.rag.chat'] as Map<String, dynamic>;
+        final qaHistory = haikuRagChat['qa_history'] as List<dynamic>;
+        expect(qaHistory, hasLength(1));
+        expect((qaHistory[0] as Map<String, dynamic>)['question'], 'Q1');
+      });
+
+      test('creates List when intermediate path uses "-" append syntax', () {
+        final state = <String, dynamic>{};
+        final operations = [
+          {'op': 'add', 'path': '/data/items/-', 'value': 'first'},
+        ];
+
+        final result = applyJsonPatch(state, operations);
+
+        final data = result['data'] as Map<String, dynamic>;
+        final items = data['items'] as List<dynamic>;
+        expect(items, ['first']);
+      });
+    });
+
     group('edge cases', () {
       test('handles empty path', () {
         final state = <String, dynamic>{'key': 'value'};


### PR DESCRIPTION
## Summary

- Fix JSON Patch `_setAtPath` to create `List` instead of `Map` when the next path segment is numeric
- Add regression tests for intermediate container creation

When applying JSON Patch operations with paths like `/qa_history/0`, intermediate containers were always created as Maps. This caused type errors when the container was later accessed as a List.

Now looks ahead to the next path segment - if it's numeric or `-` (append), creates a List instead of a Map.

## Test plan

- [x] Added test: creates List when path segment is followed by numeric index
- [x] Added test: creates List when intermediate path uses `-` append syntax
- [x] All existing JSON Patch tests pass

Fixes #162
Fixes https://github.com/enfold/afsoc-rag/issues/928

🤖 Generated with [Claude Code](https://claude.ai/code)