### PR TITLE
docs(logging): add API documentation (M02)

### DIFF
--- a/docs/logging-quickstart.md
+++ b/docs/logging-quickstart.md
@@ -1,0 +1,128 @@
+# Logging Quickstart
+
+This guide covers how to use the logging system in the Soliplex Flutter app.
+
+## Overview
+
+The logging system consists of:
+
+1. **soliplex_logging package** - Pure Dart logging primitives
+2. **Loggers class** - Type-safe static accessors for app-wide loggers
+3. **LogConfig** - Persistent configuration via SharedPreferences
+4. **consoleSinkProvider** - Riverpod provider managing sink lifecycle
+
+## Using Type-Safe Loggers
+
+Always use the `Loggers` class for logging in the app:
+
+```dart
+import 'package:soliplex_frontend/core/logging/loggers.dart';
+
+// Simple logging
+Loggers.auth.info('User logged in');
+Loggers.http.debug('GET /api/users');
+Loggers.chat.warning('Message retry');
+
+// Error logging with context
+try {
+  await api.call();
+} catch (e, stackTrace) {
+  Loggers.activeRun.error('API call failed', error: e, stackTrace: stackTrace);
+}
+```
+
+## Available Loggers
+
+| Logger | Use For |
+|--------|---------|
+| `Loggers.auth` | Authentication events (login, logout, token refresh) |
+| `Loggers.http` | HTTP request/response logging |
+| `Loggers.activeRun` | AG-UI run processing events |
+| `Loggers.chat` | Chat feature events |
+| `Loggers.room` | Room feature events |
+| `Loggers.router` | Navigation/routing events |
+| `Loggers.quiz` | Quiz feature events |
+| `Loggers.config` | Configuration changes |
+| `Loggers.ui` | General UI events |
+
+## Adding a New Logger
+
+1. Edit `lib/core/logging/loggers.dart`:
+
+```dart
+abstract final class Loggers {
+  // ... existing loggers ...
+
+  /// Description of what this logger is for.
+  static final myFeature = LogManager.instance.getLogger('MyFeature');
+}
+```
+
+1. Update this guide with the new logger.
+
+## Log Level Guidelines
+
+| Level | When to Use | Example |
+|-------|-------------|---------|
+| trace | Loop iterations, detailed flow | `Loggers.http.trace('Header: $key=$value')` |
+| debug | State changes, request/response | `Loggers.http.debug('GET $url')` |
+| info | User actions, lifecycle events | `Loggers.auth.info('User logged in')` |
+| warning | Recoverable issues, deprecations | `Loggers.config.warning('Using fallback')` |
+| error | Failures that affect functionality | `Loggers.chat.error('Send failed', error: e)` |
+| fatal | Unrecoverable, app must restart | `Loggers.config.fatal('Corrupt state')` |
+
+### Guidelines
+
+- **trace/debug**: Use liberally during development; these are filtered in
+  production
+- **info**: Use for events that would be useful in production logs
+- **warning**: Use when something unexpected happened but the app can continue
+- **error**: Always include the `error` and `stackTrace` parameters
+- **fatal**: Rare; only for truly unrecoverable situations
+
+## Span Context (Future)
+
+The logging system supports span IDs for future telemetry integration:
+
+```dart
+// When telemetry is implemented, you'll be able to correlate logs with traces
+Loggers.http.info(
+  'Request started',
+  spanId: currentSpan.id,
+  traceId: currentTrace.id,
+);
+```
+
+For now, these fields are optional and can be omitted.
+
+## Changing Log Level
+
+The log level can be changed via the Settings screen (coming in M04) or
+programmatically:
+
+```dart
+// Via provider
+ref.read(logConfigProvider.notifier).setMinimumLevel(LogLevel.debug);
+
+// Directly (for testing)
+LogManager.instance.minimumLevel = LogLevel.trace;
+```
+
+## Troubleshooting
+
+### Logs not appearing
+
+1. Check that `consoleSinkProvider` is being read somewhere in the widget tree
+2. Verify the minimum level allows your log (default is `info`)
+3. Check that console logging is enabled in LogConfig
+
+### Duplicate logs
+
+This shouldn't happen if using `consoleSinkProvider` as the single source of
+truth. If you see duplicates, check that no code is manually adding sinks.
+
+### Performance concerns
+
+- Use `trace`/`debug` for high-frequency logs
+- These levels are filtered in production
+- Log messages are not formatted if below minimum level

--- a/packages/soliplex_logging/README.md
+++ b/packages/soliplex_logging/README.md
@@ -1,0 +1,138 @@
+# soliplex_logging
+
+Central logging package for Soliplex applications. Provides a structured,
+level-based logging system with span support for future telemetry integration.
+
+## Installation
+
+Add to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  soliplex_logging:
+    path: packages/soliplex_logging
+```
+
+## Quick Start
+
+```dart
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+// Initialize (typically done once in main.dart)
+LogManager.instance.addSink(ConsoleSink());
+
+// Get a logger (raw API)
+final log = LogManager.instance.getLogger('MyClass');
+
+// Log messages
+log.info('Application started');
+log.debug('Processing item');
+log.error('Failed to connect', error: e, stackTrace: s);
+
+// With span context (for future telemetry)
+log.info('Processing request', spanId: span.id, traceId: trace.id);
+```
+
+### Type-Safe Usage in Applications
+
+In the Soliplex app, prefer the type-safe `Loggers` class:
+
+```dart
+import 'package:soliplex_frontend/core/logging/loggers.dart';
+
+Loggers.auth.info('User logged in');
+Loggers.http.debug('GET /api/users');
+Loggers.activeRun.error('Failed', error: e, stackTrace: s);
+```
+
+See [logging-quickstart.md](../../docs/logging-quickstart.md) for app-specific
+usage.
+
+## Log Levels
+
+| Level   | Value | Usage                        |
+|---------|-------|------------------------------|
+| trace   | 0     | Very detailed debugging      |
+| debug   | 100   | Development debugging        |
+| info    | 200   | Normal operations            |
+| warning | 300   | Recoverable issues           |
+| error   | 400   | Errors affecting functionality |
+| fatal   | 500   | Unrecoverable errors         |
+
+## API Reference
+
+### LogLevel
+
+Enum representing log severity levels with numeric values for comparison.
+
+```dart
+if (LogLevel.warning >= LogLevel.info) {
+  // warning is more severe than info
+}
+```
+
+### LogRecord
+
+Immutable data class containing log event information:
+
+- `level` - Severity level
+- `message` - Log message
+- `timestamp` - When the log was created
+- `loggerName` - Name of the logger
+- `error` - Optional error object
+- `stackTrace` - Optional stack trace
+- `spanId` - Optional span ID for telemetry
+- `traceId` - Optional trace ID for telemetry
+
+### LogSink
+
+Interface for log output destinations:
+
+```dart
+abstract interface class LogSink {
+  void write(LogRecord record);
+  Future<void> flush();
+  Future<void> close();
+}
+```
+
+### ConsoleSink
+
+Log sink that outputs to the console via `dart:developer`.
+
+```dart
+final sink = ConsoleSink(enabled: true);
+LogManager.instance.addSink(sink);
+```
+
+### Logger
+
+Facade for emitting log records. Obtained via `LogManager.instance.getLogger()`.
+
+Methods: `trace()`, `debug()`, `info()`, `warning()`, `error()`, `fatal()`
+
+All methods accept optional parameters:
+
+- `error` - Associated error object
+- `stackTrace` - Stack trace for errors
+- `spanId` - Span ID for telemetry
+- `traceId` - Trace ID for telemetry
+
+### LogManager
+
+Singleton manager for log configuration and sink management.
+
+```dart
+// Set minimum level (logs below this are filtered)
+LogManager.instance.minimumLevel = LogLevel.debug;
+
+// Add/remove sinks
+LogManager.instance.addSink(mySink);
+LogManager.instance.removeSink(mySink);
+
+// Flush all sinks
+await LogManager.instance.flush();
+
+// Close all sinks
+await LogManager.instance.close();
+```

--- a/packages/soliplex_logging/test/logger_test.dart
+++ b/packages/soliplex_logging/test/logger_test.dart
@@ -15,8 +15,6 @@ class TestSink implements LogSink {
 
   @override
   Future<void> close() async {}
-
-  void clear() => records.clear();
 }
 
 void main() {


### PR DESCRIPTION
## Summary

- Package README with installation and quick start examples
- Quickstart guide documenting type-safe Loggers.x usage
- Log level guidelines with practical examples

## Changes

- **packages/soliplex_logging/README.md**: Full API reference documentation
- **docs/logging-quickstart.md**: App-specific usage guide

## Test plan

- [x] Markdown linting passes
- [x] `dart doc` builds without warnings
- [x] Gemini review: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)