### PR TITLE
fix(agui): configure explicit timeout values for AgUiClient

### DIFF
--- a/lib/core/providers/api_provider.dart
+++ b/lib/core/providers/api_provider.dart
@@ -215,7 +215,11 @@ final agUiClientProvider = Provider<AgUiClient>((ref) {
   final protectedClient = _NonClosingHttpClient(httpClient);
 
   final client = AgUiClient(
-    config: AgUiClientConfig(baseUrl: '${config.baseUrl}/api/v1'),
+    config: AgUiClientConfig(
+      baseUrl: '${config.baseUrl}/api/v1',
+      requestTimeout: const Duration(seconds: 600),
+      connectionTimeout: const Duration(seconds: 600),
+    ),
     httpClient: protectedClient,
   );
 


### PR DESCRIPTION
## Summary

- Adds explicit timeout configuration to `AgUiClient` instead of relying on defaults
- Sets `requestTimeout` and `connectionTimeout` to 600 seconds (10 minutes)

## Details

| Config | Default | Now Set | Impact |
|--------|---------|---------|--------|
| `requestTimeout` | 30s | 600s | ✅ Applies to initial POST request |
| `connectionTimeout` | 60s | 600s | ⚠️ No effect currently (see below) |

### Why `connectionTimeout` has no effect

The ag_ui package's `runAgent()` method uses `SseClient.parseStream()` which ignores the `idleTimeout` parameter. The idle timer logic only runs when using `SseClient.connect()`.

This configuration is added to:
1. Document intent (we want 600s timeouts)
2. Be ready when ag_ui fixes this upstream

See [issue comment](https://github.com/soliplex/flutter/issues/146#issuecomment-3849620947) for full analysis.

## Test plan

- [ ] Verify app still connects to SSE endpoints
- [ ] Verify initial request timeout works (would need to simulate slow backend)

Refs: #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)