### PR TITLE
feat(logging): add web console support with platform abstraction

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:soliplex_frontend/core/auth/auth_provider.dart';
 import 'package:soliplex_frontend/core/auth/auth_state.dart';
+import 'package:soliplex_frontend/core/logging/logging_provider.dart';
 import 'package:soliplex_frontend/core/providers/shell_config_provider.dart';
 import 'package:soliplex_frontend/core/router/app_router.dart';
 import 'package:soliplex_frontend/design/theme/theme.dart';
@@ -12,6 +13,9 @@ class SoliplexApp extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // Initialize console logging (must be watched to activate the provider).
+    ref.watch(consoleSinkProvider);
+
     final authState = ref.watch(authProvider);
     final shellConfig = ref.watch(shellConfigProvider);
     final themeConfig = shellConfig.theme;

--- a/packages/soliplex_logging/lib/src/sinks/console_sink_native.dart
+++ b/packages/soliplex_logging/lib/src/sinks/console_sink_native.dart
@@ -1,0 +1,35 @@
+import 'dart:developer' as developer;
+
+import 'package:soliplex_logging/src/log_level.dart';
+import 'package:soliplex_logging/src/log_record.dart';
+import 'package:soliplex_logging/src/sinks/log_format.dart';
+
+/// Writes a log record to the native console via dart:developer.
+///
+/// Called by `ConsoleSink.write` via conditional import on native platforms
+/// (iOS, macOS, Android, Windows, Linux).
+void writeToConsole(LogRecord record) {
+  developer.log(
+    formatLogMessage(record),
+    name: record.loggerName,
+    level: _mapLevel(record.level),
+    time: record.timestamp,
+    error: record.error,
+    stackTrace: record.stackTrace,
+  );
+}
+
+/// Maps LogLevel to dart:developer log levels.
+///
+/// dart:developer uses numeric levels where higher values indicate
+/// more severe log messages (0-2000 range).
+int _mapLevel(LogLevel level) {
+  return switch (level) {
+    LogLevel.trace => 300,
+    LogLevel.debug => 500,
+    LogLevel.info => 800,
+    LogLevel.warning => 900,
+    LogLevel.error => 1000,
+    LogLevel.fatal => 1200,
+  };
+}

--- a/packages/soliplex_logging/lib/src/sinks/console_sink_web.dart
+++ b/packages/soliplex_logging/lib/src/sinks/console_sink_web.dart
@@ -1,0 +1,89 @@
+import 'dart:js_interop';
+
+import 'package:soliplex_logging/src/log_level.dart';
+import 'package:soliplex_logging/src/log_record.dart';
+import 'package:soliplex_logging/src/sinks/log_format.dart';
+
+@JS('console')
+external JSConsole get _console;
+
+/// Extension type for browser console with flexible argument types.
+///
+/// Uses [JSAny?] to preserve object references for browser inspection.
+/// The browser console can display these as expandable objects.
+extension type JSConsole(JSObject _) implements JSObject {
+  /// Logs a debug message (often hidden by default in browsers).
+  external void debug(JSAny? message, [JSAny? arg1, JSAny? arg2]);
+
+  /// Logs an info message (distinct icon in some browsers).
+  external void info(JSAny? message, [JSAny? arg1, JSAny? arg2]);
+
+  /// Logs a standard message.
+  external void log(JSAny? message, [JSAny? arg1, JSAny? arg2]);
+
+  /// Logs a warning message (yellow styling).
+  external void warn(JSAny? message, [JSAny? arg1, JSAny? arg2]);
+
+  /// Logs an error message (red styling).
+  external void error(JSAny? message, [JSAny? arg1, JSAny? arg2]);
+}
+
+/// Writes a log record to the browser console.
+///
+/// Called by `ConsoleSink.write` via conditional import on web platform.
+///
+/// Maps log levels to appropriate console methods:
+/// - trace/debug -> console.debug (often hidden by default)
+/// - info -> console.info (distinct icon)
+/// - warning -> console.warn (yellow styling)
+/// - error/fatal -> console.error (red styling)
+///
+/// Stack traces are appended to the message for guaranteed visibility.
+void writeToConsole(LogRecord record) {
+  // Build message with stack trace appended for visibility.
+  // Browser consoles often collapse additional arguments, so embedding
+  // the stack trace in the message ensures it's always shown.
+  var msgString = formatLogMessage(record);
+  if (record.stackTrace != null) {
+    msgString += '\n${record.stackTrace}';
+  }
+
+  final message = msgString.toJS;
+  final errorArg = _convertError(record.error);
+
+  switch (record.level) {
+    case LogLevel.trace:
+    case LogLevel.debug:
+      _console.debug(message, errorArg);
+    case LogLevel.info:
+      _console.info(message, errorArg);
+    case LogLevel.warning:
+      _console.warn(message, errorArg);
+    case LogLevel.error:
+    case LogLevel.fatal:
+      _console.error(message, errorArg);
+  }
+}
+
+/// Converts a Dart error to a JS object for browser inspection.
+///
+/// Creates a structured object with type and message that browsers
+/// can display as an expandable tree structure.
+///
+/// Returns null if conversion fails to ensure logging never crashes the app.
+JSAny? _convertError(Object? error) {
+  if (error == null) return null;
+
+  // Create a JS object with error details that browsers can inspect.
+  // Wrapped in try-catch because a logging library must never crash the app,
+  // even if the error object has problematic toString() implementations.
+  try {
+    return <String, Object?>{
+      'type': error.runtimeType.toString(),
+      'message': error.toString(),
+    }.jsify();
+  } on Object {
+    // If conversion fails (e.g., problematic toString), return a safe fallback.
+    return '[Error conversion failed]'.toJS;
+  }
+}

--- a/packages/soliplex_logging/lib/src/sinks/log_format.dart
+++ b/packages/soliplex_logging/lib/src/sinks/log_format.dart
@@ -1,0 +1,22 @@
+import 'package:soliplex_logging/src/log_record.dart';
+
+/// Formats the basic log message (level, logger, message, spans).
+///
+/// Error and stackTrace are handled separately by each platform implementation
+/// since they have different capabilities:
+/// - Native: `dart:developer` accepts them as separate parameters
+/// - Web: Browser console can display them as expandable objects
+String formatLogMessage(LogRecord record) {
+  final buffer = StringBuffer()
+    ..write('[${record.level.label}] ${record.loggerName}: ${record.message}');
+
+  if (record.spanId != null || record.traceId != null) {
+    buffer.write(' (');
+    if (record.traceId != null) buffer.write('trace=${record.traceId}');
+    if (record.spanId != null && record.traceId != null) buffer.write(', ');
+    if (record.spanId != null) buffer.write('span=${record.spanId}');
+    buffer.write(')');
+  }
+
+  return buffer.toString();
+}

--- a/packages/soliplex_logging/test/console_sink_test.dart
+++ b/packages/soliplex_logging/test/console_sink_test.dart
@@ -14,7 +14,11 @@ void main() {
     });
 
     test('write does nothing when disabled', () {
-      final sink = ConsoleSink(enabled: false);
+      final captured = <LogRecord>[];
+      final sink = ConsoleSink(
+        enabled: false,
+        testWriter: captured.add,
+      );
       final record = LogRecord(
         level: LogLevel.info,
         message: 'Test',
@@ -22,8 +26,9 @@ void main() {
         loggerName: 'Test',
       );
 
-      // Should not throw
       sink.write(record);
+
+      expect(captured, isEmpty);
     });
 
     test('flush completes immediately', () async {
@@ -38,5 +43,382 @@ void main() {
       await sink.close();
       expect(sink.enabled, isFalse);
     });
+
+    group('testWriter', () {
+      test('captures records when provided', () {
+        final captured = <LogRecord>[];
+        final sink = ConsoleSink(testWriter: captured.add);
+
+        final record = LogRecord(
+          level: LogLevel.debug,
+          message: 'test message',
+          timestamp: DateTime.now(),
+          loggerName: 'TestLogger',
+        );
+
+        sink.write(record);
+
+        expect(captured, hasLength(1));
+        expect(captured.first.level, LogLevel.debug);
+        expect(captured.first.message, 'test message');
+        expect(captured.first.loggerName, 'TestLogger');
+      });
+
+      test('captures multiple records', () {
+        final captured = <LogRecord>[];
+        final sink = ConsoleSink(testWriter: captured.add);
+        final now = DateTime.now();
+
+        sink
+          ..write(
+            LogRecord(
+              level: LogLevel.info,
+              message: 'first',
+              timestamp: now,
+              loggerName: 'Test',
+            ),
+          )
+          ..write(
+            LogRecord(
+              level: LogLevel.warning,
+              message: 'second',
+              timestamp: now,
+              loggerName: 'Test',
+            ),
+          )
+          ..write(
+            LogRecord(
+              level: LogLevel.error,
+              message: 'third',
+              timestamp: now,
+              loggerName: 'Test',
+            ),
+          );
+
+        expect(captured, hasLength(3));
+        expect(captured[0].level, LogLevel.info);
+        expect(captured[1].level, LogLevel.warning);
+        expect(captured[2].level, LogLevel.error);
+      });
+
+      test('captures records with span context', () {
+        final captured = <LogRecord>[];
+        ConsoleSink(testWriter: captured.add).write(
+          LogRecord(
+            level: LogLevel.info,
+            message: 'traced message',
+            timestamp: DateTime.now(),
+            loggerName: 'Test',
+            spanId: 'span-123',
+            traceId: 'trace-456',
+          ),
+        );
+
+        expect(captured, hasLength(1));
+        expect(captured.first.spanId, 'span-123');
+        expect(captured.first.traceId, 'trace-456');
+      });
+
+      test('respects enabled flag', () {
+        final captured = <LogRecord>[];
+        ConsoleSink(enabled: false, testWriter: captured.add).write(
+          LogRecord(
+            level: LogLevel.info,
+            message: 'should not appear',
+            timestamp: DateTime.now(),
+            loggerName: 'Test',
+          ),
+        );
+
+        expect(captured, isEmpty);
+      });
+
+      test('stops capturing after close', () async {
+        final captured = <LogRecord>[];
+        final sink = ConsoleSink(testWriter: captured.add)
+          ..write(
+            LogRecord(
+              level: LogLevel.info,
+              message: 'before close',
+              timestamp: DateTime.now(),
+              loggerName: 'Test',
+            ),
+          );
+
+        await sink.close();
+
+        sink.write(
+          LogRecord(
+            level: LogLevel.info,
+            message: 'after close',
+            timestamp: DateTime.now(),
+            loggerName: 'Test',
+          ),
+        );
+
+        expect(captured, hasLength(1));
+        expect(captured.first.message, 'before close');
+      });
+    });
+
+    group('exception logging', () {
+      test('captures Exception with message', () {
+        final captured = <LogRecord>[];
+        final sink = ConsoleSink(testWriter: captured.add);
+        final exception = Exception('Something went wrong');
+
+        sink.write(
+          LogRecord(
+            level: LogLevel.error,
+            message: 'Operation failed',
+            timestamp: DateTime.now(),
+            loggerName: 'Test',
+            error: exception,
+          ),
+        );
+
+        expect(captured, hasLength(1));
+        expect(captured.first.error, exception);
+        expect(
+          captured.first.error.toString(),
+          contains('Something went wrong'),
+        );
+      });
+
+      test('captures Error with stackTrace', () {
+        final captured = <LogRecord>[];
+        final sink = ConsoleSink(testWriter: captured.add);
+        final error = StateError('Invalid state');
+        final stackTrace = StackTrace.current;
+
+        sink.write(
+          LogRecord(
+            level: LogLevel.error,
+            message: 'State error occurred',
+            timestamp: DateTime.now(),
+            loggerName: 'Test',
+            error: error,
+            stackTrace: stackTrace,
+          ),
+        );
+
+        expect(captured, hasLength(1));
+        expect(captured.first.error, error);
+        expect(captured.first.stackTrace, stackTrace);
+        expect(captured.first.error.toString(), contains('Invalid state'));
+      });
+
+      test('captures FormatException with details', () {
+        final captured = <LogRecord>[];
+        final sink = ConsoleSink(testWriter: captured.add);
+        const exception = FormatException('Invalid JSON', '{"broken', 5);
+
+        sink.write(
+          LogRecord(
+            level: LogLevel.error,
+            message: 'Parse failed',
+            timestamp: DateTime.now(),
+            loggerName: 'JsonParser',
+            error: exception,
+          ),
+        );
+
+        expect(captured, hasLength(1));
+        expect(captured.first.error, isA<FormatException>());
+        final capturedError = captured.first.error! as FormatException;
+        expect(capturedError.message, 'Invalid JSON');
+        expect(capturedError.source, '{"broken');
+        expect(capturedError.offset, 5);
+      });
+
+      test('captures ArgumentError', () {
+        final captured = <LogRecord>[];
+        final sink = ConsoleSink(testWriter: captured.add);
+        final error = ArgumentError.value(-1, 'count', 'must be non-negative');
+
+        sink.write(
+          LogRecord(
+            level: LogLevel.error,
+            message: 'Invalid argument',
+            timestamp: DateTime.now(),
+            loggerName: 'Validator',
+            error: error,
+          ),
+        );
+
+        expect(captured, hasLength(1));
+        expect(captured.first.error, isA<ArgumentError>());
+        expect(
+          captured.first.error.toString(),
+          contains('must be non-negative'),
+        );
+      });
+
+      test('captures RangeError', () {
+        final captured = <LogRecord>[];
+        final sink = ConsoleSink(testWriter: captured.add);
+        final error = RangeError.range(10, 0, 5, 'index');
+
+        sink.write(
+          LogRecord(
+            level: LogLevel.error,
+            message: 'Index out of range',
+            timestamp: DateTime.now(),
+            loggerName: 'List',
+            error: error,
+          ),
+        );
+
+        expect(captured, hasLength(1));
+        expect(captured.first.error, isA<RangeError>());
+      });
+
+      test('captures custom exception class', () {
+        final captured = <LogRecord>[];
+        final sink = ConsoleSink(testWriter: captured.add);
+        final exception = _CustomException('Custom error', 42);
+
+        sink.write(
+          LogRecord(
+            level: LogLevel.error,
+            message: 'Custom exception',
+            timestamp: DateTime.now(),
+            loggerName: 'Custom',
+            error: exception,
+          ),
+        );
+
+        expect(captured, hasLength(1));
+        expect(captured.first.error, isA<_CustomException>());
+        final capturedError = captured.first.error! as _CustomException;
+        expect(capturedError.message, 'Custom error');
+        expect(capturedError.code, 42);
+      });
+
+      test('captures error with null stackTrace', () {
+        final captured = <LogRecord>[];
+        final sink = ConsoleSink(testWriter: captured.add);
+        final error = Exception('No stack trace');
+
+        sink.write(
+          LogRecord(
+            level: LogLevel.error,
+            message: 'Error without stack',
+            timestamp: DateTime.now(),
+            loggerName: 'Test',
+            error: error,
+          ),
+        );
+
+        expect(captured, hasLength(1));
+        expect(captured.first.error, error);
+        expect(captured.first.stackTrace, isNull);
+      });
+
+      test('captures stackTrace without error', () {
+        final captured = <LogRecord>[];
+        final sink = ConsoleSink(testWriter: captured.add);
+        final stackTrace = StackTrace.current;
+
+        sink.write(
+          LogRecord(
+            level: LogLevel.warning,
+            message: 'Warning with stack',
+            timestamp: DateTime.now(),
+            loggerName: 'Test',
+            stackTrace: stackTrace,
+          ),
+        );
+
+        expect(captured, hasLength(1));
+        expect(captured.first.error, isNull);
+        expect(captured.first.stackTrace, stackTrace);
+      });
+
+      test('captures nested exception', () {
+        final captured = <LogRecord>[];
+        final sink = ConsoleSink(testWriter: captured.add);
+        final innerException = Exception('Inner error');
+        final outerException = _WrappedException(
+          'Outer error',
+          innerException,
+        );
+
+        sink.write(
+          LogRecord(
+            level: LogLevel.error,
+            message: 'Nested exception',
+            timestamp: DateTime.now(),
+            loggerName: 'Test',
+            error: outerException,
+          ),
+        );
+
+        expect(captured, hasLength(1));
+        expect(captured.first.error, isA<_WrappedException>());
+        final capturedError = captured.first.error! as _WrappedException;
+        expect(capturedError.innerException, innerException);
+      });
+
+      test('captures multiple errors in sequence', () {
+        final captured = <LogRecord>[];
+        final sink = ConsoleSink(testWriter: captured.add);
+        final now = DateTime.now();
+
+        sink
+          ..write(
+            LogRecord(
+              level: LogLevel.error,
+              message: 'First error',
+              timestamp: now,
+              loggerName: 'Test',
+              error: Exception('First'),
+            ),
+          )
+          ..write(
+            LogRecord(
+              level: LogLevel.error,
+              message: 'Second error',
+              timestamp: now,
+              loggerName: 'Test',
+              error: StateError('Second'),
+            ),
+          )
+          ..write(
+            LogRecord(
+              level: LogLevel.fatal,
+              message: 'Third error',
+              timestamp: now,
+              loggerName: 'Test',
+              error: ArgumentError('Third'),
+            ),
+          );
+
+        expect(captured, hasLength(3));
+        expect(captured[0].error, isA<Exception>());
+        expect(captured[1].error, isA<StateError>());
+        expect(captured[2].error, isA<ArgumentError>());
+      });
+    });
   });
+}
+
+/// Custom exception for testing.
+class _CustomException implements Exception {
+  _CustomException(this.message, this.code);
+  final String message;
+  final int code;
+
+  @override
+  String toString() => 'CustomException: $message (code: $code)';
+}
+
+/// Wrapped exception for testing nested exceptions.
+class _WrappedException implements Exception {
+  _WrappedException(this.message, this.innerException);
+  final String message;
+  final Exception innerException;
+
+  @override
+  String toString() => 'WrappedException: $message\nCaused by: $innerException';
 }

--- a/packages/soliplex_logging/test/log_format_test.dart
+++ b/packages/soliplex_logging/test/log_format_test.dart
@@ -1,0 +1,189 @@
+import 'package:soliplex_logging/soliplex_logging.dart';
+import 'package:soliplex_logging/src/sinks/log_format.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('formatLogMessage', () {
+    test('formats basic message with level and logger name', () {
+      final record = LogRecord(
+        level: LogLevel.info,
+        message: 'Hello world',
+        timestamp: DateTime.now(),
+        loggerName: 'TestLogger',
+      );
+
+      final result = formatLogMessage(record);
+
+      expect(result, '[INFO] TestLogger: Hello world');
+    });
+
+    test('formats message for each log level', () {
+      final now = DateTime.now();
+
+      expect(
+        formatLogMessage(
+          LogRecord(
+            level: LogLevel.trace,
+            message: 'msg',
+            timestamp: now,
+            loggerName: 'L',
+          ),
+        ),
+        '[TRACE] L: msg',
+      );
+
+      expect(
+        formatLogMessage(
+          LogRecord(
+            level: LogLevel.debug,
+            message: 'msg',
+            timestamp: now,
+            loggerName: 'L',
+          ),
+        ),
+        '[DEBUG] L: msg',
+      );
+
+      expect(
+        formatLogMessage(
+          LogRecord(
+            level: LogLevel.info,
+            message: 'msg',
+            timestamp: now,
+            loggerName: 'L',
+          ),
+        ),
+        '[INFO] L: msg',
+      );
+
+      expect(
+        formatLogMessage(
+          LogRecord(
+            level: LogLevel.warning,
+            message: 'msg',
+            timestamp: now,
+            loggerName: 'L',
+          ),
+        ),
+        '[WARNING] L: msg',
+      );
+
+      expect(
+        formatLogMessage(
+          LogRecord(
+            level: LogLevel.error,
+            message: 'msg',
+            timestamp: now,
+            loggerName: 'L',
+          ),
+        ),
+        '[ERROR] L: msg',
+      );
+
+      expect(
+        formatLogMessage(
+          LogRecord(
+            level: LogLevel.fatal,
+            message: 'msg',
+            timestamp: now,
+            loggerName: 'L',
+          ),
+        ),
+        '[FATAL] L: msg',
+      );
+    });
+
+    test('includes traceId when present', () {
+      final record = LogRecord(
+        level: LogLevel.info,
+        message: 'traced',
+        timestamp: DateTime.now(),
+        loggerName: 'Test',
+        traceId: 'trace-123',
+      );
+
+      final result = formatLogMessage(record);
+
+      expect(result, '[INFO] Test: traced (trace=trace-123)');
+    });
+
+    test('includes spanId when present', () {
+      final record = LogRecord(
+        level: LogLevel.info,
+        message: 'spanned',
+        timestamp: DateTime.now(),
+        loggerName: 'Test',
+        spanId: 'span-456',
+      );
+
+      final result = formatLogMessage(record);
+
+      expect(result, '[INFO] Test: spanned (span=span-456)');
+    });
+
+    test('includes both traceId and spanId when present', () {
+      final record = LogRecord(
+        level: LogLevel.info,
+        message: 'full context',
+        timestamp: DateTime.now(),
+        loggerName: 'Test',
+        traceId: 'trace-123',
+        spanId: 'span-456',
+      );
+
+      final result = formatLogMessage(record);
+
+      expect(
+        result,
+        '[INFO] Test: full context (trace=trace-123, span=span-456)',
+      );
+    });
+
+    test('does not include error in message (handled by platform)', () {
+      final record = LogRecord(
+        level: LogLevel.error,
+        message: 'error occurred',
+        timestamp: DateTime.now(),
+        loggerName: 'Test',
+        error: Exception('test error'),
+        stackTrace: StackTrace.current,
+      );
+
+      final result = formatLogMessage(record);
+
+      // Error and stackTrace should NOT be in the formatted message
+      // They are handled separately by each platform
+      expect(result, '[ERROR] Test: error occurred');
+      expect(result, isNot(contains('Exception')));
+    });
+
+    test('handles empty message', () {
+      final record = LogRecord(
+        level: LogLevel.debug,
+        message: '',
+        timestamp: DateTime.now(),
+        loggerName: 'Test',
+      );
+
+      final result = formatLogMessage(record);
+
+      expect(result, '[DEBUG] Test: ');
+    });
+
+    test('handles message with special characters', () {
+      final record = LogRecord(
+        level: LogLevel.info,
+        message: 'Message with "quotes" and \'apostrophes\' and\nnewlines',
+        timestamp: DateTime.now(),
+        loggerName: 'Test',
+      );
+
+      final result = formatLogMessage(record);
+
+      expect(
+        result,
+        '[INFO] Test: Message with "quotes" and \'apostrophes\' and\nnewlines',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Implement platform-specific console logging using conditional imports
- Web: uses browser's `console` API with level-appropriate methods (debug/info/warn/error)
- Native: uses `dart:developer.log` (unchanged behavior)
- Fix: Initialize `consoleSinkProvider` in SoliplexApp so logs actually appear

## Changes
- **console_sink.dart**: Add conditional import switching between native/web implementations
- **console_sink_native.dart**: Extract native implementation using `dart:developer`
- **console_sink_web.dart**: New web implementation using browser console API
- **log_format.dart**: Shared formatting utility for consistent log messages
- **app.dart**: Watch `consoleSinkProvider` to initialize logging on app start
- **Tests**: Comprehensive exception logging tests using `testWriter` injection

## Technical Details
- Log levels map to browser console methods: trace/debug → `console.debug`, info → `console.info`, warning → `console.warn`, error/fatal → `console.error`
- Errors converted to JS objects with `jsify()` for browser inspection
- Stack traces appended to message string for guaranteed visibility
- Try-catch protection ensures logging never crashes the app

## Test plan
- [x] `dart format` passes
- [x] `dart analyze --fatal-infos` reports 0 issues
- [x] All 64 tests pass
- [x] 95% business logic coverage (platform code excluded)
- [x] Validated by Gemini Pro 3 (3 iterations including critic review)
- [ ] Manual test: verify errors with stack traces appear in browser DevTools

🤖 Generated with [Claude Code](https://claude.ai/code)