### PR TITLE
refactor(config): simplify backend URL resolution hierarchy

### DIFF
--- a/lib/core/models/soliplex_config.dart
+++ b/lib/core/models/soliplex_config.dart
@@ -34,7 +34,7 @@ class SoliplexConfig {
   const SoliplexConfig({
     required this.logo,
     this.appName = 'Soliplex',
-    this.defaultBackendUrl,
+    this.defaultBackendUrl = 'http://localhost:8000',
     this.oauthRedirectScheme,
     this.features = const Features(),
     this.theme = const ThemeConfig(),
@@ -48,13 +48,13 @@ class SoliplexConfig {
 
   /// The default backend URL for API requests.
   ///
-  /// When null, uses platform-specific defaults:
-  /// - Native: `http://localhost:8000`
-  /// - Web + localhost: `http://localhost:8000`
-  /// - Web + production: same origin as client
+  /// Defaults to `http://localhost:8000`. On native and web localhost,
+  /// this value is used directly. On web production, the client's origin
+  /// is used instead (ignoring this value).
   ///
-  /// Can be overridden by the user in settings if settings are enabled.
-  final String? defaultBackendUrl;
+  /// Overridden when the user connects to a different backend from the
+  /// home screen (persisted to SharedPreferences for subsequent launches).
+  final String defaultBackendUrl;
 
   /// OAuth redirect URI scheme for native platforms (iOS/Android).
   ///

--- a/test/api_contract/soliplex_frontend_contract_test.dart
+++ b/test/api_contract/soliplex_frontend_contract_test.dart
@@ -313,9 +313,9 @@ void main() {
         const config = SoliplexConfig(logo: LogoConfig.soliplex);
 
         expect(config.appName, equals('Soliplex'));
-        // null means "use platform default" (localhost on native, origin on
-        // web). Resolved at runtime by ConfigNotifier.
-        expect(config.defaultBackendUrl, isNull);
+        // Defaults to localhost:8000. Used on native and web localhost.
+        // On web production, origin is used instead (ignoring this value).
+        expect(config.defaultBackendUrl, 'http://localhost:8000');
         // null requires explicit override for native platforms
         expect(config.oauthRedirectScheme, isNull);
         expect(config.features.enableHttpInspector, isTrue);

--- a/test/core/models/soliplex_config_test.dart
+++ b/test/core/models/soliplex_config_test.dart
@@ -12,7 +12,7 @@ void main() {
 
       expect(config.logo, equals(LogoConfig.soliplex));
       expect(config.appName, equals('Soliplex'));
-      expect(config.defaultBackendUrl, isNull);
+      expect(config.defaultBackendUrl, 'http://localhost:8000');
       expect(config.features, equals(const Features()));
       expect(config.theme, equals(const ThemeConfig()));
       expect(config.routes, equals(const RouteConfig()));
@@ -47,7 +47,7 @@ void main() {
       expect(modified.appName, equals('NewName'));
       expect(modified.logo, equals(newLogo));
       expect(modified.features.enableQuizzes, isFalse);
-      expect(modified.defaultBackendUrl, isNull);
+      expect(modified.defaultBackendUrl, 'http://localhost:8000');
       expect(modified.theme, equals(const ThemeConfig()));
     });
 

--- a/test/features/home/home_screen_test.dart
+++ b/test/features/home/home_screen_test.dart
@@ -98,13 +98,10 @@ Widget _createAppWithRouter({
   return UncontrolledProviderScope(
     container: ProviderContainer(
       overrides: [
-        // Use localhost:8000 as default to match test URLs so connecting
-        // is not treated as a backend change (which triggers signOut).
+        // Default localhost:8000 matches test URLs so connecting is not
+        // treated as a backend change (which triggers signOut).
         shellConfigProvider.overrideWithValue(
-          const SoliplexConfig(
-            logo: LogoConfig.soliplex,
-            defaultBackendUrl: 'http://localhost:8000',
-          ),
+          const SoliplexConfig(logo: LogoConfig.soliplex),
         ),
         ...overrides.cast(),
       ],


### PR DESCRIPTION
## Summary

- Make `SoliplexConfig.defaultBackendUrl` non-nullable with constructor default `'http://localhost:8000'`
- Pass config URL through `platformDefaultBackendUrl()` which decides whether to use it or ignore it
- Remove redundant explicit `defaultBackendUrl` in test helper (now uses default)

## URL Resolution Hierarchy

**Previous:**
```
1. SharedPreferences saved URL
2. SoliplexConfig.defaultBackendUrl (standalone null check)
3. platformDefaultBackendUrl()
   └─ !kIsWeb → hardcoded localhost:8000
   └─ localhost/127.0.0.1 → hardcoded localhost:8000
   └─ else → Uri.base.origin
```

**New:**
```
1. SharedPreferences saved URL
2. platformDefaultBackendUrl(configUrl)
   └─ !kIsWeb → configUrl (non-nullable, has constructor default)
   └─ localhost/127.0.0.1 → configUrl
   └─ else → Uri.base.origin (ignores configUrl)
```

## Test plan

- [x] All 1105 tests pass
- [x] `flutter analyze` reports 0 issues
- [x] Verify native uses config URL
- [x] Verify web localhost uses config URL
- [x] Verify web production uses origin (ignores config URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)