### PR TITLE
feat(run): add RunHandle model (slice 2/11)

### DIFF
--- a/lib/core/models/run_handle.dart
+++ b/lib/core/models/run_handle.dart
@@ -24,7 +24,7 @@ class RunHandle {
     required this.cancelToken,
     required this.subscription,
     ActiveRunState? initialState,
-  }) : _state = initialState ?? const IdleState();
+  }) : state = initialState ?? const IdleState();
 
   /// The room this run belongs to.
   final String roomId;
@@ -39,19 +39,13 @@ class RunHandle {
   final StreamSubscription<BaseEvent> subscription;
 
   /// Current state of the run.
-  ActiveRunState _state;
-
-  /// Gets the current state of the run.
-  ActiveRunState get state => _state;
-
-  /// Updates the run state.
-  set state(ActiveRunState newState) => _state = newState;
+  ActiveRunState state;
 
   /// Composite key for registry lookups: "roomId:threadId".
   String get key => '$roomId:$threadId';
 
   /// Whether the run is currently active (not idle or completed).
-  bool get isActive => _state.isRunning;
+  bool get isActive => state.isRunning;
 
   /// Disposes of all resources held by this handle.
   ///
@@ -62,5 +56,5 @@ class RunHandle {
   }
 
   @override
-  String toString() => 'RunHandle(key: $key, state: $_state)';
+  String toString() => 'RunHandle(key: $key, state: $state)';
 }

--- a/test/core/models/run_handle_test.dart
+++ b/test/core/models/run_handle_test.dart
@@ -188,6 +188,9 @@ void main() {
           eventReceived = true;
         });
 
+        addTearDown(testSubscription.cancel);
+        addTearDown(broadcastController.close);
+
         final handle = RunHandle(
           roomId: 'room-1',
           threadId: 'thread-1',
@@ -204,8 +207,6 @@ void main() {
         await Future<void>.delayed(Duration.zero);
 
         expect(eventReceived, isFalse);
-
-        await broadcastController.close();
       });
 
       test('can be called multiple times safely', () async {


### PR DESCRIPTION
## Summary

- Add `RunHandle` class to encapsulate run resources (CancelToken, StreamSubscription, ActiveRunState)
- Composite `key` property for registry lookups: `roomId:threadId`
- `dispose()` method for cleanup
- `isActive` helper for checking run state

**Slice 2 of 11** for [Network Multiplexer (#71)](https://github.com/soliplex/flutter/issues/71)

This is an internal refactor that prepares for multi-run tracking in slice 3.

## Test plan

- [x] Unit tests for construction with required/optional fields
- [x] Unit tests for `key` property
- [x] Unit tests for `dispose()` cancels token and subscription
- [x] Unit tests for `isActive` reflects state correctly
- [x] All 13 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)