### PR TITLE
feat(native): add Android Cronet HTTP transport

### DIFF
--- a/packages/soliplex_client_native/lib/soliplex_client_native.dart
+++ b/packages/soliplex_client_native/lib/soliplex_client_native.dart
@@ -1,6 +1,7 @@
 /// Native HTTP clients for soliplex_client.
 ///
 /// Provides platform-optimized HTTP clients:
+/// - `CronetHttpClient` for Android using Cronet (HTTP/2, HTTP/3, QUIC)
 /// - `CupertinoHttpClient` for iOS and macOS using NSURLSession
 /// - `createPlatformClient` for automatic platform detection
 ///
@@ -14,6 +15,7 @@
 ///
 /// // Or use specific client
 /// final cupertinoClient = CupertinoHttpClient();
+/// final cronetClient = CronetHttpClient();
 /// ```
 library soliplex_client_native;
 

--- a/packages/soliplex_client_native/lib/src/clients/clients.dart
+++ b/packages/soliplex_client_native/lib/src/clients/clients.dart
@@ -1,2 +1,4 @@
+export 'cronet_http_client_stub.dart'
+    if (dart.library.io) 'cronet_http_client.dart';
 export 'cupertino_http_client_stub.dart'
     if (dart.library.io) 'cupertino_http_client.dart';

--- a/packages/soliplex_client_native/lib/src/clients/cronet_http_client.dart
+++ b/packages/soliplex_client_native/lib/src/clients/cronet_http_client.dart
@@ -1,0 +1,243 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cronet_http/cronet_http.dart';
+import 'package:http/http.dart' as http;
+import 'package:meta/meta.dart';
+import 'package:soliplex_client/soliplex_client.dart';
+
+/// HTTP client using Google's Cronet via cronet_http.
+///
+/// Provides native HTTP support on Android with benefits including:
+/// - HTTP/2 and HTTP/3 (QUIC) support
+/// - Connection pooling and multiplexing
+/// - Brotli compression
+/// - Automatic proxy and VPN support
+/// - Continuous security updates via Google Play Services
+///
+/// Example:
+/// ```dart
+/// final client = CronetHttpClient();
+/// try {
+///   final response = await client.request(
+///     'GET',
+///     Uri.parse('https://api.example.com/data'),
+///   );
+///   print(response.body);
+/// } finally {
+///   client.close();
+/// }
+/// ```
+class CronetHttpClient implements SoliplexHttpClient {
+  /// Creates a Cronet HTTP client.
+  ///
+  /// Parameters:
+  /// - [engine]: Optional CronetEngine. If not provided, the default
+  ///   Cronet engine (backed by Google Play Services) is used.
+  /// - [defaultTimeout]: Default timeout for requests.
+  CronetHttpClient({
+    CronetEngine? engine,
+    this.defaultTimeout = defaultHttpTimeout,
+  }) : _client = engine != null
+            ? CronetClient.fromCronetEngine(engine, closeEngine: true)
+            : CronetClient.defaultCronetEngine();
+
+  /// Creates a Cronet HTTP client with a custom client for testing.
+  ///
+  /// This constructor allows injecting a mock client for unit testing.
+  @visibleForTesting
+  CronetHttpClient.forTesting({
+    required http.Client client,
+    this.defaultTimeout = defaultHttpTimeout,
+  }) : _client = client;
+
+  final http.Client _client;
+
+  /// Default timeout for requests when not specified per-request.
+  final Duration defaultTimeout;
+
+  bool _closed = false;
+
+  @override
+  Future<HttpResponse> request(
+    String method,
+    Uri uri, {
+    Map<String, String>? headers,
+    Object? body,
+    Duration? timeout,
+  }) async {
+    _checkNotClosed();
+
+    final effectiveTimeout = timeout ?? defaultTimeout;
+    final request = _createRequest(method, uri, headers, body);
+
+    try {
+      final streamedResponse = await _client.send(request).timeout(
+        effectiveTimeout,
+        onTimeout: () {
+          throw TimeoutException(
+            'Request timed out after ${effectiveTimeout.inSeconds}s',
+            effectiveTimeout,
+          );
+        },
+      );
+
+      final bodyBytes = await streamedResponse.stream.toBytes().timeout(
+        effectiveTimeout,
+        onTimeout: () {
+          throw TimeoutException(
+            'Response body timed out after ${effectiveTimeout.inSeconds}s',
+            effectiveTimeout,
+          );
+        },
+      );
+
+      return HttpResponse(
+        statusCode: streamedResponse.statusCode,
+        bodyBytes: Uint8List.fromList(bodyBytes),
+        headers: _normalizeHeaders(streamedResponse.headers),
+        reasonPhrase: streamedResponse.reasonPhrase,
+      );
+    } on TimeoutException catch (e, stackTrace) {
+      throw NetworkException(
+        message: e.message ?? 'Request timed out',
+        isTimeout: true,
+        originalError: e,
+        stackTrace: stackTrace,
+      );
+    } on http.ClientException catch (e, stackTrace) {
+      throw NetworkException(
+        message: 'Client error: ${e.message}',
+        originalError: e,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  @override
+  Stream<List<int>> requestStream(
+    String method,
+    Uri uri, {
+    Map<String, String>? headers,
+    Object? body,
+  }) {
+    _checkNotClosed();
+
+    final request = _createRequest(method, uri, headers, body);
+
+    late StreamController<List<int>> controller;
+    StreamSubscription<List<int>>? subscription;
+
+    controller = StreamController<List<int>>(
+      onListen: () async {
+        try {
+          final streamedResponse = await _client.send(request);
+
+          // Check for HTTP errors before streaming
+          if (streamedResponse.statusCode >= 400) {
+            controller.addError(
+              NetworkException(
+                message: 'HTTP ${streamedResponse.statusCode}: '
+                    '${streamedResponse.reasonPhrase}',
+              ),
+            );
+            await controller.close();
+            return;
+          }
+
+          subscription = streamedResponse.stream.listen(
+            controller.add,
+            onError: (Object error, StackTrace stackTrace) {
+              if (error is http.ClientException) {
+                controller.addError(
+                  NetworkException(
+                    message: 'Connection error: ${error.message}',
+                    originalError: error,
+                    stackTrace: stackTrace,
+                  ),
+                );
+              } else {
+                controller.addError(error, stackTrace);
+              }
+            },
+            onDone: controller.close,
+            cancelOnError: true,
+          );
+        } on http.ClientException catch (e, stackTrace) {
+          controller.addError(
+            NetworkException(
+              message: 'Client error: ${e.message}',
+              originalError: e,
+              stackTrace: stackTrace,
+            ),
+          );
+          await controller.close();
+        }
+      },
+      onCancel: () async {
+        await subscription?.cancel();
+      },
+    );
+
+    return controller.stream;
+  }
+
+  @override
+  void close() {
+    if (!_closed) {
+      _closed = true;
+      _client.close();
+    }
+  }
+
+  /// Creates an HTTP request with the given parameters.
+  http.Request _createRequest(
+    String method,
+    Uri uri,
+    Map<String, String>? headers,
+    Object? body,
+  ) {
+    final request = http.Request(method.toUpperCase(), uri);
+
+    if (headers != null) {
+      request.headers.addAll(headers);
+    }
+
+    if (body != null) {
+      if (body is String) {
+        // Set content-type before body to prevent http package from overriding
+        request.headers['content-type'] ??= 'text/plain; charset=utf-8';
+        request.body = body;
+      } else if (body is List<int>) {
+        request.headers['content-type'] ??= 'application/octet-stream';
+        request.bodyBytes = body;
+      } else if (body is Map<String, dynamic>) {
+        // Set content-type before body to prevent http package from overriding
+        request.headers['content-type'] ??= 'application/json; charset=utf-8';
+        request.body = jsonEncode(body);
+      } else {
+        throw ArgumentError(
+          'Unsupported body type: ${body.runtimeType}. '
+          'Use String, List<int>, or Map<String, dynamic>.',
+        );
+      }
+    }
+
+    return request;
+  }
+
+  /// Normalizes headers by converting keys to lowercase.
+  Map<String, String> _normalizeHeaders(Map<String, String> headers) {
+    return headers.map((key, value) => MapEntry(key.toLowerCase(), value));
+  }
+
+  /// Checks that the client has not been closed.
+  void _checkNotClosed() {
+    if (_closed) {
+      throw StateError(
+        'Cannot use CronetHttpClient after close() was called',
+      );
+    }
+  }
+}

--- a/packages/soliplex_client_native/lib/src/clients/cronet_http_client_stub.dart
+++ b/packages/soliplex_client_native/lib/src/clients/cronet_http_client_stub.dart
@@ -1,0 +1,3 @@
+// Empty stub for web platform.
+// CronetHttpClient is not available on web.
+// Use createPlatformClient() instead.

--- a/packages/soliplex_client_native/lib/src/platform/create_platform_client.dart
+++ b/packages/soliplex_client_native/lib/src/platform/create_platform_client.dart
@@ -5,8 +5,9 @@ import 'package:soliplex_client_native/src/platform/create_platform_client_stub.
 /// Creates an HTTP client optimized for the current platform.
 ///
 /// Returns:
+/// - `CronetHttpClient` on Android (uses Cronet via Google Play Services)
 /// - `CupertinoHttpClient` on iOS and macOS (uses NSURLSession)
-/// - `DartHttpClient` on all other platforms (Android, Windows, Linux, Web)
+/// - `DartHttpClient` on all other platforms (Windows, Linux, Web)
 ///
 /// The [defaultTimeout] parameter sets the default request timeout.
 ///

--- a/packages/soliplex_client_native/lib/src/platform/create_platform_client_io.dart
+++ b/packages/soliplex_client_native/lib/src/platform/create_platform_client_io.dart
@@ -1,18 +1,30 @@
 import 'dart:io';
 
 import 'package:soliplex_client/soliplex_client.dart';
+import 'package:soliplex_client_native/src/clients/cronet_http_client.dart';
 import 'package:soliplex_client_native/src/clients/cupertino_http_client.dart';
 
 /// Creates platform-specific client for IO platforms.
 ///
-/// Returns [CupertinoHttpClient] on macOS and iOS, otherwise returns
-/// [DartHttpClient] for Android, Windows, and Linux.
+/// Returns:
+/// - [CronetHttpClient] on Android (uses Cronet via Google Play Services)
+/// - [CupertinoHttpClient] on macOS and iOS (uses NSURLSession)
+/// - [DartHttpClient] on all other platforms (Windows, Linux)
 ///
 /// Note: Falls back to [DartHttpClient] if native bindings are unavailable
-/// (e.g., in Flutter test environment).
+/// (e.g., in Flutter test environment or when Cronet/Play Services missing).
 SoliplexHttpClient createPlatformClientImpl({
   Duration defaultTimeout = defaultHttpTimeout,
 }) {
+  if (Platform.isAndroid) {
+    try {
+      return CronetHttpClient(defaultTimeout: defaultTimeout);
+    } catch (e) {
+      // Fallback to DartHttpClient if Cronet unavailable
+      // (e.g., Google Play Services missing)
+      return DartHttpClient(defaultTimeout: defaultTimeout);
+    }
+  }
   if (Platform.isMacOS || Platform.isIOS) {
     try {
       return CupertinoHttpClient(defaultTimeout: defaultTimeout);
@@ -22,6 +34,6 @@ SoliplexHttpClient createPlatformClientImpl({
       return DartHttpClient(defaultTimeout: defaultTimeout);
     }
   }
-  // Fallback to DartHttpClient for Android, Windows, Linux
+  // Fallback to DartHttpClient for Windows, Linux
   return DartHttpClient(defaultTimeout: defaultTimeout);
 }

--- a/packages/soliplex_client_native/pubspec.yaml
+++ b/packages/soliplex_client_native/pubspec.yaml
@@ -1,5 +1,5 @@
 name: soliplex_client_native
-description: Native HTTP clients for soliplex_client on iOS and macOS
+description: Native HTTP clients for soliplex_client on iOS, macOS, and Android
 version: 1.0.0-dev
 publish_to: none
 
@@ -8,10 +8,11 @@ environment:
   flutter: '>=3.10.0'
 
 dependencies:
+  cronet_http: ^1.7.0
   cupertino_http: ^2.0.0
   flutter:
     sdk: flutter
-  http: ^1.2.0
+  http: ^1.5.0
   meta: ^1.9.0
   soliplex_client:
     path: ../soliplex_client

--- a/packages/soliplex_client_native/test/clients/cronet_http_client_test.dart
+++ b/packages/soliplex_client_native/test/clients/cronet_http_client_test.dart
@@ -1,0 +1,811 @@
+@TestOn('vm')
+library;
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
+import 'package:soliplex_client/soliplex_client.dart';
+// Import implementation directly since package uses conditional exports
+import 'package:soliplex_client_native/src/clients/cronet_http_client.dart';
+
+class MockHttpClient extends Mock implements http.Client {}
+
+class FakeBaseRequest extends Fake implements http.BaseRequest {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(FakeBaseRequest());
+  });
+
+  group('CronetHttpClient', () {
+    late MockHttpClient mockClient;
+    late CronetHttpClient client;
+
+    setUp(() {
+      mockClient = MockHttpClient();
+      client = CronetHttpClient.forTesting(client: mockClient);
+    });
+
+    tearDown(() {
+      client.close();
+    });
+
+    group('request', () {
+      test('performs GET request and returns response', () async {
+        final responseBody = utf8.encode('{"data": "test"}');
+        final streamedResponse = _createStreamedResponse(
+          statusCode: 200,
+          body: responseBody,
+          headers: {'content-type': 'application/json'},
+        );
+
+        when(
+          () => mockClient.send(any()),
+        ).thenAnswer((_) async => streamedResponse);
+
+        final response = await client.request(
+          'GET',
+          Uri.parse('https://example.com/api'),
+        );
+
+        expect(response.statusCode, equals(200));
+        expect(response.body, equals('{"data": "test"}'));
+        expect(response.contentType, equals('application/json'));
+      });
+
+      test('performs POST request with JSON body', () async {
+        final streamedResponse = _createStreamedResponse(
+          statusCode: 201,
+          body: [],
+        );
+
+        http.Request? capturedRequest;
+        when(() => mockClient.send(any())).thenAnswer((invocation) async {
+          capturedRequest = invocation.positionalArguments[0] as http.Request;
+          return streamedResponse;
+        });
+
+        await client.request(
+          'POST',
+          Uri.parse('https://example.com/api'),
+          body: {'key': 'value'},
+        );
+
+        expect(capturedRequest?.method, equals('POST'));
+        expect(capturedRequest?.body, equals('{"key":"value"}'));
+        expect(
+          capturedRequest?.headers['content-type'],
+          contains('application/json'),
+        );
+      });
+
+      test('performs POST request with string body', () async {
+        final streamedResponse = _createStreamedResponse(
+          statusCode: 200,
+          body: [],
+        );
+
+        http.Request? capturedRequest;
+        when(() => mockClient.send(any())).thenAnswer((invocation) async {
+          capturedRequest = invocation.positionalArguments[0] as http.Request;
+          return streamedResponse;
+        });
+
+        await client.request(
+          'POST',
+          Uri.parse('https://example.com/api'),
+          body: 'plain text',
+        );
+
+        expect(capturedRequest?.body, equals('plain text'));
+        expect(
+          capturedRequest?.headers['content-type'],
+          contains('text/plain'),
+        );
+      });
+
+      test('performs POST request with bytes body', () async {
+        final streamedResponse = _createStreamedResponse(
+          statusCode: 200,
+          body: [],
+        );
+
+        http.Request? capturedRequest;
+        when(() => mockClient.send(any())).thenAnswer((invocation) async {
+          capturedRequest = invocation.positionalArguments[0] as http.Request;
+          return streamedResponse;
+        });
+
+        await client.request(
+          'POST',
+          Uri.parse('https://example.com/api'),
+          body: [1, 2, 3, 4],
+        );
+
+        expect(capturedRequest?.bodyBytes, equals([1, 2, 3, 4]));
+        expect(
+          capturedRequest?.headers['content-type'],
+          contains('application/octet-stream'),
+        );
+      });
+
+      test('includes custom headers in request', () async {
+        final streamedResponse = _createStreamedResponse(
+          statusCode: 200,
+          body: [],
+        );
+
+        http.Request? capturedRequest;
+        when(() => mockClient.send(any())).thenAnswer((invocation) async {
+          capturedRequest = invocation.positionalArguments[0] as http.Request;
+          return streamedResponse;
+        });
+
+        await client.request(
+          'GET',
+          Uri.parse('https://example.com/api'),
+          headers: {'Authorization': 'Bearer token123'},
+        );
+
+        expect(
+          capturedRequest?.headers['Authorization'],
+          equals('Bearer token123'),
+        );
+      });
+
+      test('does not override user-provided content-type', () async {
+        final streamedResponse = _createStreamedResponse(
+          statusCode: 200,
+          body: [],
+        );
+
+        http.Request? capturedRequest;
+        when(() => mockClient.send(any())).thenAnswer((invocation) async {
+          capturedRequest = invocation.positionalArguments[0] as http.Request;
+          return streamedResponse;
+        });
+
+        await client.request(
+          'POST',
+          Uri.parse('https://example.com/api'),
+          headers: {'content-type': 'application/xml'},
+          body: '<xml>data</xml>',
+        );
+
+        // User's content-type is preserved (http package may append charset)
+        expect(
+          capturedRequest?.headers['content-type'],
+          startsWith('application/xml'),
+        );
+      });
+
+      test(
+        'throws NetworkException with isTimeout on request timeout',
+        () async {
+          when(() => mockClient.send(any())).thenAnswer(
+            (_) => Future.delayed(
+              const Duration(seconds: 5),
+              () => _createStreamedResponse(statusCode: 200, body: []),
+            ),
+          );
+
+          client = CronetHttpClient.forTesting(
+            client: mockClient,
+            defaultTimeout: const Duration(milliseconds: 50),
+          );
+
+          await expectLater(
+            client.request('GET', Uri.parse('https://example.com/api')),
+            throwsA(
+              isA<NetworkException>().having(
+                (e) => e.isTimeout,
+                'isTimeout',
+                isTrue,
+              ),
+            ),
+          );
+        },
+      );
+
+      test('throws NetworkException on ClientException', () async {
+        when(
+          () => mockClient.send(any()),
+        ).thenThrow(http.ClientException('Network error'));
+
+        await expectLater(
+          client.request('GET', Uri.parse('https://example.com/api')),
+          throwsA(isA<NetworkException>()),
+        );
+      });
+
+      test('throws ArgumentError for unsupported body type', () async {
+        expect(
+          () => client.request(
+            'POST',
+            Uri.parse('https://example.com/api'),
+            body: DateTime.now(),
+          ),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+
+      test('uses custom timeout when provided', () async {
+        when(() => mockClient.send(any())).thenAnswer(
+          (_) => Future.delayed(
+            const Duration(milliseconds: 200),
+            () => _createStreamedResponse(statusCode: 200, body: []),
+          ),
+        );
+
+        await expectLater(
+          client.request(
+            'GET',
+            Uri.parse('https://example.com/api'),
+            timeout: const Duration(milliseconds: 50),
+          ),
+          throwsA(isA<NetworkException>()),
+        );
+      });
+
+      test('normalizes response headers to lowercase', () async {
+        final streamedResponse = _createStreamedResponse(
+          statusCode: 200,
+          body: [],
+          headers: {'Content-Type': 'application/json', 'X-Custom': 'value'},
+        );
+
+        when(
+          () => mockClient.send(any()),
+        ).thenAnswer((_) async => streamedResponse);
+
+        final response = await client.request(
+          'GET',
+          Uri.parse('https://example.com/api'),
+        );
+
+        expect(response.headers['content-type'], equals('application/json'));
+        expect(response.headers['x-custom'], equals('value'));
+      });
+
+      test('uppercases HTTP method', () async {
+        final streamedResponse = _createStreamedResponse(
+          statusCode: 200,
+          body: [],
+        );
+
+        http.Request? capturedRequest;
+        when(() => mockClient.send(any())).thenAnswer((invocation) async {
+          capturedRequest = invocation.positionalArguments[0] as http.Request;
+          return streamedResponse;
+        });
+
+        await client.request('get', Uri.parse('https://example.com/api'));
+
+        expect(capturedRequest?.method, equals('GET'));
+      });
+
+      test('includes reasonPhrase in response', () async {
+        final streamedResponse = _createStreamedResponse(
+          statusCode: 201,
+          body: [],
+          reasonPhrase: 'Created',
+        );
+
+        when(
+          () => mockClient.send(any()),
+        ).thenAnswer((_) async => streamedResponse);
+
+        final response = await client.request(
+          'POST',
+          Uri.parse('https://example.com/api'),
+        );
+
+        expect(response.reasonPhrase, equals('Created'));
+      });
+
+      test('preserves original error in NetworkException', () async {
+        final originalError = http.ClientException('Connection refused');
+        when(() => mockClient.send(any())).thenThrow(originalError);
+
+        try {
+          await client.request('GET', Uri.parse('https://example.com/api'));
+          fail('Expected NetworkException');
+        } on NetworkException catch (e) {
+          expect(e.originalError, equals(originalError));
+          expect(e.stackTrace, isNotNull);
+        }
+      });
+
+      test('throws NetworkException on response body timeout', () async {
+        // Create a stream that delays forever to simulate body timeout
+        final bodyController = StreamController<List<int>>();
+        final streamedResponse = http.StreamedResponse(
+          bodyController.stream,
+          200,
+          reasonPhrase: 'OK',
+        );
+
+        when(
+          () => mockClient.send(any()),
+        ).thenAnswer((_) async => streamedResponse);
+
+        client = CronetHttpClient.forTesting(
+          client: mockClient,
+          defaultTimeout: const Duration(milliseconds: 50),
+        );
+
+        await expectLater(
+          client.request('GET', Uri.parse('https://example.com/api')),
+          throwsA(
+            isA<NetworkException>()
+                .having((e) => e.isTimeout, 'isTimeout', isTrue)
+                .having(
+                  (e) => e.message,
+                  'message',
+                  contains('Response body timed out'),
+                ),
+          ),
+        );
+
+        await bodyController.close();
+      });
+
+      test('handles TimeoutException with null message', () async {
+        when(() => mockClient.send(any())).thenThrow(TimeoutException(null));
+
+        await expectLater(
+          client.request('GET', Uri.parse('https://example.com/api')),
+          throwsA(
+            isA<NetworkException>()
+                .having((e) => e.isTimeout, 'isTimeout', isTrue)
+                .having(
+                  (e) => e.message,
+                  'message',
+                  equals('Request timed out'),
+                ),
+          ),
+        );
+      });
+
+      test('request with no body sends empty request', () async {
+        final streamedResponse = _createStreamedResponse(
+          statusCode: 200,
+          body: [],
+        );
+
+        http.Request? capturedRequest;
+        when(() => mockClient.send(any())).thenAnswer((invocation) async {
+          capturedRequest = invocation.positionalArguments[0] as http.Request;
+          return streamedResponse;
+        });
+
+        await client.request('GET', Uri.parse('https://example.com/api'));
+
+        expect(capturedRequest?.bodyBytes, isEmpty);
+      });
+
+      test(
+        'request with no headers sends request without custom headers',
+        () async {
+          final streamedResponse = _createStreamedResponse(
+            statusCode: 200,
+            body: [],
+          );
+
+          http.Request? capturedRequest;
+          when(() => mockClient.send(any())).thenAnswer((invocation) async {
+            capturedRequest = invocation.positionalArguments[0] as http.Request;
+            return streamedResponse;
+          });
+
+          await client.request('GET', Uri.parse('https://example.com/api'));
+
+          // Should not have custom headers
+          // (only default ones from http package)
+          expect(
+            capturedRequest?.headers.containsKey('Authorization'),
+            isFalse,
+          );
+        },
+      );
+    });
+
+    group('requestStream', () {
+      test('streams response body chunks', () async {
+        final controller = StreamController<List<int>>();
+        final streamedResponse = http.StreamedResponse(
+          controller.stream,
+          200,
+          reasonPhrase: 'OK',
+        );
+
+        when(
+          () => mockClient.send(any()),
+        ).thenAnswer((_) async => streamedResponse);
+
+        final stream = client.requestStream(
+          'GET',
+          Uri.parse('https://example.com/stream'),
+        );
+
+        final chunks = <List<int>>[];
+        final completer = Completer<void>();
+
+        stream.listen(
+          chunks.add,
+          onDone: completer.complete,
+          onError: completer.completeError,
+        );
+
+        // Give time for the listener to be set up
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+
+        controller
+          ..add([1, 2, 3])
+          ..add([4, 5, 6]);
+        await controller.close();
+
+        await completer.future;
+
+        expect(
+          chunks,
+          equals([
+            [1, 2, 3],
+            [4, 5, 6],
+          ]),
+        );
+      });
+
+      test('emits NetworkException on HTTP error status', () async {
+        final streamedResponse = _createStreamedResponse(
+          statusCode: 500,
+          body: utf8.encode('Internal Server Error'),
+          reasonPhrase: 'Internal Server Error',
+        );
+
+        when(
+          () => mockClient.send(any()),
+        ).thenAnswer((_) async => streamedResponse);
+
+        final stream = client.requestStream(
+          'GET',
+          Uri.parse('https://example.com/stream'),
+        );
+
+        await expectLater(stream, emitsError(isA<NetworkException>()));
+      });
+
+      test('emits NetworkException on client exception', () async {
+        when(
+          () => mockClient.send(any()),
+        ).thenThrow(http.ClientException('Client error'));
+
+        final stream = client.requestStream(
+          'GET',
+          Uri.parse('https://example.com/stream'),
+        );
+
+        await expectLater(stream, emitsError(isA<NetworkException>()));
+      });
+
+      test('can be cancelled via subscription', () async {
+        final controller = StreamController<List<int>>();
+        final streamedResponse = http.StreamedResponse(
+          controller.stream,
+          200,
+          reasonPhrase: 'OK',
+        );
+
+        when(
+          () => mockClient.send(any()),
+        ).thenAnswer((_) async => streamedResponse);
+
+        final stream = client.requestStream(
+          'GET',
+          Uri.parse('https://example.com/stream'),
+        );
+
+        final chunks = <List<int>>[];
+        final subscription = stream.listen(chunks.add);
+
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+
+        controller.add([1, 2, 3]);
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+
+        await subscription.cancel();
+
+        // Should not add more chunks after cancel
+        controller.add([4, 5, 6]);
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+
+        expect(
+          chunks,
+          equals([
+            [1, 2, 3],
+          ]),
+        );
+
+        await controller.close();
+      });
+
+      test(
+        'converts ClientException during streaming to NetworkException',
+        () async {
+          final controller = StreamController<List<int>>();
+          final streamedResponse = http.StreamedResponse(
+            controller.stream,
+            200,
+            reasonPhrase: 'OK',
+          );
+
+          when(
+            () => mockClient.send(any()),
+          ).thenAnswer((_) async => streamedResponse);
+
+          final stream = client.requestStream(
+            'GET',
+            Uri.parse('https://example.com/stream'),
+          );
+
+          final errors = <Object>[];
+          final completer = Completer<void>();
+
+          stream.listen(
+            (_) {},
+            onError: (Object e) {
+              errors.add(e);
+              completer.complete();
+            },
+            onDone: () {
+              if (!completer.isCompleted) completer.complete();
+            },
+          );
+
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+
+          // Simulate a ClientException during streaming
+          controller.addError(http.ClientException('Connection lost'));
+
+          await completer.future;
+
+          expect(errors, hasLength(1));
+          expect(errors.first, isA<NetworkException>());
+          expect(
+            (errors.first as NetworkException).message,
+            contains('Connection lost'),
+          );
+
+          await controller.close();
+        },
+      );
+
+      test(
+        'passes through non-ClientException errors during streaming',
+        () async {
+          final controller = StreamController<List<int>>();
+          final streamedResponse = http.StreamedResponse(
+            controller.stream,
+            200,
+            reasonPhrase: 'OK',
+          );
+
+          when(
+            () => mockClient.send(any()),
+          ).thenAnswer((_) async => streamedResponse);
+
+          final stream = client.requestStream(
+            'GET',
+            Uri.parse('https://example.com/stream'),
+          );
+
+          final errors = <Object>[];
+          final completer = Completer<void>();
+
+          stream.listen(
+            (_) {},
+            onError: (Object e) {
+              errors.add(e);
+              completer.complete();
+            },
+            onDone: () {
+              if (!completer.isCompleted) completer.complete();
+            },
+          );
+
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+
+          // Simulate a non-ClientException error during streaming
+          controller.addError(Exception('Some other error'));
+
+          await completer.future;
+
+          expect(errors, hasLength(1));
+          // Non-ClientException errors should be passed through as-is
+          expect(errors.first, isA<Exception>());
+          expect(errors.first, isNot(isA<NetworkException>()));
+
+          await controller.close();
+        },
+      );
+
+      test('handles stream with body parameter', () async {
+        final controller = StreamController<List<int>>();
+        final streamedResponse = http.StreamedResponse(
+          controller.stream,
+          200,
+          reasonPhrase: 'OK',
+        );
+
+        http.Request? capturedRequest;
+        when(() => mockClient.send(any())).thenAnswer((invocation) async {
+          capturedRequest = invocation.positionalArguments[0] as http.Request;
+          return streamedResponse;
+        });
+
+        final stream = client.requestStream(
+          'POST',
+          Uri.parse('https://example.com/stream'),
+          body: {'key': 'value'},
+          headers: {'X-Custom': 'header'},
+        );
+
+        final chunks = <List<int>>[];
+        final completer = Completer<void>();
+
+        stream.listen(chunks.add, onDone: completer.complete);
+
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+
+        controller.add([1, 2, 3]);
+        await controller.close();
+
+        await completer.future;
+
+        expect(capturedRequest?.method, equals('POST'));
+        expect(capturedRequest?.body, equals('{"key":"value"}'));
+        expect(capturedRequest?.headers['X-Custom'], equals('header'));
+        expect(
+          chunks,
+          equals([
+            [1, 2, 3],
+          ]),
+        );
+      });
+    });
+
+    group('close', () {
+      test('closes underlying client', () {
+        client.close();
+
+        verify(() => mockClient.close()).called(1);
+      });
+
+      test('multiple close calls only close client once', () {
+        client
+          ..close()
+          ..close()
+          ..close();
+
+        verify(() => mockClient.close()).called(1);
+      });
+
+      test('throws StateError when request called after close', () {
+        client.close();
+
+        expect(
+          () => client.request('GET', Uri.parse('https://example.com')),
+          throwsStateError,
+        );
+      });
+
+      test('throws StateError when requestStream called after close', () {
+        client.close();
+
+        expect(
+          () => client.requestStream('GET', Uri.parse('https://example.com')),
+          throwsStateError,
+        );
+      });
+    });
+
+    group('HTTP methods', () {
+      test('supports PUT request', () async {
+        final streamedResponse = _createStreamedResponse(
+          statusCode: 200,
+          body: [],
+        );
+
+        http.Request? capturedRequest;
+        when(() => mockClient.send(any())).thenAnswer((invocation) async {
+          capturedRequest = invocation.positionalArguments[0] as http.Request;
+          return streamedResponse;
+        });
+
+        await client.request(
+          'PUT',
+          Uri.parse('https://example.com/api'),
+          body: {'update': 'data'},
+        );
+
+        expect(capturedRequest?.method, equals('PUT'));
+      });
+
+      test('supports DELETE request', () async {
+        final streamedResponse = _createStreamedResponse(
+          statusCode: 204,
+          body: [],
+        );
+
+        http.Request? capturedRequest;
+        when(() => mockClient.send(any())).thenAnswer((invocation) async {
+          capturedRequest = invocation.positionalArguments[0] as http.Request;
+          return streamedResponse;
+        });
+
+        await client.request(
+          'DELETE',
+          Uri.parse('https://example.com/api/123'),
+        );
+
+        expect(capturedRequest?.method, equals('DELETE'));
+      });
+
+      test('supports PATCH request', () async {
+        final streamedResponse = _createStreamedResponse(
+          statusCode: 200,
+          body: [],
+        );
+
+        http.Request? capturedRequest;
+        when(() => mockClient.send(any())).thenAnswer((invocation) async {
+          capturedRequest = invocation.positionalArguments[0] as http.Request;
+          return streamedResponse;
+        });
+
+        await client.request(
+          'PATCH',
+          Uri.parse('https://example.com/api/123'),
+          body: {'partial': 'update'},
+        );
+
+        expect(capturedRequest?.method, equals('PATCH'));
+      });
+
+      test('supports HEAD request', () async {
+        final streamedResponse = _createStreamedResponse(
+          statusCode: 200,
+          body: [],
+        );
+
+        http.Request? capturedRequest;
+        when(() => mockClient.send(any())).thenAnswer((invocation) async {
+          capturedRequest = invocation.positionalArguments[0] as http.Request;
+          return streamedResponse;
+        });
+
+        await client.request('HEAD', Uri.parse('https://example.com/api'));
+
+        expect(capturedRequest?.method, equals('HEAD'));
+      });
+    });
+  });
+}
+
+/// Helper to create a StreamedResponse for testing.
+http.StreamedResponse _createStreamedResponse({
+  required int statusCode,
+  required List<int> body,
+  Map<String, String>? headers,
+  String? reasonPhrase,
+}) {
+  return http.StreamedResponse(
+    Stream.value(body),
+    statusCode,
+    headers: headers ?? {},
+    reasonPhrase: reasonPhrase,
+  );
+}


### PR DESCRIPTION
## Summary
- Add `CronetHttpClient` for native Android HTTP via Google Play Services Cronet
- Provides HTTP/2, HTTP/3 (QUIC), connection pooling, Brotli compression
- Mirrors existing `CupertinoHttpClient` pattern with graceful `DartHttpClient` fallback

## Changes
- **pubspec.yaml**: Add `cronet_http: ^1.7.0`, bump `http` to `^1.5.0`
- **CronetHttpClient**: New client with `.forTesting` constructor, same interface as Cupertino
- **clients.dart**: Add conditional export for Cronet (stub on web, real on IO)
- **create_platform_client_io.dart**: Add `Platform.isAndroid` branch with try-catch fallback
- **Docs**: Updated library and factory doc comments to list Cronet/Android
- **Tests**: 33 new unit tests + 2 platform detection tests for Android

## Test plan
- [x] `flutter pub get` resolves cleanly
- [x] `dart analyze` — 0 issues
- [x] `flutter test` — 72 pass, 8 skip (platform-specific)
- [x] Pre-commit hooks pass (format, analyze, secrets)
- [ ] Build Android APK and verify Cronet loads on device
- [ ] Check HTTP inspector in-app shows requests via Cronet transport

🤖 Generated with [Claude Code](https://claude.com/claude-code)