### PR TITLE
feat(logging): wire BackendLogSink into app with providers and UI (12.3)

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:soliplex_frontend/core/auth/auth_provider.dart';
@@ -39,6 +41,17 @@ class _SoliplexAppState extends ConsumerState<SoliplexApp>
     if (state == AppLifecycleState.resumed) {
       _enableWakelock();
     }
+    if (state == AppLifecycleState.paused ||
+        state == AppLifecycleState.hidden ||
+        state == AppLifecycleState.detached) {
+      _flushBackendLogs();
+    }
+  }
+
+  void _flushBackendLogs() {
+    ref.read(backendLogSinkProvider).whenData((sink) {
+      if (sink != null) unawaited(sink.flush());
+    });
   }
 
   Future<void> _enableWakelock() async {

--- a/lib/core/logging/log_config.dart
+++ b/lib/core/logging/log_config.dart
@@ -9,6 +9,8 @@ class LogConfig {
     required this.minimumLevel,
     required this.consoleLoggingEnabled,
     required this.stdoutLoggingEnabled,
+    this.backendLoggingEnabled = false,
+    this.backendEndpoint = '/api/v1/logs',
   });
 
   /// Default configuration used before preferences are loaded.
@@ -33,17 +35,28 @@ class LogConfig {
   /// to dart:developer. On mobile and web, this setting has no effect.
   final bool stdoutLoggingEnabled;
 
+  /// Whether backend log shipping is enabled.
+  final bool backendLoggingEnabled;
+
+  /// Backend endpoint for log ingestion.
+  final String backendEndpoint;
+
   /// Creates a copy with the specified fields replaced.
   LogConfig copyWith({
     LogLevel? minimumLevel,
     bool? consoleLoggingEnabled,
     bool? stdoutLoggingEnabled,
+    bool? backendLoggingEnabled,
+    String? backendEndpoint,
   }) {
     return LogConfig(
       minimumLevel: minimumLevel ?? this.minimumLevel,
       consoleLoggingEnabled:
           consoleLoggingEnabled ?? this.consoleLoggingEnabled,
       stdoutLoggingEnabled: stdoutLoggingEnabled ?? this.stdoutLoggingEnabled,
+      backendLoggingEnabled:
+          backendLoggingEnabled ?? this.backendLoggingEnabled,
+      backendEndpoint: backendEndpoint ?? this.backendEndpoint,
     );
   }
 
@@ -54,14 +67,23 @@ class LogConfig {
           runtimeType == other.runtimeType &&
           minimumLevel == other.minimumLevel &&
           consoleLoggingEnabled == other.consoleLoggingEnabled &&
-          stdoutLoggingEnabled == other.stdoutLoggingEnabled;
+          stdoutLoggingEnabled == other.stdoutLoggingEnabled &&
+          backendLoggingEnabled == other.backendLoggingEnabled &&
+          backendEndpoint == other.backendEndpoint;
 
   @override
-  int get hashCode =>
-      Object.hash(minimumLevel, consoleLoggingEnabled, stdoutLoggingEnabled);
+  int get hashCode => Object.hash(
+        minimumLevel,
+        consoleLoggingEnabled,
+        stdoutLoggingEnabled,
+        backendLoggingEnabled,
+        backendEndpoint,
+      );
 
   @override
   String toString() => 'LogConfig(minimumLevel: $minimumLevel, '
       'consoleLoggingEnabled: $consoleLoggingEnabled, '
-      'stdoutLoggingEnabled: $stdoutLoggingEnabled)';
+      'stdoutLoggingEnabled: $stdoutLoggingEnabled, '
+      'backendLoggingEnabled: $backendLoggingEnabled, '
+      'backendEndpoint: $backendEndpoint)';
 }

--- a/lib/core/logging/loggers.dart
+++ b/lib/core/logging/loggers.dart
@@ -43,4 +43,7 @@ abstract final class Loggers {
 
   /// General UI events.
   static final ui = LogManager.instance.getLogger('UI');
+
+  /// Telemetry and backend log shipping events.
+  static final telemetry = LogManager.instance.getLogger('Telemetry');
 }

--- a/lib/core/logging/logging_provider.dart
+++ b/lib/core/logging/logging_provider.dart
@@ -1,8 +1,20 @@
+import 'dart:async';
+import 'dart:developer' as developer;
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:soliplex_frontend/core/auth/auth_provider.dart';
 import 'package:soliplex_frontend/core/logging/log_config.dart';
+import 'package:soliplex_frontend/core/logging/loggers.dart';
+import 'package:soliplex_frontend/core/providers/api_provider.dart';
+import 'package:soliplex_frontend/core/providers/config_provider.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
+import 'package:uuid/uuid.dart';
 
 /// SharedPreferences key for minimum log level.
 const _kLogLevelKey = 'log_level';
@@ -12,6 +24,15 @@ const _kConsoleLoggingKey = 'console_logging';
 
 /// SharedPreferences key for stdout logging enabled.
 const _kStdoutLoggingKey = 'stdout_logging';
+
+/// SharedPreferences key for backend logging enabled.
+const _kBackendLoggingKey = 'backend_logging';
+
+/// SharedPreferences key for backend endpoint.
+const _kBackendEndpointKey = 'backend_endpoint';
+
+/// SharedPreferences key for persistent install ID.
+const _kInstallIdKey = 'install_id';
 
 /// Notifier for managing log configuration.
 ///
@@ -31,6 +52,8 @@ class LogConfigNotifier extends Notifier<LogConfig> {
     final levelIndex = prefs.getInt(_kLogLevelKey);
     final consoleEnabled = prefs.getBool(_kConsoleLoggingKey);
     final stdoutEnabled = prefs.getBool(_kStdoutLoggingKey);
+    final backendEnabled = prefs.getBool(_kBackendLoggingKey);
+    final backendEndpoint = prefs.getString(_kBackendEndpointKey);
 
     return LogConfig(
       minimumLevel: levelIndex != null && levelIndex < LogLevel.values.length
@@ -40,6 +63,10 @@ class LogConfigNotifier extends Notifier<LogConfig> {
           consoleEnabled ?? LogConfig.defaultConfig.consoleLoggingEnabled,
       stdoutLoggingEnabled:
           stdoutEnabled ?? LogConfig.defaultConfig.stdoutLoggingEnabled,
+      backendLoggingEnabled:
+          backendEnabled ?? LogConfig.defaultConfig.backendLoggingEnabled,
+      backendEndpoint:
+          backendEndpoint ?? LogConfig.defaultConfig.backendEndpoint,
     );
   }
 
@@ -59,6 +86,18 @@ class LogConfigNotifier extends Notifier<LogConfig> {
   Future<void> setStdoutLoggingEnabled({required bool enabled}) async {
     await _prefs.setBool(_kStdoutLoggingKey, enabled);
     state = state.copyWith(stdoutLoggingEnabled: enabled);
+  }
+
+  /// Updates whether backend log shipping is enabled.
+  Future<void> setBackendLoggingEnabled({required bool enabled}) async {
+    await _prefs.setBool(_kBackendLoggingKey, enabled);
+    state = state.copyWith(backendLoggingEnabled: enabled);
+  }
+
+  /// Updates the backend endpoint for log ingestion.
+  Future<void> setBackendEndpoint(String endpoint) async {
+    await _prefs.setString(_kBackendEndpointKey, endpoint);
+    state = state.copyWith(backendEndpoint: endpoint);
   }
 }
 
@@ -152,6 +191,150 @@ final stdoutSinkProvider = Provider<StdoutSink?>((ref) {
 });
 
 // ============================================================================
+// Backend Telemetry Providers
+// ============================================================================
+
+/// Persistent install ID (UUID v4), generated once and stored in prefs.
+final installIdProvider = Provider<String>((ref) {
+  ref.keepAlive();
+  final prefs = ref.read(preloadedPrefsProvider);
+  var id = prefs.getString(_kInstallIdKey);
+  if (id == null) {
+    id = const Uuid().v4();
+    prefs.setString(_kInstallIdKey, id);
+  }
+  return id;
+});
+
+/// Session ID (UUID v4), generated once per provider container lifetime.
+final sessionIdProvider = Provider<String>((ref) {
+  ref.keepAlive();
+  return const Uuid().v4();
+});
+
+/// Current network connectivity state.
+///
+/// Emits a `network_changed` log when connectivity changes.
+final connectivityProvider =
+    StreamProvider<List<ConnectivityResult>>((ref) async* {
+  ref.keepAlive();
+  final connectivity = Connectivity();
+
+  // Emit current state first.
+  yield await connectivity.checkConnectivity();
+
+  // Then listen for changes.
+  await for (final results in connectivity.onConnectivityChanged) {
+    Loggers.telemetry.info(
+      'network_changed',
+      attributes: {'connectivity': results.map((r) => r.name).join(', ')},
+    );
+    yield results;
+  }
+});
+
+/// Resource attributes gathered from device and package info.
+///
+/// Resolved once asynchronously; cached for the lifetime of the container.
+final resourceAttributesProvider =
+    FutureProvider<Map<String, Object>>((ref) async {
+  ref.keepAlive();
+
+  final packageInfo = await PackageInfo.fromPlatform();
+  final attributes = <String, Object>{
+    'app.version': packageInfo.version,
+    'app.build': packageInfo.buildNumber,
+    'app.package': packageInfo.packageName,
+  };
+
+  if (!kIsWeb) {
+    final deviceInfo = DeviceInfoPlugin();
+    final base = await deviceInfo.deviceInfo;
+    final data = base.data;
+    // Extract common fields safely.
+    final model = data['model'];
+    if (model is String) attributes['device.model'] = model;
+    final systemVersion = data['systemVersion'] ?? data['version'];
+    if (systemVersion is String) {
+      attributes['os.version'] = systemVersion;
+    } else if (systemVersion is Map) {
+      final release = systemVersion['release'];
+      if (release is String) attributes['os.version'] = release;
+    }
+  }
+
+  attributes['os.type'] = defaultTargetPlatform.name;
+
+  return attributes;
+});
+
+/// Holds the [BackendLogSink] instance when backend logging is enabled.
+///
+/// Created lazily when first accessed. The controller manages registration
+/// with LogManager based on config.backendLoggingEnabled.
+final backendLogSinkProvider = FutureProvider<BackendLogSink?>((ref) async {
+  ref.keepAlive();
+
+  final config = ref.read(logConfigProvider);
+  if (!config.backendLoggingEnabled) return null;
+
+  final appConfig = ref.read(configProvider);
+  final client = ref.read(httpClientProvider);
+  final installId = ref.read(installIdProvider);
+  final sessionId = ref.read(sessionIdProvider);
+  final endpoint = '${appConfig.baseUrl}${config.backendEndpoint}';
+
+  // Resolve async dependencies.
+  final resourceAttrs =
+      await ref.read(resourceAttributesProvider.future).catchError(
+            (_) => <String, Object>{},
+          );
+
+  // Build disk queue directory (web gets in-memory fallback).
+  late final DiskQueue diskQueue;
+  if (kIsWeb) {
+    diskQueue = DiskQueue(directoryPath: '');
+  } else {
+    final appDir = await getApplicationSupportDirectory();
+    diskQueue = DiskQueue(directoryPath: '${appDir.path}/log_queue');
+  }
+
+  final sink = BackendLogSink(
+    endpoint: endpoint,
+    client: client,
+    installId: installId,
+    sessionId: sessionId,
+    diskQueue: diskQueue,
+    resourceAttributes: resourceAttrs,
+    jwtProvider: () => ref.read(accessTokenProvider),
+    networkChecker: () {
+      final connectivity = ref.read(connectivityProvider);
+      return connectivity.maybeWhen(
+        data: (results) => !results.contains(ConnectivityResult.none),
+        orElse: () => true,
+      );
+    },
+    onError: (message, error) {
+      developer.log(
+        'BackendLogSink: $message',
+        error: error,
+        name: 'Telemetry',
+      );
+    },
+  );
+
+  LogManager.instance.addSink(sink);
+
+  ref.onDispose(() {
+    LogManager.instance.removeSink(sink);
+    unawaited(sink.close());
+    unawaited(diskQueue.close());
+  });
+
+  return sink;
+});
+
+// ============================================================================
 // Log Config Controller
 // ============================================================================
 // This provider manages the side effects of applying config to the logging
@@ -163,6 +346,8 @@ final stdoutSinkProvider = Provider<StdoutSink?>((ref) {
 /// This provider:
 /// - Sets the global minimum log level on LogManager
 /// - Enables/disables sinks based on config
+/// - Wires `LogSanitizer` into `LogManager.instance.sanitizer`
+/// - Creates/destroys `BackendLogSink` based on config
 /// - Uses ref.listen to react to config changes without rebuilding sinks
 ///
 /// Watch this provider in your app root to initialize logging.
@@ -176,20 +361,35 @@ final logConfigControllerProvider = Provider<void>((ref) {
   final consoleSink = ref.watch(consoleSinkProvider);
   final stdoutSink = ref.watch(stdoutSinkProvider);
 
+  // Wire sanitizer into LogManager.
+  LogManager.instance.sanitizer ??= LogSanitizer();
+
   // Apply config immediately and listen for changes.
-  void applyConfig(LogConfig config) {
+  void applyConfig(LogConfig? previous, LogConfig config) {
     // Apply minimum level to LogManager (centralized ownership).
     LogManager.instance.minimumLevel = config.minimumLevel;
 
     // Enable/disable sinks based on config.
     consoleSink.enabled = config.consoleLoggingEnabled;
     stdoutSink?.enabled = config.stdoutLoggingEnabled;
+
+    // Handle backend sink lifecycle on toggle change.
+    final backendChanged = previous == null ||
+        previous.backendLoggingEnabled != config.backendLoggingEnabled;
+    if (backendChanged) {
+      // Invalidate to dispose any existing sink (onDispose removes from
+      // LogManager and closes it). Then re-read to trigger creation if
+      // the new config has backend logging enabled.
+      ref
+        ..invalidate(backendLogSinkProvider)
+        ..read(backendLogSinkProvider);
+    }
   }
 
   // Listen to config changes.
   ref.listen(
     logConfigProvider,
-    (previous, next) => applyConfig(next),
+    applyConfig,
     fireImmediately: true,
   );
 });

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -18,6 +18,7 @@ import 'package:soliplex_frontend/features/room/room_screen.dart';
 import 'package:soliplex_frontend/features/rooms/rooms_screen.dart';
 import 'package:soliplex_frontend/features/settings/backend_versions_screen.dart';
 import 'package:soliplex_frontend/features/settings/settings_screen.dart';
+import 'package:soliplex_frontend/features/settings/telemetry_screen.dart';
 import 'package:soliplex_frontend/shared/widgets/app_shell.dart';
 import 'package:soliplex_frontend/shared/widgets/shell_config.dart';
 
@@ -336,6 +337,14 @@ final routerProvider = Provider<GoRouter>((ref) {
               name: 'log-viewer',
               pageBuilder: (context, state) => const NoTransitionPage(
                 child: LogViewerScreen(),
+              ),
+            ),
+            GoRoute(
+              path: 'telemetry',
+              name: 'telemetry',
+              pageBuilder: (context, state) => _staticPage(
+                title: const Text('Telemetry'),
+                body: const TelemetryScreen(),
               ),
             ),
           ],

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -90,6 +90,7 @@ class SettingsScreen extends ConsumerWidget {
         const Divider(),
         const _NetworkRequestsTile(),
         const _LogViewerTile(),
+        const _TelemetryTile(),
         const Divider(),
         _AuthSection(authState: authState),
       ],
@@ -135,6 +136,23 @@ class _LogViewerTile extends ConsumerWidget {
           onTap: () => context.push('/settings/logs'),
         );
       },
+    );
+  }
+}
+
+class _TelemetryTile extends ConsumerWidget {
+  const _TelemetryTile();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final config = ref.watch(logConfigProvider);
+
+    return ListTile(
+      leading: const Icon(Icons.cloud_upload_outlined),
+      title: const Text('Telemetry'),
+      subtitle: Text(config.backendLoggingEnabled ? 'Enabled' : 'Disabled'),
+      trailing: const Icon(Icons.chevron_right),
+      onTap: () => context.push('/settings/telemetry'),
     );
   }
 }

--- a/lib/features/settings/telemetry_screen.dart
+++ b/lib/features/settings/telemetry_screen.dart
@@ -1,0 +1,121 @@
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:soliplex_frontend/core/logging/logging_provider.dart';
+
+/// Telemetry settings screen for enabling/disabling backend log shipping.
+class TelemetryScreen extends ConsumerWidget {
+  const TelemetryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final config = ref.watch(logConfigProvider);
+    final connectivity = ref.watch(connectivityProvider);
+
+    return ListView(
+      children: [
+        SwitchListTile(
+          secondary: const Icon(Icons.cloud_upload_outlined),
+          title: const Text('Backend Logging'),
+          subtitle: const Text('Ship logs to the backend for analysis'),
+          value: config.backendLoggingEnabled,
+          onChanged: (value) => ref
+              .read(logConfigProvider.notifier)
+              .setBackendLoggingEnabled(enabled: value),
+        ),
+        const Divider(),
+        ListTile(
+          leading: const Icon(Icons.link),
+          title: const Text('Endpoint'),
+          subtitle: SelectableText(config.backendEndpoint),
+          trailing: kReleaseMode
+              ? null
+              : IconButton(
+                  icon: const Icon(Icons.edit),
+                  onPressed: () =>
+                      _showEndpointDialog(context, ref, config.backendEndpoint),
+                ),
+        ),
+        ListTile(
+          leading: Icon(
+            _connectivityIcon(connectivity),
+            color: _connectivityColor(context, connectivity),
+          ),
+          title: const Text('Connection Status'),
+          subtitle: Text(_connectivityLabel(connectivity)),
+        ),
+      ],
+    );
+  }
+
+  IconData _connectivityIcon(AsyncValue<List<ConnectivityResult>> state) {
+    return state.when(
+      data: (results) => results.contains(ConnectivityResult.none)
+          ? Icons.cloud_off
+          : Icons.cloud_done,
+      loading: () => Icons.cloud_queue,
+      error: (_, __) => Icons.cloud_off,
+    );
+  }
+
+  Color _connectivityColor(
+    BuildContext context,
+    AsyncValue<List<ConnectivityResult>> state,
+  ) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return state.when(
+      data: (results) => results.contains(ConnectivityResult.none)
+          ? colorScheme.error
+          : colorScheme.primary,
+      loading: () => colorScheme.outline,
+      error: (_, __) => colorScheme.error,
+    );
+  }
+
+  String _connectivityLabel(AsyncValue<List<ConnectivityResult>> state) {
+    return state.when(
+      data: (results) {
+        if (results.contains(ConnectivityResult.none)) return 'No connection';
+        return results.map((r) => r.name).join(', ');
+      },
+      loading: () => 'Checking...',
+      error: (_, __) => 'Unknown',
+    );
+  }
+
+  Future<void> _showEndpointDialog(
+    BuildContext context,
+    WidgetRef ref,
+    String currentEndpoint,
+  ) async {
+    final controller = TextEditingController(text: currentEndpoint);
+    final result = await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Backend Endpoint'),
+        content: TextField(
+          controller: controller,
+          decoration: const InputDecoration(
+            labelText: 'Endpoint path',
+            hintText: '/api/v1/logs',
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(controller.text),
+            child: const Text('Save'),
+          ),
+        ],
+      ),
+    );
+
+    if (result != null && result.isNotEmpty && context.mounted) {
+      await ref.read(logConfigProvider.notifier).setBackendEndpoint(result);
+    }
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -122,6 +122,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  connectivity_plus:
+    dependency: "direct main"
+    description:
+      name: connectivity_plus
+      sha256: b5e72753cf63becce2c61fd04dfe0f1c430cc5278b53a1342dc5ad839eab29ec
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.5"
+  connectivity_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: connectivity_plus_platform_interface
+      sha256: "42657c1715d48b167930d5f34d00222ac100475f73d10162ddf43e714932f204"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   convert:
     dependency: transitive
     description:
@@ -178,6 +194,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.11"
+  device_info_plus:
+    dependency: "direct main"
+    description:
+      name: device_info_plus
+      sha256: "98f28b42168cc509abc92f88518882fd58061ea372d7999aecc424345c7bff6a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.5.0"
+  device_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: device_info_plus_platform_interface
+      sha256: e1ea89119e34903dca74b883d0dd78eb762814f97fb6c76f35e9ff74d261a18f
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.3"
   fake_async:
     dependency: transitive
     description:
@@ -202,6 +234,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -529,6 +569,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.17.2"
+  nm:
+    dependency: transitive
+    description:
+      name: nm
+      sha256: "2c9aae4127bdc8993206464fcc063611e0e36e72018696cd9631023a31b24254"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   node_preamble:
     dependency: transitive
     description:
@@ -554,7 +602,7 @@ packages:
     source: hosted
     version: "2.2.0"
   package_info_plus:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: package_info_plus
       sha256: f69da0d3189a4b4ceaeb1a3defb0f329b3b352517f52bed4290f83d4f06bc08d
@@ -578,7 +626,7 @@ packages:
     source: hosted
     version: "1.9.1"
   path_provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider
       sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
@@ -899,6 +947,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
+  uuid:
+    dependency: "direct main"
+    description:
+      name: uuid
+      sha256: a11b666489b1954e01d992f3d601b1804a33937b5a8fe677bd26b8a9f96f96e8
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.2"
   vector_math:
     dependency: transitive
     description:
@@ -987,6 +1043,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.15.0"
+  win32_registry:
+    dependency: transitive
+    description:
+      name: win32_registry
+      sha256: "6f1b564492d0147b330dd794fee8f512cec4977957f310f9951b5f9d83618dae"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,9 @@ environment:
   flutter: '>=3.35.0'
 
 dependencies:
+  connectivity_plus: ^6.1.4
   cupertino_icons: ^1.0.8
+  device_info_plus: ^11.3.3
   flutter:
     sdk: flutter
 
@@ -24,6 +26,8 @@ dependencies:
   intl: ^0.20.1
   markdown: ^7.0.0
   meta: ^1.15.0
+  package_info_plus: ^9.0.0
+  path_provider: ^2.1.5
   shared_preferences: ^2.5.4
   soliplex_client:
     path: packages/soliplex_client
@@ -31,6 +35,7 @@ dependencies:
     path: packages/soliplex_client_native
   soliplex_logging:
     path: packages/soliplex_logging
+  uuid: ^4.5.1
   wakelock_plus: ^1.4.0
   web: ^1.1.1
 

--- a/test/core/logging/log_config_test.dart
+++ b/test/core/logging/log_config_test.dart
@@ -8,6 +8,8 @@ void main() {
       expect(LogConfig.defaultConfig.minimumLevel, LogLevel.debug);
       expect(LogConfig.defaultConfig.consoleLoggingEnabled, isTrue);
       expect(LogConfig.defaultConfig.stdoutLoggingEnabled, isTrue);
+      expect(LogConfig.defaultConfig.backendLoggingEnabled, isFalse);
+      expect(LogConfig.defaultConfig.backendEndpoint, '/api/v1/logs');
     });
 
     test('creates with specified values', () {
@@ -80,6 +82,25 @@ void main() {
         expect(copied.consoleLoggingEnabled, isFalse);
         expect(copied.stdoutLoggingEnabled, isFalse);
       });
+
+      test('copies backendLoggingEnabled only', () {
+        const original = LogConfig.defaultConfig;
+
+        final copied = original.copyWith(backendLoggingEnabled: true);
+
+        expect(copied.backendLoggingEnabled, isTrue);
+        expect(copied.backendEndpoint, '/api/v1/logs');
+        expect(copied.minimumLevel, LogLevel.debug);
+      });
+
+      test('copies backendEndpoint only', () {
+        const original = LogConfig.defaultConfig;
+
+        final copied = original.copyWith(backendEndpoint: '/custom');
+
+        expect(copied.backendEndpoint, '/custom');
+        expect(copied.backendLoggingEnabled, isFalse);
+      });
     });
 
     group('equality', () {
@@ -123,6 +144,30 @@ void main() {
 
         expect(config1, isNot(equals(config2)));
       });
+
+      test('different backendLoggingEnabled are not equal', () {
+        const config1 = LogConfig.defaultConfig;
+        const config2 = LogConfig(
+          minimumLevel: LogLevel.debug,
+          consoleLoggingEnabled: true,
+          stdoutLoggingEnabled: true,
+          backendLoggingEnabled: true,
+        );
+
+        expect(config1, isNot(equals(config2)));
+      });
+
+      test('different backendEndpoint are not equal', () {
+        const config1 = LogConfig.defaultConfig;
+        const config2 = LogConfig(
+          minimumLevel: LogLevel.debug,
+          consoleLoggingEnabled: true,
+          stdoutLoggingEnabled: true,
+          backendEndpoint: '/custom',
+        );
+
+        expect(config1, isNot(equals(config2)));
+      });
     });
 
     test('toString returns expected format', () {
@@ -136,7 +181,9 @@ void main() {
         config.toString(),
         'LogConfig(minimumLevel: LogLevel.warning, '
         'consoleLoggingEnabled: false, '
-        'stdoutLoggingEnabled: true)',
+        'stdoutLoggingEnabled: true, '
+        'backendLoggingEnabled: false, '
+        'backendEndpoint: /api/v1/logs)',
       );
     });
   });

--- a/test/features/settings/telemetry_screen_test.dart
+++ b/test/features/settings/telemetry_screen_test.dart
@@ -1,0 +1,134 @@
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:soliplex_frontend/core/logging/log_config.dart';
+import 'package:soliplex_frontend/core/logging/logging_provider.dart';
+import 'package:soliplex_frontend/features/settings/telemetry_screen.dart';
+
+import '../../helpers/test_helpers.dart';
+
+void main() {
+  late SharedPreferences prefs;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+  });
+
+  Widget buildScreen({
+    LogConfig? config,
+    AsyncValue<List<ConnectivityResult>>? connectivity,
+  }) {
+    final effectiveConfig = config ?? LogConfig.defaultConfig;
+    return createTestApp(
+      home: const TelemetryScreen(),
+      overrides: [
+        preloadedPrefsProvider.overrideWithValue(prefs),
+        logConfigProvider.overrideWith(() {
+          return _MockLogConfigNotifier(effectiveConfig);
+        }),
+        connectivityProvider.overrideWithValue(
+          connectivity ?? const AsyncValue.data([ConnectivityResult.wifi]),
+        ),
+      ],
+    );
+  }
+
+  group('TelemetryScreen', () {
+    testWidgets('shows toggle in off state by default', (tester) async {
+      await tester.pumpWidget(buildScreen());
+
+      final switchFinder = find.byType(SwitchListTile);
+      expect(switchFinder, findsOneWidget);
+
+      final switchTile = tester.widget<SwitchListTile>(switchFinder);
+      expect(switchTile.value, isFalse);
+      expect(find.text('Backend Logging'), findsOneWidget);
+    });
+
+    testWidgets('shows toggle in on state when enabled', (tester) async {
+      await tester.pumpWidget(
+        buildScreen(
+          config: LogConfig.defaultConfig.copyWith(
+            backendLoggingEnabled: true,
+          ),
+        ),
+      );
+
+      final switchTile = tester.widget<SwitchListTile>(
+        find.byType(SwitchListTile),
+      );
+      expect(switchTile.value, isTrue);
+    });
+
+    testWidgets('displays endpoint path', (tester) async {
+      await tester.pumpWidget(buildScreen());
+
+      expect(find.text('/api/v1/logs'), findsOneWidget);
+      expect(find.text('Endpoint'), findsOneWidget);
+    });
+
+    testWidgets('displays custom endpoint', (tester) async {
+      await tester.pumpWidget(
+        buildScreen(
+          config: LogConfig.defaultConfig.copyWith(
+            backendEndpoint: '/custom/endpoint',
+          ),
+        ),
+      );
+
+      expect(find.text('/custom/endpoint'), findsOneWidget);
+    });
+
+    testWidgets('shows connected status for wifi', (tester) async {
+      await tester.pumpWidget(buildScreen());
+
+      expect(find.text('Connection Status'), findsOneWidget);
+      expect(find.text('wifi'), findsOneWidget);
+    });
+
+    testWidgets('shows no connection status', (tester) async {
+      await tester.pumpWidget(
+        buildScreen(
+          connectivity: const AsyncValue.data([ConnectivityResult.none]),
+        ),
+      );
+
+      expect(find.text('No connection'), findsOneWidget);
+    });
+
+    testWidgets('shows loading connectivity status', (tester) async {
+      await tester.pumpWidget(
+        buildScreen(
+          connectivity: const AsyncValue.loading(),
+        ),
+      );
+
+      expect(find.text('Checking...'), findsOneWidget);
+    });
+
+    testWidgets('shows error connectivity status', (tester) async {
+      await tester.pumpWidget(
+        buildScreen(
+          connectivity: AsyncValue.error(
+            Exception('fail'),
+            StackTrace.current,
+          ),
+        ),
+      );
+
+      expect(find.text('Unknown'), findsOneWidget);
+    });
+  });
+}
+
+class _MockLogConfigNotifier extends LogConfigNotifier {
+  _MockLogConfigNotifier(this._config);
+
+  final LogConfig _config;
+
+  @override
+  LogConfig build() => _config;
+}

--- a/test/integration/backend_toggle_flow_test.dart
+++ b/test/integration/backend_toggle_flow_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:soliplex_frontend/core/logging/logging_provider.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+void main() {
+  late SharedPreferences prefs;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    LogManager.instance.reset();
+  });
+
+  tearDown(LogManager.instance.reset);
+
+  ProviderContainer createContainer() {
+    return ProviderContainer(
+      overrides: [
+        preloadedPrefsProvider.overrideWithValue(prefs),
+      ],
+    );
+  }
+
+  group('backend toggle flow', () {
+    test('toggling off keeps backend sink null', () async {
+      final container = createContainer();
+      addTearDown(container.dispose);
+
+      // Initialize the controller.
+      container.read(logConfigControllerProvider);
+
+      // Backend is off by default.
+      await container.read(backendLogSinkProvider.future);
+      final sink = container.read(backendLogSinkProvider).value;
+      expect(sink, isNull);
+
+      // Explicitly disable — should remain null.
+      await container
+          .read(logConfigProvider.notifier)
+          .setBackendLoggingEnabled(enabled: false);
+      await container.read(backendLogSinkProvider.future);
+      final sinkAfter = container.read(backendLogSinkProvider).value;
+      expect(sinkAfter, isNull);
+    });
+
+    test('config persists across notifier rebuilds', () async {
+      final container = createContainer();
+      addTearDown(container.dispose);
+
+      // Enable backend logging.
+      await container
+          .read(logConfigProvider.notifier)
+          .setBackendLoggingEnabled(enabled: true);
+
+      // Verify persistence.
+      expect(prefs.getBool('backend_logging'), isTrue);
+
+      // Simulate rebuild by reading config again — should still be enabled.
+      final config = container.read(logConfigProvider);
+      expect(config.backendLoggingEnabled, isTrue);
+
+      // Disable.
+      await container
+          .read(logConfigProvider.notifier)
+          .setBackendLoggingEnabled(enabled: false);
+      expect(prefs.getBool('backend_logging'), isFalse);
+
+      final configAfter = container.read(logConfigProvider);
+      expect(configAfter.backendLoggingEnabled, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Wires `BackendLogSink` into the Flutter app via Riverpod providers
- Adds telemetry settings screen with backend logging toggle, endpoint editor, and connectivity status
- `logConfigControllerProvider` manages sink lifecycle based on config changes

## Changes
- **`lib/core/logging/logging_provider.dart`**: `backendLogSinkProvider`, `resourceAttributesProvider`, `installIdProvider`, `sessionIdProvider`, `connectivityProvider`, `logConfigControllerProvider`
- **`lib/features/settings/telemetry_screen.dart`**: Backend logging toggle, endpoint editor dialog, connectivity indicator

## Test plan
- [x] `dart format` — clean
- [x] `dart analyze` — 0 issues
- [x] Provider unit tests pass
- [x] Manual: toggle backend logging on/off, verify DiskQueue writes