### PR TITLE
feat(logging): add breadcrumb attachment to BackendLogSink (4/5)

### DIFF
--- a/lib/core/logging/backend_logging_provider.dart
+++ b/lib/core/logging/backend_logging_provider.dart
@@ -106,12 +106,15 @@ final backendLogSinkProvider = FutureProvider<BackendLogSink?>((ref) async {
     diskQueue = DiskQueue(directoryPath: '${appDir.path}/log_queue');
   }
 
+  final memorySink = ref.read(memorySinkProvider);
+
   final sink = BackendLogSink(
     endpoint: endpoint,
     client: client,
     installId: installId,
     sessionId: sessionId,
     diskQueue: diskQueue,
+    memorySink: memorySink,
     resourceAttributes: resourceAttrs,
     jwtProvider: () {
       final authState = ref.read(authProvider);

--- a/packages/soliplex_logging/lib/src/sinks/backend_log_sink.dart
+++ b/packages/soliplex_logging/lib/src/sinks/backend_log_sink.dart
@@ -9,6 +9,7 @@ import 'package:soliplex_logging/src/log_level.dart';
 import 'package:soliplex_logging/src/log_record.dart';
 import 'package:soliplex_logging/src/log_sink.dart';
 import 'package:soliplex_logging/src/sinks/disk_queue.dart';
+import 'package:soliplex_logging/src/sinks/memory_sink.dart';
 
 /// Maximum record size in bytes before truncation (64 KB).
 const int _maxRecordBytes = 64 * 1024;
@@ -34,6 +35,8 @@ class BackendLogSink implements LogSink {
     required this.sessionId,
     required DiskQueue diskQueue,
     this.userId,
+    this.memorySink,
+    this.maxBreadcrumbs = 20,
     Map<String, Object> resourceAttributes = const {},
     this.maxBatchBytes = _defaultMaxBatchBytes,
     this.batchSize = 100,
@@ -58,6 +61,12 @@ class BackendLogSink implements LogSink {
 
   /// Current user ID (null before auth).
   String? userId;
+
+  /// Optional memory sink for breadcrumb retrieval on error/fatal.
+  final MemorySink? memorySink;
+
+  /// Maximum number of breadcrumb records to attach on error/fatal.
+  final int maxBreadcrumbs;
 
   /// Resource attributes for the payload envelope.
   final Map<String, Object> resourceAttributes;
@@ -105,6 +114,11 @@ class BackendLogSink implements LogSink {
     if (_closed) return;
 
     final json = _recordToJson(record);
+
+    if (record.level >= LogLevel.error && memorySink != null) {
+      json['breadcrumbs'] = _collectBreadcrumbs();
+    }
+
     final truncated = _truncateRecord(json);
 
     if (record.level == LogLevel.fatal) {
@@ -412,6 +426,28 @@ class BackendLogSink implements LogSink {
     return '${utf8.decode(encoded.sublist(0, end))}…[truncated]';
   }
 
+  /// Reads the last [maxBreadcrumbs] records from [memorySink].
+  List<Map<String, Object?>> _collectBreadcrumbs() {
+    if (maxBreadcrumbs <= 0) return [];
+    final records = memorySink!.records;
+    final start =
+        records.length > maxBreadcrumbs ? records.length - maxBreadcrumbs : 0;
+    return [
+      for (var i = start; i < records.length; i++)
+        _breadcrumbFromRecord(records[i]),
+    ];
+  }
+
+  Map<String, Object?> _breadcrumbFromRecord(LogRecord record) {
+    return {
+      'timestamp': record.timestamp.toUtc().toIso8601String(),
+      'level': record.level.name,
+      'logger': record.loggerName,
+      'message': record.message,
+      'category': deriveBreadcrumbCategory(record),
+    };
+  }
+
   /// Caps records by byte size.
   ///
   /// Returns a tuple of (batch to send, total records to confirm).
@@ -456,4 +492,38 @@ class BackendLogSink implements LogSink {
     }
     return (result, scanned);
   }
+}
+
+/// Logger name prefixes that map to breadcrumb categories.
+const _loggerCategoryPrefixes = {
+  'Router': 'ui',
+  'Navigation': 'ui',
+  'UI': 'ui',
+  'Http': 'network',
+  'Network': 'network',
+  'Connectivity': 'network',
+  'Lifecycle': 'system',
+  'Permission': 'system',
+  'Auth': 'user',
+  'Login': 'user',
+  'User': 'user',
+};
+
+/// Derives a breadcrumb category from a [LogRecord].
+///
+/// If the record has an explicit `breadcrumb_category` attribute, that
+/// value is used. Otherwise, the category is inferred from the
+/// [LogRecord.loggerName] prefix (e.g. `Router.Home` -> `ui`).
+/// Falls back to `system` if no match is found.
+String deriveBreadcrumbCategory(LogRecord record) {
+  final explicit = record.attributes['breadcrumb_category'];
+  if (explicit is String) return explicit;
+
+  final name = record.loggerName;
+  for (final entry in _loggerCategoryPrefixes.entries) {
+    if (name == entry.key || name.startsWith('${entry.key}.')) {
+      return entry.value;
+    }
+  }
+  return 'system';
 }

--- a/packages/soliplex_logging/test/sinks/backend_log_sink_breadcrumb_test.dart
+++ b/packages/soliplex_logging/test/sinks/backend_log_sink_breadcrumb_test.dart
@@ -1,0 +1,259 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart' as http_testing;
+import 'package:soliplex_logging/soliplex_logging.dart';
+import 'package:soliplex_logging/src/sinks/disk_queue_io.dart';
+import 'package:test/test.dart';
+
+LogRecord makeRecord({
+  LogLevel level = LogLevel.info,
+  String message = 'Test message',
+  String loggerName = 'Test',
+  Map<String, Object> attributes = const {},
+}) {
+  return LogRecord(
+    level: level,
+    message: message,
+    timestamp: DateTime.utc(2026, 2, 6, 12),
+    loggerName: loggerName,
+    attributes: attributes,
+  );
+}
+
+void main() {
+  late Directory tempDir;
+  late PlatformDiskQueue diskQueue;
+  late List<http.Request> capturedRequests;
+  late http.Client mockClient;
+  late MemorySink memorySink;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('breadcrumb_test_');
+    diskQueue = PlatformDiskQueue(directoryPath: tempDir.path);
+    capturedRequests = [];
+    memorySink = MemorySink();
+
+    mockClient = http_testing.MockClient((request) async {
+      capturedRequests.add(request);
+      return http.Response('', 200);
+    });
+  });
+
+  tearDown(() async {
+    await diskQueue.close();
+    await memorySink.close();
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  BackendLogSink createSink({
+    bool withMemorySink = true,
+    int maxBreadcrumbs = 20,
+  }) {
+    return BackendLogSink(
+      endpoint: 'https://api.example.com/logs',
+      client: mockClient,
+      installId: 'install-001',
+      sessionId: 'session-001',
+      diskQueue: diskQueue,
+      memorySink: withMemorySink ? memorySink : null,
+      maxBreadcrumbs: maxBreadcrumbs,
+      flushInterval: const Duration(hours: 1),
+    );
+  }
+
+  group('breadcrumbs', () {
+    test('error records include breadcrumbs from memorySink', () async {
+      // Write some info records to memorySink.
+      for (var i = 0; i < 5; i++) {
+        memorySink.write(makeRecord(message: 'breadcrumb $i'));
+      }
+
+      final sink = createSink()
+        ..write(makeRecord(level: LogLevel.error, message: 'crash'));
+      // Error-level write triggers flush(force: true) internally.
+      // Wait for that to complete, then close.
+      await sink.close();
+
+      expect(capturedRequests, isNotEmpty);
+      final body =
+          jsonDecode(capturedRequests.first.body) as Map<String, Object?>;
+      final logs = body['logs']! as List<Object?>;
+      final record = logs.first! as Map<String, Object?>;
+
+      expect(record['breadcrumbs'], isA<List<Object?>>());
+      final breadcrumbs = record['breadcrumbs']! as List<Object?>;
+      expect(breadcrumbs, hasLength(5));
+
+      final first = breadcrumbs.first! as Map<String, Object?>;
+      expect(first['message'], 'breadcrumb 0');
+      expect(first['level'], 'info');
+      expect(first['category'], isA<String>());
+    });
+
+    test('info records do not include breadcrumbs', () async {
+      memorySink.write(makeRecord(message: 'breadcrumb'));
+
+      final sink = createSink()..write(makeRecord(message: 'normal'));
+      await sink.flush();
+      await sink.close();
+
+      expect(capturedRequests, hasLength(1));
+      final body =
+          jsonDecode(capturedRequests.first.body) as Map<String, Object?>;
+      final logs = body['logs']! as List<Object?>;
+      final record = logs.first! as Map<String, Object?>;
+
+      expect(record.containsKey('breadcrumbs'), isFalse);
+    });
+
+    test('breadcrumbs capped at 20 records', () async {
+      for (var i = 0; i < 30; i++) {
+        memorySink.write(makeRecord(message: 'crumb $i'));
+      }
+
+      final sink = createSink()
+        ..write(makeRecord(level: LogLevel.error, message: 'crash'));
+      await sink.flush();
+      await sink.close();
+
+      final body =
+          jsonDecode(capturedRequests.first.body) as Map<String, Object?>;
+      final logs = body['logs']! as List<Object?>;
+      final record = logs.first! as Map<String, Object?>;
+      final breadcrumbs = record['breadcrumbs']! as List<Object?>;
+
+      expect(breadcrumbs, hasLength(20));
+      // First breadcrumb should be crumb 10 (30 - 20).
+      final first = breadcrumbs.first! as Map<String, Object?>;
+      expect(first['message'], 'crumb 10');
+    });
+
+    test('no breadcrumbs when memorySink is null', () async {
+      final sink = createSink(withMemorySink: false)
+        ..write(makeRecord(level: LogLevel.error, message: 'crash'));
+      await sink.flush();
+      await sink.close();
+
+      final body =
+          jsonDecode(capturedRequests.first.body) as Map<String, Object?>;
+      final logs = body['logs']! as List<Object?>;
+      final record = logs.first! as Map<String, Object?>;
+
+      expect(record.containsKey('breadcrumbs'), isFalse);
+    });
+
+    test('fatal records include breadcrumbs', () async {
+      memorySink.write(makeRecord(message: 'context'));
+
+      final sink = createSink()
+        ..write(makeRecord(level: LogLevel.fatal, message: 'fatal crash'));
+      await sink.flush();
+      await sink.close();
+
+      final body =
+          jsonDecode(capturedRequests.first.body) as Map<String, Object?>;
+      final logs = body['logs']! as List<Object?>;
+      final record = logs.first! as Map<String, Object?>;
+
+      expect(record['breadcrumbs'], isA<List<Object?>>());
+    });
+
+    test('empty memorySink produces empty breadcrumbs list', () async {
+      final sink = createSink()
+        ..write(makeRecord(level: LogLevel.error, message: 'crash'));
+      await sink.close();
+
+      final body =
+          jsonDecode(capturedRequests.first.body) as Map<String, Object?>;
+      final logs = body['logs']! as List<Object?>;
+      final record = logs.first! as Map<String, Object?>;
+
+      expect(record['breadcrumbs'], isA<List<Object?>>());
+      expect(record['breadcrumbs']! as List<Object?>, isEmpty);
+    });
+
+    test('fewer than maxBreadcrumbs includes all available', () async {
+      for (var i = 0; i < 3; i++) {
+        memorySink.write(makeRecord(message: 'crumb $i'));
+      }
+
+      final sink = createSink()
+        ..write(makeRecord(level: LogLevel.error, message: 'crash'));
+      await sink.close();
+
+      final body =
+          jsonDecode(capturedRequests.first.body) as Map<String, Object?>;
+      final logs = body['logs']! as List<Object?>;
+      final record = logs.first! as Map<String, Object?>;
+      final breadcrumbs = record['breadcrumbs']! as List<Object?>;
+
+      expect(breadcrumbs, hasLength(3));
+      final first = breadcrumbs.first! as Map<String, Object?>;
+      expect(first['message'], 'crumb 0');
+    });
+
+    test('custom maxBreadcrumbs limits count', () async {
+      for (var i = 0; i < 10; i++) {
+        memorySink.write(makeRecord(message: 'crumb $i'));
+      }
+
+      final sink = createSink(maxBreadcrumbs: 5)
+        ..write(makeRecord(level: LogLevel.error, message: 'crash'));
+      await sink.close();
+
+      final body =
+          jsonDecode(capturedRequests.first.body) as Map<String, Object?>;
+      final logs = body['logs']! as List<Object?>;
+      final record = logs.first! as Map<String, Object?>;
+      final breadcrumbs = record['breadcrumbs']! as List<Object?>;
+
+      expect(breadcrumbs, hasLength(5));
+      // First breadcrumb should be crumb 5 (10 - 5).
+      final first = breadcrumbs.first! as Map<String, Object?>;
+      expect(first['message'], 'crumb 5');
+    });
+  });
+
+  group('deriveBreadcrumbCategory', () {
+    test('returns explicit category from attributes', () {
+      final record = makeRecord(
+        attributes: {'breadcrumb_category': 'custom'},
+      );
+      expect(deriveBreadcrumbCategory(record), 'custom');
+    });
+
+    test('maps Router logger to ui', () {
+      final record = makeRecord(loggerName: 'Router');
+      expect(deriveBreadcrumbCategory(record), 'ui');
+    });
+
+    test('maps Router.Home sub-logger to ui', () {
+      final record = makeRecord(loggerName: 'Router.Home');
+      expect(deriveBreadcrumbCategory(record), 'ui');
+    });
+
+    test('maps Http logger to network', () {
+      final record = makeRecord(loggerName: 'Http');
+      expect(deriveBreadcrumbCategory(record), 'network');
+    });
+
+    test('maps Auth logger to user', () {
+      final record = makeRecord(loggerName: 'Auth');
+      expect(deriveBreadcrumbCategory(record), 'user');
+    });
+
+    test('maps Lifecycle logger to system', () {
+      final record = makeRecord(loggerName: 'Lifecycle');
+      expect(deriveBreadcrumbCategory(record), 'system');
+    });
+
+    test('falls back to system for unknown logger', () {
+      final record = makeRecord(loggerName: 'SomeOther');
+      expect(deriveBreadcrumbCategory(record), 'system');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Attach breadcrumbs (last 20 MemorySink records) to error/fatal log records before shipping
- Add `deriveBreadcrumbCategory()` to classify breadcrumbs by logger name prefix (ui, network, system, user)
- Wire `memorySink` into `BackendLogSink` via `backendLogSinkProvider`

## Changes

- **BackendLogSink**: Add optional `memorySink` constructor param; on `write()` for error/fatal records, collect breadcrumbs from the ring buffer and attach to the JSON payload before truncation
- **`_collectBreadcrumbs()`**: Takes last 20 records from MemorySink, formats each as `{timestamp, level, logger, message, category}`
- **`deriveBreadcrumbCategory()`**: Public function — checks for explicit `breadcrumb_category` attribute, then falls back to logger-name prefix mapping (`Router`→ui, `Http`→network, `Auth`→user, `Lifecycle`→system, etc.)
- **logging_provider.dart**: Pass `memorySink: ref.read(memorySinkProvider)` to BackendLogSink constructor

## Test plan

- [x] 12 unit tests in `backend_log_sink_breadcrumb_test.dart`:
  - Error records include breadcrumbs from memorySink
  - Info records do not include breadcrumbs
  - Breadcrumbs capped at 20 records
  - No breadcrumbs when memorySink is null
  - Fatal records include breadcrumbs
  - `deriveBreadcrumbCategory` — explicit attribute, Router→ui, Router.Home→ui, Http→network, Auth→user, Lifecycle→system, unknown→system
- [x] 22 existing `backend_log_sink_test.dart` tests still pass
- [x] `dart format --set-exit-if-changed .` clean
- [x] `dart analyze` zero issues