### PR TITLE
fix(hooks): add dart fix step and worktree-safe wrappers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,16 +13,23 @@ repos:
       - id: gitleaks
   - repo: local
     hooks:
+      - id: dart-fix
+        name: dart fix
+        entry: scripts/dart-fix.sh
+        language: script
+        types: [dart]
+        exclude: ^packages/soliplex_client/lib/src/schema/
       - id: dart-format
         name: dart format
-        entry: dart format --set-exit-if-changed
-        language: system
+        entry: scripts/dart-format.sh --set-exit-if-changed
+        language: script
         types: [dart]
         exclude: ^packages/soliplex_client/lib/src/schema/
       - id: flutter-analyze
         name: flutter analyze
-        entry: flutter analyze --fatal-infos
-        language: system
+        entry: scripts/flutter-analyze.sh --fatal-infos
+        language: script
+        types: [dart]
         pass_filenames: false
       - id: dart-analyze-packages
         name: dart analyze packages

--- a/scripts/dart-fix.sh
+++ b/scripts/dart-fix.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Workaround for Dart SDK resolution in git worktrees.
+# See flutter-analyze.sh for details.
+unset GIT_DIR
+unset GIT_WORK_TREE
+exec dart fix --apply "$@"

--- a/scripts/dart-format.sh
+++ b/scripts/dart-format.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Workaround for Dart SDK resolution in git worktrees.
+# See flutter-analyze.sh for details.
+unset GIT_DIR
+unset GIT_WORK_TREE
+exec dart format "$@"

--- a/scripts/flutter-analyze.sh
+++ b/scripts/flutter-analyze.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Workaround for Flutter SDK version resolution in git worktrees.
+# Git sets GIT_DIR in worktrees, which confuses Flutter's version detection
+# (reports 0.0.0-unknown). Unsetting it restores correct behavior.
+unset GIT_DIR
+unset GIT_WORK_TREE
+exec flutter analyze "$@"


### PR DESCRIPTION
## Summary
- Add `dart fix --apply` as pre-commit hook step before `dart format`
- Add wrapper scripts that `unset GIT_DIR` for worktree compatibility

## Changes
- **`.pre-commit-config.yaml`**: New `dart-fix` hook runs first; all hooks use `scripts/` wrappers with `language: script`
- **`scripts/dart-fix.sh`**: Unsets `GIT_DIR`, runs `dart fix --apply`
- **`scripts/dart-format.sh`**: Unsets `GIT_DIR`, runs `dart format`
- **`scripts/flutter-analyze.sh`**: Unsets `GIT_DIR`, runs `flutter analyze`

## Problem
`dart format` wraps long argument lists to multiple lines but does not add trailing commas. `flutter analyze --fatal-infos` then rejects the result due to `require_trailing_commas`. This creates a cycle where format produces code that analyze rejects.

Additionally, git worktrees set `GIT_DIR` which breaks Flutter's SDK version detection (reports `0.0.0-unknown`), causing `flutter analyze` to fail with version resolution errors.

## Solution
Hook order: `dart fix` → `dart format` → `flutter analyze`

`dart fix --apply` inserts trailing commas (and other auto-fixable lints) before `dart format` touches whitespace. Wrapper scripts unset `GIT_DIR` for worktree compatibility.

## Test plan
- [x] Pre-commit hooks pass on commit
- [x] Hooks work from git worktrees (unset GIT_DIR)
- [x] Verify hooks on fresh clone (manual)

Generated with [Claude Code](https://claude.com/claude-code)