### PR TITLE
feat(patrol): Phase D — log hardening

### DIFF
--- a/integration_test/live_chat_test.dart
+++ b/integration_test/live_chat_test.dart
@@ -44,7 +44,9 @@ void main() {
       harness.dumpLogs(last: 50);
       rethrow;
     } finally {
-      harness.dispose();
+      harness
+        ..expectNoErrors()
+        ..dispose();
     }
   });
 
@@ -115,13 +117,28 @@ void main() {
         ..expectLog('ActiveRun', 'TEXT_START:')
         ..expectLog('ActiveRun', 'RUN_FINISHED');
 
+      // Phase D: performance bounds — detect backend regressions.
+      final runDuration = harness.measureLogDelta(
+        'ActiveRun',
+        'RUN_STARTED',
+        'ActiveRun',
+        'RUN_FINISHED',
+      );
+      expect(
+        runDuration,
+        lessThan(const Duration(seconds: 30)),
+        reason: 'AG-UI run took ${runDuration.inSeconds}s (limit: 30s)',
+      );
+
       // Pump extra frames for macOS rendering.
       await $.tester.pump(const Duration(seconds: 1));
     } catch (e) {
       harness.dumpLogs(last: 50);
       rethrow;
     } finally {
-      harness.dispose();
+      harness
+        ..expectNoErrors()
+        ..dispose();
     }
   });
 }

--- a/integration_test/oidc_test.dart
+++ b/integration_test/oidc_test.dart
@@ -107,10 +107,13 @@ void main() {
       expect(find.byType(ChatMessageWidget), findsAtLeast(2));
 
       // White-box: AG-UI lifecycle with authenticated backend.
+      // Phase D: auth lifecycle + HTTP audit.
       harness
         ..expectLog('ActiveRun', 'RUN_STARTED')
         ..expectLog('ActiveRun', 'TEXT_START:')
-        ..expectLog('ActiveRun', 'RUN_FINISHED');
+        ..expectLog('ActiveRun', 'RUN_FINISHED')
+        ..expectNoLog('Auth', 'restore')
+        ..expectNoHttpErrors();
 
       // Pump extra frames so the rendered UI is visible in the macOS window.
       for (var i = 0; i < 5; i++) {
@@ -120,7 +123,9 @@ void main() {
       harness.dumpLogs(last: 50);
       rethrow;
     } finally {
-      harness.dispose();
+      harness
+        ..expectNoErrors()
+        ..dispose();
     }
   });
 
@@ -168,7 +173,9 @@ void main() {
       harness.dumpLogs(last: 50);
       rethrow;
     } finally {
-      harness.dispose();
+      harness
+        ..expectNoErrors()
+        ..dispose();
     }
   });
 }

--- a/integration_test/settings_test.dart
+++ b/integration_test/settings_test.dart
@@ -68,7 +68,9 @@ void main() {
       harness.dumpLogs(last: 50);
       rethrow;
     } finally {
-      harness.dispose();
+      harness
+        ..expectNoErrors()
+        ..dispose();
     }
   });
 
@@ -216,7 +218,9 @@ void main() {
       harness.dumpLogs(last: 50);
       rethrow;
     } finally {
-      harness.dispose();
+      harness
+        ..expectNoErrors()
+        ..dispose();
     }
   });
 }

--- a/integration_test/smoke_test.dart
+++ b/integration_test/smoke_test.dart
@@ -30,7 +30,11 @@ void main() {
 
       // Verify the router ran (proves full boot sequence: binding → logging
       // → auth → router → screen). Log-based assertion from the harness.
-      harness.expectLog('Router', 'redirect called');
+      harness
+        ..expectLog('Router', 'redirect called')
+
+        // Phase D: verify app picked up the correct runtime configuration.
+        ..expectLog('Config', backendUrl);
 
       // Pump extra frames so the rendered UI is visible in the macOS window.
       for (var i = 0; i < 5; i++) {
@@ -40,7 +44,9 @@ void main() {
       harness.dumpLogs(last: 50);
       rethrow;
     } finally {
-      harness.dispose();
+      harness
+        ..expectNoErrors()
+        ..dispose();
     }
   });
 }

--- a/integration_test/test_log_harness.dart
+++ b/integration_test/test_log_harness.dart
@@ -11,6 +11,10 @@ import 'package:soliplex_logging/soliplex_logging.dart';
 /// - [prefs] and [sink] for constructing provider overrides
 /// - [waitForLog] — stream-based wait for internal log events
 /// - [expectLog] — synchronous assertion on past log records
+/// - [expectNoLog] — negative assertion (log must NOT exist)
+/// - [expectNoErrors] — error sentinel across all loggers
+/// - [expectNoHttpErrors] — HTTP-specific error audit
+/// - [measureLogDelta] — time between two log events
 /// - [dumpLogs] — dump recent logs to console on failure
 class TestLogHarness {
   late final MemorySink sink;
@@ -72,6 +76,98 @@ class TestLogHarness {
       dumpLogs(last: 30);
       fail('Log not found: [$loggerName] containing "$messagePattern"');
     }
+  }
+
+  /// Assert that a log record does NOT exist in the buffer.
+  ///
+  /// Use for negative assertions — proving something didn't happen.
+  /// For example, `expectNoLog('Auth', 'restore')` proves the
+  /// `PreAuthenticatedNotifier` skipped the restore path.
+  void expectNoLog(String loggerName, String messagePattern) {
+    final found = sink.records.any(
+      (r) => r.loggerName == loggerName && r.message.contains(messagePattern),
+    );
+    if (found) {
+      dumpLogs(last: 30);
+      fail('Unexpected log found: [$loggerName] containing "$messagePattern"');
+    }
+  }
+
+  /// Assert no unexpected error-level logs exist across all loggers.
+  ///
+  /// Call in every test's `finally` block to catch silent failures.
+  /// Use [allowedPatterns] to suppress known acceptable errors
+  /// (e.g., keychain unavailable in debug builds).
+  void expectNoErrors({List<String> allowedPatterns = const []}) {
+    final errors = sink.records
+        .where((r) => r.level >= LogLevel.error)
+        .where((r) => !allowedPatterns.any((p) => r.message.contains(p)))
+        .toList();
+    if (errors.isNotEmpty) {
+      dumpLogs(last: 50);
+      fail(
+        '${errors.length} unexpected error(s):\n'
+        '${errors.map((r) => '  [${r.loggerName}] ${r.message}').join('\n')}',
+      );
+    }
+  }
+
+  /// Assert no unexpected HTTP error responses during a test.
+  ///
+  /// Checks for HTTP status codes >= 400 in logs. Use [allowedStatuses]
+  /// to permit expected errors (e.g., 404 for optional endpoints).
+  void expectNoHttpErrors({List<int> allowedStatuses = const []}) {
+    final httpErrors = sink.records.where((r) {
+      if (r.loggerName != 'HTTP') return false;
+      final match = _httpStatusPattern.firstMatch(r.message);
+      if (match == null) return false;
+      final status = int.parse(match.group(1)!);
+      return status >= 400 && !allowedStatuses.contains(status);
+    }).toList();
+    if (httpErrors.isNotEmpty) {
+      dumpLogs(last: 50);
+      fail(
+        '${httpErrors.length} unexpected HTTP error(s):\n'
+        '${httpErrors.map((r) => '  ${r.message}').join('\n')}',
+      );
+    }
+  }
+
+  static final _httpStatusPattern = RegExp(r'HTTP (\d{3})');
+
+  /// Measure the time between two log events.
+  ///
+  /// Returns the [Duration] between the first record matching
+  /// [startLogger]/[startPattern] and the first matching
+  /// [endLogger]/[endPattern]. Fails if either record is not found.
+  Duration measureLogDelta(
+    String startLogger,
+    String startPattern,
+    String endLogger,
+    String endPattern,
+  ) {
+    final records = sink.records;
+    LogRecord? start;
+    LogRecord? end;
+    for (final r in records) {
+      if (start == null &&
+          r.loggerName == startLogger &&
+          r.message.contains(startPattern)) {
+        start = r;
+      }
+      if (r.loggerName == endLogger && r.message.contains(endPattern)) {
+        end = r;
+      }
+    }
+    if (start == null) {
+      dumpLogs(last: 30);
+      fail('Start log not found: [$startLogger] "$startPattern"');
+    }
+    if (end == null) {
+      dumpLogs(last: 30);
+      fail('End log not found: [$endLogger] "$endPattern"');
+    }
+    return end.timestamp.difference(start.timestamp);
   }
 
   /// Dump recent logs to console (for failure diagnostics).

--- a/lib/core/providers/config_provider.dart
+++ b/lib/core/providers/config_provider.dart
@@ -62,14 +62,15 @@ class ConfigNotifier extends Notifier<AppConfig> {
     // typically static, watch enables proper rebuilding in tests.
     final preloadedUrl = ref.watch(preloadedBaseUrlProvider);
     if (preloadedUrl != null) {
-      Loggers.config.debug('URL resolved from saved preferences');
+      Loggers.config.info('Backend URL: $preloadedUrl (saved preferences)');
       return AppConfig(baseUrl: preloadedUrl);
     }
 
     final configUrl = ref.watch(shellConfigProvider).defaultBackendUrl;
     final resolved = platformDefaultBackendUrl(configUrl);
-    Loggers.config.debug(
-      'URL resolved from ${kIsWeb ? "platform origin" : "shell config"}',
+    Loggers.config.info(
+      'Backend URL: $resolved '
+      '(${kIsWeb ? "platform origin" : "shell config"})',
     );
     return AppConfig(baseUrl: resolved);
   }

--- a/lib/core/providers/http_log_provider.dart
+++ b/lib/core/providers/http_log_provider.dart
@@ -61,7 +61,7 @@ class HttpLogNotifier extends Notifier<List<HttpEvent>>
 
   @override
   void onResponse(HttpResponseEvent event) {
-    Loggers.http.debug('${event.statusCode} response');
+    Loggers.http.debug('HTTP ${event.statusCode} response');
     _addEvent(event);
   }
 


### PR DESCRIPTION
## Summary
- Phase D log hardening for Patrol E2E test infrastructure

## Changes
- **Phase D**: Harden logging for reliable test diagnostics

## Merge order
> **Slice 4/4** — merge after PR #236 (patrol-client-tools)

| Slice | PR | Branch | Status |
|-------|-----|--------|--------|
| 1/4 | #83 | `feat/client-tool-calling` | Open |
| 2/4 | #235 | `docs/patrol-planning` | Open |
| 3/4 | #236 | `feat/patrol-client-tools` | Open |
| **4/4** | **this** | `phase-d/log-hardening` | **Open** |

## Test plan
- [x] `flutter analyze` — 0 issues
- [x] `flutter test` — all pass