### PR TITLE
docs(patrol): planning specs — phases A through E

### DIFF
--- a/docs/patrol-analysis.md
+++ b/docs/patrol-analysis.md
@@ -1,0 +1,282 @@
+# Patrol Integration Testing Analysis
+
+> Collaborative analysis by Claude, Gemini (2.5-pro), and Codex (gpt-5.2)
+> Date: 2026-01-20
+
+## Executive Summary
+
+This document analyzes the setup requirements for Patrol integration tests in the
+Soliplex Flutter frontend. The goal is a minimal, LLM-compatible test suite that
+connects to a live backend in no-auth-mode.
+
+## Current State
+
+### Existing Infrastructure
+
+- `integration_test/tool_calling_test.dart` - Uses mocked AG-UI streams
+- `integration_tests/whitelabel_config_test.dart` - Tests against live backend
+  (gitignored)
+- `integration_test` SDK already in pubspec.yaml
+- macOS bundle ID: `ai.soliplex.client`
+- Test helpers in `test/helpers/test_helpers.dart`
+
+### API Endpoints (from soliplex_client)
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/v1/rooms` | GET | List rooms |
+| `/api/v1/rooms/{roomId}/agui` | GET | List threads |
+| `/api/v1/rooms/{roomId}/agui` | POST | Create thread |
+| `/api/v1/rooms/{roomId}/agui/{threadId}` | POST | Create run (starts SSE) |
+
+## Patrol Setup Requirements
+
+### 1. Dependencies (pubspec.yaml)
+
+```yaml
+dev_dependencies:
+  patrol: ^4.3.0
+  patrol_finders: ^3.0.0  # Optional but recommended for cleaner finders
+```
+
+### 2. Patrol Configuration (pubspec.yaml)
+
+```yaml
+patrol:
+  app_name: Soliplex
+  test_directory: integration_test
+  macos:
+    bundle_id: ai.soliplex.client
+  ios:
+    bundle_id: ai.soliplex.client
+```
+
+### 3. CLI Installation
+
+```bash
+dart pub global activate patrol_cli
+```
+
+## Test Architecture Recommendations
+
+### File Organization (LLM-Compatible)
+
+```
+integration_test/
+├── patrol_test_base.dart      # Shared setup, helpers, _NoAuthNotifier
+├── live_chat_test.dart        # Room nav + chat send/receive
+├── live_tool_calling_test.dart # Client tool execution
+└── README.md                  # Test inventory for LLM reference
+```
+
+**Naming Convention**: Use dot-separated IDs for test names:
+
+- `live.rooms.load` - Load rooms from backend
+- `live.chat.send_receive` - Send message, receive streaming response
+- `live.tools.client_execution` - Client-side tool calling
+
+### Streaming Response Pattern
+
+**Critical**: Avoid `pumpAndSettle()` for streaming - it hangs waiting for
+streams to close.
+
+Use condition-based polling:
+
+```dart
+Future<void> waitForCondition(
+  WidgetTester tester, {
+  required bool Function() condition,
+  required Duration timeout,
+  Duration step = const Duration(milliseconds: 200),
+  String? failureMessage,
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    await tester.pump(step);
+    if (condition()) return;
+  }
+  fail(failureMessage ?? 'Timed out after $timeout');
+}
+```
+
+### Screenshot on Failure
+
+Wrap tests with automatic screenshot capture:
+
+```dart
+void patrolTestWithScreenshot(
+  String id,
+  Future<void> Function(PatrolTester $) body,
+) {
+  final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  patrolTest(id, ($) async {
+    try {
+      await body($);
+    } catch (_) {
+      final safeName = id.replaceAll(RegExp(r'[^a-zA-Z0-9._-]'), '_');
+      await binding.takeScreenshot('FAIL__$safeName');
+      rethrow;
+    }
+  });
+}
+```
+
+### Backend Connectivity
+
+**Preflight Check**: Before running UI tests, verify backend is reachable:
+
+```dart
+Future<void> verifyBackendOrFail(String backendUrl) async {
+  try {
+    final res = await http.get(Uri.parse('$backendUrl/api/v1/rooms'))
+        .timeout(const Duration(seconds: 8));
+    if (res.statusCode != 200) {
+      fail('Backend returned ${res.statusCode}');
+    }
+  } catch (e) {
+    fail('Backend unreachable at $backendUrl: $e');
+  }
+}
+```
+
+**Environment Variable**: Use `SOLIPLEX_BACKEND_URL` (default: `localhost:8000`)
+
+```dart
+const backendUrl = String.fromEnvironment(
+  'SOLIPLEX_BACKEND_URL',
+  defaultValue: 'http://localhost:8000',
+);
+```
+
+## Test Isolation Strategy
+
+### For Live Backend Tests
+
+1. **Create fresh threads per test** - Don't reuse existing threads
+2. **Use unique message tokens** - Include timestamp in test messages
+3. **Cleanup via tearDown** - Delete test threads after completion
+4. **Prefix test data** - Use `test-` prefix for easy identification
+
+### Provider Overrides (Existing Pattern)
+
+Continue using `ProviderScope.overrides` as established:
+
+```dart
+ProviderScope(
+  overrides: [
+    shellConfigProvider.overrideWithValue(config),
+    authProvider.overrideWith(_NoAuthNotifier.new),
+  ],
+  child: Consumer(...),
+)
+```
+
+## macOS-Specific Considerations
+
+### Keyboard Assertion Workaround
+
+Keep the existing workaround for Flutter macOS keyboard bug:
+
+```dart
+void ignoreKeyboardAssertions() {
+  final originalOnError = FlutterError.onError;
+  FlutterError.onError = (details) {
+    if (details.exception.toString().contains('_pressedKeys.containsKey') ||
+        details.exception.toString().contains('KeyUpEvent is dispatched')) {
+      return; // Ignore
+    }
+    originalOnError?.call(details);
+  };
+}
+```
+
+### Entitlements
+
+macOS entitlements already include `com.apple.security.network.client` for
+localhost connections.
+
+## CI/CD Considerations
+
+### GitHub Actions Workflow
+
+```yaml
+integration-test:
+  runs-on: macos-latest
+  timeout-minutes: 30
+  steps:
+    - uses: actions/checkout@v4
+    - uses: subosito/flutter-action@v2
+      with:
+        channel: stable
+        cache: true
+    - name: Install Patrol CLI
+      run: dart pub global activate patrol_cli
+    - name: Run integration tests
+      env:
+        SOLIPLEX_BACKEND_URL: ${{ secrets.STAGING_BACKEND_URL }}
+      run: |
+        flutter pub get
+        patrol test --target integration_test/live_chat_test.dart
+    - name: Upload screenshots
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: patrol-screenshots
+        path: build/patrol/screenshots/
+```
+
+### Local Development
+
+```bash
+# Start backend in no-auth-mode
+cd soliplex && soliplex-cli serve example/minimal.yaml --no-auth-mode
+
+# Run Patrol tests
+SOLIPLEX_BACKEND_URL=http://localhost:8000 patrol test
+```
+
+## Comparison: Patrol vs integration_test
+
+| Feature | integration_test | Patrol |
+|---------|------------------|--------|
+| Native UI (OIDC popup) | No | Yes |
+| Custom finders | No | Yes (`$('text')`) |
+| Screenshot on failure | Manual | Built-in flag |
+| Hot restart | No | Yes |
+| CLI tooling | flutter test | patrol test |
+| Learning curve | Low | Low (extends existing) |
+
+**Recommendation**: Use Patrol for future-proofing (OIDC, location permissions)
+while keeping tests simple enough to run with `flutter test` as fallback.
+
+## Test Scenarios (Priority Order)
+
+### 1. live.rooms.load
+
+- GET /api/v1/rooms
+- Verify RoomListTile widgets render
+- Screenshot room list
+
+### 2. live.chat.send_receive
+
+- Navigate to room
+- Send message via chat input
+- Wait for streaming response (SSE)
+- Verify ChatMessageWidget appears with response
+
+### 3. live.tools.client_execution
+
+- Send message that triggers tool call
+- Verify ToolCallStartEvent processed
+- Verify client executor runs
+- Verify continuation run with tool result
+
+## Appendix: Key Files Reference
+
+| File | Purpose |
+|------|---------|
+| `lib/core/providers/api_provider.dart` | API client providers |
+| `lib/core/providers/active_run_notifier.dart` | AG-UI streaming orchestration |
+| `packages/soliplex_client/lib/src/application/tool_registry.dart` | Client tool registration |
+| `test/helpers/test_helpers.dart` | Mock factories and test utilities |

--- a/docs/planning/patrol/OVERVIEW.md
+++ b/docs/planning/patrol/OVERVIEW.md
@@ -1,0 +1,61 @@
+# Patrol E2E Integration - Overview
+
+## What
+
+End-to-end integration tests for the Soliplex Flutter frontend using
+[Patrol](https://pub.dev/packages/patrol) by LeanCode. Tests run against a live
+backend (no mocks) and verify the full user flow from app launch through chat
+interaction.
+
+## Why Patrol
+
+Standard `integration_test` cannot interact with native UI outside the Flutter
+widget tree. Patrol adds:
+
+- **`$.native` API** — drives system dialogs, browser popups, permission prompts
+- **Custom finders** — cleaner syntax (`$('text')`) alongside standard finders
+- **CLI tooling** — `patrol test` with hot restart, device targeting, screenshots
+- **Future-proofing** — OIDC popups, location permissions, share sheets
+
+## Platform Support
+
+| Platform | `patrol test` | `$.native` | Notes |
+|----------|:---:|:---:|-------|
+| **macOS** | yes | yes | Primary target. Uses Accessibility APIs. |
+| **iOS** | yes | yes | Uses XCUITest. Bundle ID already configured. |
+| **Web** | no | no | Patrol relies on native UI frameworks. Use `integration_test` + ChromeDriver for web E2E. |
+
+Initial scope: **macOS only**. iOS requires minimal additional config (same
+bundle ID `ai.soliplex.client`).
+
+## Current State
+
+### Existing Infrastructure
+
+- `integration_test/` directory does not exist yet
+- `integration_test` SDK dependency missing from `pubspec.yaml`
+- macOS bundle ID: `ai.soliplex.client`
+- macOS entitlements include `com.apple.security.network.client`
+- Test helpers in `test/helpers/test_helpers.dart` (mock factories, `pumpWithProviders`)
+
+### API Endpoints (from soliplex_client)
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/v1/rooms` | GET | List rooms |
+| `/api/v1/rooms/{roomId}/agui` | GET | List threads |
+| `/api/v1/rooms/{roomId}/agui` | POST | Create thread |
+| `/api/v1/rooms/{roomId}/agui/{threadId}` | POST | Create run (starts SSE) |
+| `/api/login` | GET | Auth provider config (Keycloak) |
+
+## Source Analysis
+
+Detailed analysis of Patrol requirements, test architecture recommendations,
+and code patterns: [patrol-analysis.md](../../patrol-analysis.md)
+
+## History
+
+- 2026-02-06 — Initial 7-milestone plan created
+- 2026-02-06 — 3x Gemini critique + 1x Codex review of original plan
+- 2026-02-07 — Simplified to 3 phases after Codex + Gemini cross-validation
+- 2026-02-07 — Scoped to `--no-auth-mode` first for fastest value

--- a/docs/planning/patrol/PLAN.md
+++ b/docs/planning/patrol/PLAN.md
@@ -1,0 +1,141 @@
+# Patrol E2E Integration - Plan
+
+## Strategy
+
+Get to a working Patrol E2E test as fast as possible. Start with
+`--no-auth-mode` to eliminate auth complexity, prove the toolchain, then layer
+on OIDC and CI. Leverage the existing logging system (`soliplex_logging`) for
+white-box observability, event-driven waits, and self-documenting failures.
+
+## Phases
+
+| Phase | Focus | Auth | Outcome |
+|-------|-------|------|---------|
+| **A** | [Setup + Smoke](./phase-a-setup-smoke.md) | no-auth | Patrol runs, app boots with logging, backend reachable |
+| **B** | [Live Chat](./phase-b-live-chat.md) | no-auth | Rooms load, chat send/receive with log-driven waits |
+| **C** | [OIDC + CI](./phase-c-oidc-ci.md) | oidc | Token-seeded auth via ROPC |
+| **D** | [Log Hardening](./phase-d-log-hardening.md) | both | Error sentinels, perf bounds, HTTP audit, negative assertions |
+| **E** | [Agent-in-Loop](./phase-e-agent-loop.md) | dev-mode | Interactive test runner, MCP inspection, self-healing tests |
+
+## Dependency Graph
+
+```text
+Phase A (Setup + Smoke + TestLogHarness)
+└── Phase B (Live Chat, log-driven waits)
+    └── Phase C (OIDC auth via ROPC)
+        └── Phase D (Log hardening: sentinels, perf, audit)
+            └── Phase E (Agent-in-Loop: test runner room)
+```
+
+## Progress
+
+- [x] Phase A — Setup + Smoke
+- [x] Phase B — Live Chat (no-auth)
+- [x] Phase C — OIDC auth via ROPC
+- [ ] Phase D — Log Hardening
+- [ ] Phase E — Agent-in-Loop
+
+## Key Design Decisions
+
+### No-Auth First
+
+All initial tests run against a backend in `--no-auth-mode`. This removes every
+auth-related concern (Keycloak, tokens, provider overrides) from the critical
+path to a working test.
+
+### Token Seeding for OIDC (Not $.native)
+
+When we add OIDC in Phase C, we use **direct Keycloak ROPC token exchange** +
+provider override injection. We do NOT fight `ASWebAuthenticationSession` on
+macOS — it resists automation by design. `$.native` browser driving is deferred
+to a future hardening phase.
+
+**Keycloak requirement:** The test client must have "Direct Access Grants"
+enabled. See [Phase C](./phase-c-oidc-ci.md#keycloak-configuration).
+
+### Logging as Test Infrastructure
+
+The `soliplex_logging` package provides white-box observability inside E2E
+tests. This is the key differentiator of our Patrol rig:
+
+| Capability | Logging Component | Phase |
+|------------|-------------------|-------|
+| Event-driven waits (replace polling) | `MemorySink.onRecord` stream | A, B |
+| Internal pipeline assertions | `MemorySink.records` query | B |
+| Auto-diagnostics on failure | `MemorySink` dump (last 2000 records) | A |
+| Logfire correlation (`testRunId`) | `LogSanitizer` attribute injection | C |
+| CI failure artifacts | `logs.jsonl` + breadcrumbs bundle | C |
+| Performance regression detection | `LogRecord.timestamp` diffs | Future |
+
+### Logging Exploitation Levels
+
+```text
+Level 1: Free observation (read existing Loggers.* calls)      ← Phase A
+Level 2: Event-driven waits (MemorySink.onRecord stream)       ← Phase B
+Level 3: Structured event assertions (attribute-based)          ← Phase B
+Level 4: Logfire correlation (testRunId across client+server)   ← Phase C
+Level 5: Error sentinels (expectNoErrors across all tests)       ← Phase D
+Level 6: Negative/audit assertions (HTTP 401, auth restore)     ← Phase D
+Level 7: Performance regression detection (timestamp diffs)     ← Phase D
+```
+
+### Streaming-Safe Pumping
+
+`pumpAndSettle()` hangs on SSE streams. Phase A uses condition-based polling
+via `waitForCondition`. Phase B upgrades to log-driven waits via
+`harness.waitForLog()` where possible.
+
+### Minimal Harness, Grown Incrementally
+
+Phase A introduces `TestLogHarness` with just enough to boot the app with
+logging and dump diagnostics on failure. Each subsequent phase adds only what
+it needs.
+
+## Deferred (Future Phases)
+
+Intentionally deferred until the core test suite is stable:
+
+| Item | Reason to Defer |
+|------|-----------------|
+| `$.native` browser automation | Blocked by macOS `ASWebAuthenticationSession` |
+| Tool calling tests | Add after chat tests are stable |
+| Dual auth modes | One mode at a time is fine |
+| Dot-separated test IDs | Normal names until >5 tests |
+| `integration_test/README.md` | Write when there are real tests to document |
+| iOS targeting | Minimal config delta from macOS; add after macOS is green |
+| `runStep()` instrumentation | Add when >3 tests need timing |
+| Performance regression detection | Add when baseline established |
+
+## Review Gates
+
+Each phase must pass its gates before the next phase begins.
+Maximum 3 review/revise cycles per gate.
+
+### Phase A Gates
+
+| Gate | Tool | What |
+|------|------|------|
+| **Automated** | CLI | `flutter pub get`, `flutter analyze` = 0, `patrol --version`, `patrol doctor`, `flutter test` passes, smoke test green |
+| **Logging** | Manual | TestLogHarness initializes MemorySink, failure dumps last N records to console |
+| **Gemini Critique** | `read_files` / `gemini-3-pro-preview` | Review pubspec, harness, smoke test, logging_provider against spec |
+
+### Phase B Gates
+
+| Gate | Tool | What |
+|------|------|------|
+| **Automated** | CLI | `flutter analyze` = 0, both patrol tests green, no `pumpAndSettle` anywhere |
+| **Logging** | Manual | `waitForLog()` for SSE completion, `expectLog()` verifies HTTP + ActiveRun, `dumpLogs()` on failure |
+| **Gemini Critique** | `read_files` / `gemini-3-pro-preview` | Review test file, harness, config, loggers.dart against spec |
+| **Codex Cross-Validation** | `mcp__codex__codex` / `read-only` | Architecture review: does TestLogHarness + log-driven waits hold up? Provider override strategy correct? Anything brittle before adding auth? |
+
+Phase B gets both Gemini AND Codex review because it is the architectural
+pivot point — the harness, provider overrides, and log-driven wait pattern
+established here carry forward into Phase C and all future tests.
+
+### Phase C Gates
+
+| Gate | Tool | What |
+|------|------|------|
+| **Automated** | CLI | `flutter analyze` = 0, authenticated test green, no-auth tests still green, CI YAML valid |
+| **Logging** | Manual | `testRunId` in all LogRecords, queryable in Logfire with `SOLIPLEX_SHIP_LOGS=true`, failure artifact bundle produced |
+| **Gemini Critique** | `read_files` / `gemini-3-pro-preview` | Review auth_notifier, harness, config, authenticated test, CI workflow, logging_provider against spec |

--- a/docs/planning/patrol/client-tools-plan.md
+++ b/docs/planning/patrol/client-tools-plan.md
@@ -1,0 +1,195 @@
+# Client-Side Tool Calling for Patrol Room
+
+**Status:** plan
+**Depends on:** PR #83 (`feat/client-tool-calling`), Phase E spec
+
+## Problem
+
+The Patrol Test Runner room (`example/rooms/patrol/`) works end-to-end:
+agent receives messages, calls `patrol_run`, reports results. But
+`patrol test` fails when spawned from the Soliplex Python server because
+it runs headless — no WindowServer access means xcodebuild exits with
+code 65 ("no supported run destinations").
+
+## Solution: Client-Side Tool Execution
+
+Move `patrol_run` execution from the server to the Flutter client.
+The server orchestrates (LLM decides to call the tool), the client
+executes (has GUI access, correct paths, and environment).
+
+PR #83 adds the infrastructure:
+
+- **ToolRegistry** — register client-side tool definitions and executors
+- **ActiveRunNotifier** — detects pending tool calls, executes locally
+- **agui_message_mapper** — sends tool results back to server
+- **hasExecutor()** filter — skips server-side tools, only runs
+  client-registered tools
+
+## Architecture
+
+```text
+User: "Run the smoke test"
+        │
+        ▼
+┌──────────────────────┐
+│  Soliplex Backend     │
+│  (pydantic_ai agent)  │
+│                        │
+│  Agent decides:        │
+│  call patrol_run(      │
+│    target: smoke_test) │
+└──────────┬─────────────┘
+           │ AG-UI SSE stream
+           │ TOOL_CALL_START → TOOL_CALL_ARGS → TOOL_CALL_END
+           ▼
+┌──────────────────────┐
+│  Flutter Client       │
+│  (ActiveRunNotifier)  │
+│                        │
+│  ToolRegistry.has(     │
+│    "patrol_run") ✓     │
+│                        │
+│  Execute locally:      │
+│  Process.run("patrol   │
+│    test --device macos │
+│    --target ...")       │
+│                        │
+│  Stream STATE_DELTA    │
+│  events with stdout    │
+│  lines as they arrive  │
+└──────────┬─────────────┘
+           │ POST tool result back
+           ▼
+┌──────────────────────┐
+│  Agent continues      │
+│  "All tests PASSED"   │
+└──────────────────────┘
+```
+
+## Implementation Steps
+
+### 1. Merge PR #83 into main
+
+The client-tool-calling branch needs to be rebased onto current main
+(it's behind by ~20 commits). Resolve conflicts in:
+
+- `active_run_notifier.dart` (logging changes, state shape)
+- `chat_input.dart` (suggestion chips, document picker)
+- `agui_event_processor.dart` (ToolCallActivity)
+- `pubspec.yaml` (patrol deps, soliplex_logging)
+
+### 2. Register `patrol_run` as a client tool
+
+```dart
+// In a provider or app initialization
+final toolRegistry = ref.read(toolRegistryProvider);
+toolRegistry.register(
+  ToolDefinition(
+    name: 'patrol_run',
+    description: 'Run a Patrol E2E test locally',
+    parameters: {
+      'target': ToolParameter(type: 'string', required: true),
+      'backend_url': ToolParameter(type: 'string', required: false),
+    },
+    executor: (args) async {
+      final target = args['target'] as String;
+      final backendUrl = args['backend_url'] as String?
+          ?? 'http://localhost:8000';
+
+      // Validate target
+      const allowed = {
+        'smoke_test.dart',
+        'live_chat_test.dart',
+        'settings_test.dart',
+        'oidc_test.dart',
+      };
+      if (!allowed.contains(target)) {
+        return 'Invalid target. Allowed: ${allowed.join(', ')}';
+      }
+
+      final result = await Process.run(
+        patrolCliPath,
+        ['test', '--device', 'macos',
+         '--target', 'integration_test/$target',
+         '--dart-define', 'SOLIPLEX_BACKEND_URL=$backendUrl'],
+        workingDirectory: flutterProjectPath,
+      );
+
+      final output = result.stdout as String;
+      if (result.exitCode == 0) {
+        return 'PASSED\n\n${output.substring(output.length - 500)}';
+      }
+      return 'FAILED (exit ${result.exitCode})\n\n'
+             '${output.substring(output.length - 1000)}';
+    },
+  ),
+);
+```
+
+### 3. Update room config — declare tool as client-side
+
+The room config needs a way to tell the server that `patrol_run` is
+a client-side tool (server should emit the tool call event, not
+execute it). Options:
+
+- **Option A:** Server-side tool stub that raises "client-side only"
+- **Option B:** Room config `client_tools:` section (new feature)
+- **Option C:** Tool definition with `execution: client` flag
+
+Option A works today with no server changes — register a dummy
+`patrol_run` tool on the server that returns an instruction string,
+and the client intercepts it before the server executes.
+
+Option B is cleaner but requires server-side changes to room config
+parsing.
+
+### 4. Stream stdout via STATE_DELTA
+
+Instead of `Process.run` (blocks until completion), use `Process.start`
+and stream stdout line-by-line:
+
+```dart
+final process = await Process.start(patrolCliPath, args);
+await for (final line in process.stdout
+    .transform(utf8.decoder)
+    .transform(const LineSplitter())) {
+  // Push state delta to AG-UI stream
+  emitStateDelta({
+    'patrol': {
+      'status': 'running',
+      'output_tail': line,
+    },
+  });
+}
+```
+
+This gives real-time test output in the chat UI while patrol runs.
+
+### 5. Add patrol output widget
+
+The Flutter client needs a widget that renders `state.patrol` updates.
+Could be a collapsible log viewer in the chat thread, similar to the
+"Thinking" section.
+
+## Benefits Over Server-Side
+
+| Concern | Server-side | Client-side |
+|---------|-------------|-------------|
+| GUI access | needs hacks | native |
+| Path config | env vars | client knows its env |
+| Streaming | blocked until done | line-by-line |
+| Platform | macOS-specific hacks | wherever client runs |
+| Security | server runs commands | user's machine |
+
+## Open Questions
+
+1. **Tool stub vs client_tools config**: Which approach for telling
+   the server "don't execute this, let the client handle it"?
+2. **Process path discovery**: How does the Flutter client find the
+   `patrol` CLI path? Env var, settings page, or auto-detect from
+   `~/.pub-cache/bin/`?
+3. **Concurrent test prevention**: Should the client block a second
+   `patrol_run` while one is already executing?
+4. **Dev-mode guard**: Client-side tool registration should only
+   happen when `SOLIPLEX_DEV_MODE=true` to prevent the patrol tool
+   from appearing in production builds.

--- a/docs/planning/patrol/phase-a-setup-smoke.md
+++ b/docs/planning/patrol/phase-a-setup-smoke.md
@@ -1,0 +1,342 @@
+# Phase A: Setup + Smoke Test
+
+**Status:** pending
+**Depends on:** none
+**Logging level:** 1 (free observation + failure diagnostics)
+
+## Objective
+
+Install Patrol, configure the project, create `TestLogHarness`, and produce one
+green smoke test that boots the app with full logging against a `--no-auth-mode`
+backend. On failure, the harness automatically dumps the last 2000 log records.
+
+## Pre-flight Checklist
+
+- [ ] Verify macOS bundle ID is `ai.soliplex.client` (in `macos/Runner.xcodeproj`)
+- [ ] Check current Patrol version on [pub.dev](https://pub.dev/packages/patrol)
+- [ ] Verify macOS entitlements include `com.apple.security.network.client`
+- [ ] Read `lib/core/logging/logging_provider.dart` to confirm required overrides
+  (`preloadedPrefsProvider`, `shellConfigProvider`)
+- [ ] Read `test/helpers/test_helpers.dart` for existing provider override patterns
+
+## Deliverables
+
+1. `pubspec.yaml` — Patrol deps + config section
+2. `integration_test/test_log_harness.dart` — Logging-aware test harness
+3. `integration_test/patrol_test_config.dart` — Shared helpers and constants
+4. `integration_test/smoke_test.dart` — One passing smoke test
+
+## Implementation Steps
+
+### Step 1: Add dependencies
+
+**File:** `pubspec.yaml`
+
+- [ ] Add `integration_test` SDK dependency to `dev_dependencies`:
+
+```yaml
+dev_dependencies:
+  integration_test:
+    sdk: flutter
+  patrol: ^4.3.0
+  patrol_finders: ^3.0.0
+```
+
+- [ ] Add top-level `patrol:` configuration:
+
+```yaml
+patrol:
+  app_name: Soliplex
+  test_directory: integration_test
+  macos:
+    bundle_id: ai.soliplex.client
+```
+
+- [ ] Run `flutter pub get`
+- [ ] Note: `http` is already in `dependencies`, no need to add to `dev_dependencies`
+
+### Step 2: Install Patrol CLI
+
+- [ ] Run `dart pub global activate patrol_cli`
+- [ ] Verify `patrol --version` outputs version info
+- [ ] Verify `patrol doctor` reports no blocking issues
+
+### Step 3: Create TestLogHarness
+
+**File:** `integration_test/test_log_harness.dart`
+
+The harness wraps `MemorySink` and `LogManager` for test use. It provides:
+
+- Provider overrides needed to boot the app with logging
+- `waitForLog()` — stream-based wait for internal events
+- `expectLog()` — synchronous assertion on past log records
+- `dumpLogs()` — dump MemorySink contents on failure
+
+```dart
+import 'dart:async';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+// Import the actual providers from the app
+import 'package:soliplex/core/logging/logging_provider.dart';
+
+class TestLogHarness {
+  late final MemorySink sink;
+
+  /// Initialize logging and return provider overrides.
+  /// Caller adds these to ProviderScope.overrides.
+  Future<List<Override>> initialize() async {
+    SharedPreferences.setMockInitialValues({
+      'log_level': 0, // LogLevel.trace
+      'console_logging': true,
+      'backend_logging': false, // No backend shipping in Phase A/B
+    });
+    final prefs = await SharedPreferences.getInstance();
+
+    sink = MemorySink(maxRecords: 5000);
+    LogManager.instance.addSink(sink);
+    LogManager.instance.minimumLevel = LogLevel.trace;
+
+    return [
+      preloadedPrefsProvider.overrideWithValue(prefs),
+      memorySinkProvider.overrideWithValue(sink),
+    ];
+  }
+
+  /// Wait for a specific log to appear (stream-based, replaces polling).
+  Future<void> waitForLog(
+    String loggerName,
+    String messagePattern, {
+    Duration timeout = const Duration(seconds: 10),
+  }) async {
+    // Check existing records first
+    final found = sink.records.any(
+      (r) => r.loggerName == loggerName &&
+             r.message.contains(messagePattern),
+    );
+    if (found) return;
+
+    // Wait for future record
+    try {
+      await sink.onRecord
+          .firstWhere(
+            (r) => r.loggerName == loggerName &&
+                   r.message.contains(messagePattern),
+          )
+          .timeout(timeout);
+    } on TimeoutException {
+      dumpLogs(last: 50);
+      fail('Timed out waiting for [$loggerName] "$messagePattern"');
+    }
+  }
+
+  /// Assert a log record already exists in the buffer.
+  void expectLog(String loggerName, String messagePattern) {
+    final found = sink.records.any(
+      (r) => r.loggerName == loggerName &&
+             r.message.contains(messagePattern),
+    );
+    if (!found) {
+      dumpLogs(last: 30);
+      fail('Log not found: [$loggerName] containing "$messagePattern"');
+    }
+  }
+
+  /// Dump recent logs to console (for failure diagnostics).
+  void dumpLogs({int last = 100}) {
+    final records = sink.records;
+    final start = records.length > last ? records.length - last : 0;
+    print('\n=== TEST LOG DUMP (last $last of ${records.length}) ===');
+    for (var i = start; i < records.length; i++) {
+      print(records[i].toString());
+    }
+    print('=== END LOG DUMP ===\n');
+  }
+
+  /// Clean up after test.
+  void dispose() {
+    LogManager.instance.removeSink(sink);
+    sink.close();
+  }
+}
+```
+
+### Step 4: Create shared helpers
+
+**File:** `integration_test/patrol_test_config.dart`
+
+```dart
+import 'dart:async';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+
+/// Backend URL from --dart-define.
+const backendUrl = String.fromEnvironment(
+  'SOLIPLEX_BACKEND_URL',
+  defaultValue: 'http://localhost:8000',
+);
+
+/// Fail fast if backend is unreachable.
+/// Uses /api/login which works in both no-auth and OIDC modes.
+Future<void> verifyBackendOrFail(String url) async {
+  try {
+    final res = await http
+        .get(Uri.parse('$url/api/login'))
+        .timeout(const Duration(seconds: 8));
+    if (res.statusCode != 200) {
+      fail('Backend returned ${res.statusCode} at $url/api/login');
+    }
+  } catch (e) {
+    fail('Backend unreachable at $url: $e');
+  }
+}
+
+/// Streaming-safe alternative to pumpAndSettle.
+/// Phase B upgrades to harness.waitForLog() where possible.
+Future<void> waitForCondition(
+  WidgetTester tester, {
+  required bool Function() condition,
+  required Duration timeout,
+  Duration step = const Duration(milliseconds: 200),
+  String? failureMessage,
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    await tester.pump(step);
+    if (condition()) return;
+  }
+  fail(failureMessage ?? 'Timed out after $timeout');
+}
+
+/// Workaround for Flutter macOS keyboard assertion bug.
+void ignoreKeyboardAssertions() {
+  final originalOnError = FlutterError.onError;
+  FlutterError.onError = (details) {
+    final msg = details.exception.toString();
+    if (msg.contains('_pressedKeys.containsKey') ||
+        msg.contains('KeyUpEvent is dispatched')) {
+      return;
+    }
+    originalOnError?.call(details);
+  };
+}
+```
+
+### Step 5: Create smoke test
+
+**File:** `integration_test/smoke_test.dart`
+
+```dart
+import 'package:patrol/patrol.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'patrol_test_config.dart';
+import 'test_log_harness.dart';
+
+// TODO: Import app root widget, shellConfigProvider, authProvider.
+// Confirm exact names from lib/core/providers/ and lib/main.dart.
+
+void main() {
+  late TestLogHarness harness;
+
+  patrolTest('smoke - backend reachable and app boots', ($) async {
+    await verifyBackendOrFail(backendUrl);
+    ignoreKeyboardAssertions();
+
+    // Initialize logging harness
+    harness = TestLogHarness();
+    final loggingOverrides = await harness.initialize();
+
+    try {
+      // TODO: Pump the real app with required provider overrides:
+      // - loggingOverrides (from harness)
+      // - shellConfigProvider.overrideWithValue(testConfig)
+      // - authProvider.overrideWith(_NoAuthNotifier.new)
+      //
+      // Confirm exact provider names and SoliplexConfig construction
+      // by reading lib/core/providers/ and lib/main.dart.
+
+      // TODO: Assert that a widget from the home/rooms screen renders.
+      // This proves the full boot sequence works with logging.
+
+    } catch (e) {
+      harness.dumpLogs(last: 50);
+      rethrow;
+    } finally {
+      harness.dispose();
+    }
+  });
+}
+```
+
+### Step 6: Verify
+
+- [ ] `flutter pub get` succeeds
+- [ ] `flutter analyze --fatal-infos` reports 0 issues
+- [ ] `patrol --version` outputs version
+- [ ] `patrol doctor` reports no blocking issues
+- [ ] Existing `flutter test` suite still passes
+- [ ] Smoke test passes:
+
+```bash
+patrol test --target integration_test/smoke_test.dart \
+  --dart-define SOLIPLEX_BACKEND_URL=http://localhost:8000
+```
+
+## Required Provider Overrides
+
+These must be resolved during implementation (read the source to confirm):
+
+| Provider | Why | Override With |
+|----------|-----|---------------|
+| `preloadedPrefsProvider` | App crashes without it | `SharedPreferences` mock (from harness) |
+| `memorySinkProvider` | Test needs access to MemorySink | Test-scoped instance (from harness) |
+| `shellConfigProvider` | App crashes without it | Test `SoliplexConfig` pointing at `backendUrl` |
+| `authProvider` | Must skip real auth in no-auth mode | `_NoAuthNotifier` (returns `NoAuthRequired`) |
+
+## Out of Scope
+
+- Any auth flow (deferred to Phase C)
+- Chat or room interaction tests (deferred to Phase B)
+- Logfire correlation, testRunId injection (deferred to Phase C)
+- Structured event vocabulary (deferred to Phase B)
+- Android/iOS configuration
+
+## Review Gate
+
+**Tool:** `mcp__gemini__read_files` with `gemini-3-pro-preview`
+
+**Files:** `pubspec.yaml`, `integration_test/test_log_harness.dart`,
+`integration_test/patrol_test_config.dart`,
+`integration_test/smoke_test.dart`,
+`lib/core/logging/logging_provider.dart`,
+`docs/planning/patrol/phase-a-setup-smoke.md`
+
+**Prompt:**
+
+```text
+Review the Patrol setup, TestLogHarness, and smoke test against Phase A spec.
+
+Check:
+1. Patrol deps are current and correctly placed in dev_dependencies
+2. integration_test SDK dependency is present
+3. TestLogHarness correctly initializes MemorySink and LogManager
+4. Provider overrides include preloadedPrefsProvider and memorySinkProvider
+5. verifyBackendOrFail uses /api/login (works in both auth modes)
+6. dumpLogs() called on failure for automatic diagnostics
+7. waitForLog() checks existing records before subscribing to stream
+8. Smoke test is minimal — boots app, checks one widget, dumps on failure
+
+Report PASS or list specific issues.
+```
+
+## Success Criteria
+
+- [ ] `patrol test` runs and produces a green test
+- [ ] TestLogHarness initializes logging with MemorySink
+- [ ] Failure automatically dumps last N log records to console
+- [ ] Backend preflight gives clear error when backend is down
+- [ ] Zero analyzer issues
+- [ ] Existing tests unaffected

--- a/docs/planning/patrol/phase-b-live-chat.md
+++ b/docs/planning/patrol/phase-b-live-chat.md
@@ -1,0 +1,157 @@
+# Phase B: Live Chat Tests (No-Auth)
+
+**Status:** pending
+**Depends on:** Phase A
+**Logging level:** 2-3 (event-driven waits + structured assertions)
+
+## Objective
+
+Two tests against a `--no-auth-mode` backend: room listing and chat message
+round-trip with streaming response. Tests use `harness.waitForLog()` for
+event-driven waits and `harness.expectLog()` to verify internal pipeline
+behavior — not just UI widgets.
+
+## Pre-flight Checklist
+
+- [ ] Confirm Phase A complete (smoke test passing with TestLogHarness)
+- [ ] Backend running in `--no-auth-mode` with at least one room configured
+- [ ] Identify exact widget types by reading source:
+  - Room list items (`RoomListTile` or equivalent)
+  - Chat input field (check Semantics label, likely "Chat message input")
+  - Send button (check tooltip, likely "Send message")
+  - Chat messages (`ChatMessageWidget` or equivalent)
+  - New conversation button (text is "New Conversation", NOT "New Chat")
+- [ ] Identify key log messages emitted by existing `Loggers.*` calls:
+  - `Loggers.http` — what does it log on request/response?
+  - `Loggers.activeRun` — what does it log on SSE connect, message, finish?
+  - `Loggers.room` — what does it log on room list load?
+
+## Deliverables
+
+1. `integration_test/live_chat_test.dart` — Two Patrol tests
+
+## Implementation Steps
+
+### Step 1: Implement rooms-load test
+
+**File:** `integration_test/live_chat_test.dart`
+
+- [ ] Import `patrol_test_config.dart`, `test_log_harness.dart`, app widgets
+- [ ] `patrolTest('rooms load from backend', ...)`
+- [ ] Initialize `TestLogHarness` and get provider overrides
+- [ ] Call `verifyBackendOrFail(backendUrl)`
+- [ ] Call `ignoreKeyboardAssertions()`
+- [ ] Pump test app with provider overrides (logging + no-auth + shellConfig)
+- [ ] Navigate through connect flow (tap Connect on HomeScreen) OR
+  override auth to skip directly to rooms — decide during implementation
+- [ ] Use `waitForCondition` to wait for room list to render
+- [ ] Assert at least one room list item widget is present
+- [ ] **White-box assertion:** `harness.expectLog('HTTP', 'GET /api/v1/rooms')`
+  to verify the HTTP call actually fired (not cached/stale data)
+- [ ] On failure: `harness.dumpLogs()` automatically shows what happened
+
+### Step 2: Implement chat send/receive test
+
+**File:** `integration_test/live_chat_test.dart`
+
+- [ ] `patrolTest('chat send and receive', ...)`
+- [ ] Initialize `TestLogHarness`, provider overrides, preflight, keyboard fix
+- [ ] Pump test app, navigate to rooms
+- [ ] Wait for room list, tap first room
+- [ ] Wait for chat view to render
+- [ ] Tap **"New Conversation"** button to create a fresh thread
+- [ ] Enter test message: `'patrol-test-${DateTime.now().millisecondsSinceEpoch}'`
+- [ ] Submit message (tap send button)
+- [ ] **Log-driven wait** (replaces `waitForCondition` polling):
+
+```dart
+// Wait for the SSE run to complete — exact and deterministic
+await harness.waitForLog('ActiveRun', 'RunFinished',
+    timeout: Duration(seconds: 30));
+await $.tester.pump();
+```
+
+- [ ] Assert response `ChatMessageWidget` contains non-empty text
+- [ ] **White-box assertions** to verify the full pipeline:
+
+```dart
+harness.expectLog('HTTP', 'POST /agui');        // thread/run created
+harness.expectLog('ActiveRun', 'SSE connected'); // stream opened
+harness.expectLog('ActiveRun', 'RunFinished');   // run complete
+```
+
+- [ ] Do NOT use `pumpAndSettle` anywhere
+- [ ] On failure: `harness.dumpLogs()` shows the full internal timeline
+
+### Step 3: Test isolation
+
+- Each test creates a fresh thread via "New Conversation"
+- Test messages include timestamp for uniqueness
+- Each test gets its own `TestLogHarness` instance (fresh MemorySink)
+- No explicit teardown needed (threads are cheap)
+
+### Step 4: Run and verify
+
+```bash
+patrol test --target integration_test/live_chat_test.dart \
+  --dart-define SOLIPLEX_BACKEND_URL=http://localhost:8000
+```
+
+- [ ] Both tests pass against no-auth backend
+- [ ] Log-driven waits are faster than fixed polling
+
+## Key Logging Assertions
+
+| Test | Log Assertion | Why |
+|------|--------------|-----|
+| rooms load | `HTTP` contains `GET /rooms` | Proves HTTP call fired, not cached |
+| chat send | `HTTP` contains `POST /agui` | Proves thread/run was created |
+| chat send | `ActiveRun` contains `SSE connected` | Proves stream was established |
+| chat send | `ActiveRun` contains `RunFinished` | Proves run completed (wait trigger) |
+
+## Out of Scope
+
+- Authentication (deferred to Phase C)
+- Tool calling tests (deferred)
+- Structured event attributes on production log calls (nice-to-have, not required)
+- Thread deletion/cleanup
+- Multiple room navigation
+- Error state testing
+
+## Review Gate
+
+**Tool:** `mcp__gemini__read_files` with `gemini-3-pro-preview`
+
+**Files:** `integration_test/live_chat_test.dart`,
+`integration_test/test_log_harness.dart`,
+`integration_test/patrol_test_config.dart`,
+`lib/core/logging/loggers.dart`,
+`docs/planning/patrol/phase-b-live-chat.md`
+
+**Prompt:**
+
+```text
+Review the live chat Patrol tests against the Phase B spec.
+
+Check:
+1. No pumpAndSettle used anywhere (streaming-safe)
+2. harness.waitForLog() used for SSE completion (not polling)
+3. harness.expectLog() verifies internal HTTP and ActiveRun pipeline
+4. harness.dumpLogs() called on failure for diagnostics
+5. Test messages include unique tokens for isolation
+6. Fresh TestLogHarness per test (clean MemorySink)
+7. Button text is "New Conversation" (not "New Chat")
+8. Tests are deterministic — log-driven waits eliminate races
+
+Report PASS or list specific issues.
+```
+
+## Success Criteria
+
+- [ ] Room list test loads rooms and verifies HTTP log
+- [ ] Chat test sends message, waits for `RunFinished` log, verifies response
+- [ ] Log-driven waits replace polling where possible
+- [ ] White-box assertions verify internal pipeline (HTTP, SSE, ActiveRun)
+- [ ] Failures auto-dump log history to console
+- [ ] Tests are isolated (unique tokens, fresh threads, fresh harness)
+- [ ] Zero analyzer issues

--- a/docs/planning/patrol/phase-c-oidc-ci.md
+++ b/docs/planning/patrol/phase-c-oidc-ci.md
@@ -1,0 +1,324 @@
+# Phase C: OIDC Authentication + CI Pipeline
+
+**Status:** pending
+**Depends on:** Phase B
+**Logging level:** 4-5 (Logfire correlation + CI failure artifacts)
+
+## Objective
+
+Add OIDC authentication via Keycloak ROPC token seeding, create a GitHub Actions
+workflow, and enable Logfire correlation so every test run is queryable
+server-side. On CI failure, automatically produce a diagnostic artifact bundle.
+
+## Auth Strategy: Token Seeding (Not $.native)
+
+We use **direct Keycloak ROPC (Resource Owner Password Credentials) token
+exchange** to obtain tokens, then inject them into the app's `AuthNotifier`
+via a `@visibleForTesting` method. This approach:
+
+- Bypasses `ASWebAuthenticationSession` (resists automation on macOS)
+- Works reliably in CI (no TCC permissions needed)
+- Tests the real authenticated app flow against the real backend
+- Does NOT test the login UI flow (deferred to future `$.native` hardening)
+
+## Keycloak Configuration
+
+The Keycloak client used for testing **must** have "Direct Access Grants"
+enabled:
+
+1. Open Keycloak Admin Console
+2. Navigate to: Clients → (your client) → Settings
+3. Set **"Direct Access Grants Enabled"** = ON
+4. Save
+
+This is often **disabled by default**. Without it, the ROPC token exchange
+returns a 400 error.
+
+### Test User Setup
+
+Provision a dedicated test user in Keycloak:
+
+1. Navigate to: Users → Add User
+2. Username: `patrol-test` (or similar)
+3. Set a password (disable "Temporary")
+4. Assign the user to a group/role that has access to at least one room
+
+## Pre-flight Checklist
+
+- [ ] Confirm Phase B complete (no-auth chat tests passing)
+- [ ] Keycloak "Direct Access Grants" enabled on test client
+- [ ] Keycloak test user provisioned with room access
+- [ ] Backend running with Keycloak auth (not `--no-auth-mode`)
+- [ ] `GET /api/login` returns at least one auth provider config
+- [ ] Review `lib/core/auth/auth_notifier.dart` for state injection point
+- [ ] Verify `AuthNotifier.build()` calls `_restoreSession()` async — injection
+  must wait until restore completes to avoid race condition
+
+## Deliverables
+
+1. `lib/core/auth/auth_notifier.dart` — Add `@visibleForTesting`
+   `injectTestTokens` method
+2. `integration_test/test_log_harness.dart` — Add Logfire correlation
+3. `integration_test/patrol_test_config.dart` — Add OIDC helpers
+4. `integration_test/authenticated_test.dart` — Authenticated rooms test
+5. `.github/workflows/patrol-integration.yml` — CI workflow
+
+## Implementation Steps
+
+### Step 1: Add test token injection to AuthNotifier
+
+**File:** `lib/core/auth/auth_notifier.dart`
+
+- [ ] Add a `@visibleForTesting` method that sets state to `Authenticated`:
+
+```dart
+@visibleForTesting
+void injectTestTokens({
+  required String accessToken,
+  required String refreshToken,
+  required String idToken,
+  required DateTime expiresAt,
+  required String issuerId,
+  required String issuerDiscoveryUrl,
+  required String clientId,
+}) {
+  state = Authenticated(
+    accessToken: accessToken,
+    refreshToken: refreshToken,
+    idToken: idToken,
+    expiresAt: expiresAt,
+    issuerId: issuerId,
+    issuerDiscoveryUrl: issuerDiscoveryUrl,
+    clientId: clientId,
+  );
+}
+```
+
+- [ ] **Race condition guard:** Ensure `_restoreSession()` has completed before
+  calling `injectTestTokens`. Options:
+  - Wait for auth state to leave `AuthLoading` before injection
+  - Add a `Completer` that signals when `build()` finishes
+
+### Step 2: Add Logfire correlation to TestLogHarness
+
+**File:** `integration_test/test_log_harness.dart`
+
+- [ ] Generate a `testRunId` (UUID) per test invocation
+- [ ] Wrap `LogManager.instance.sanitizer` to inject `testRunId` into every
+  `LogRecord.attributes` via `record.copyWith(attributes: {...})`:
+
+```dart
+class _TestCorrelationSanitizer implements LogSanitizer {
+  final String testRunId;
+  final LogSanitizer? inner;
+
+  _TestCorrelationSanitizer(this.testRunId, {this.inner});
+
+  @override
+  LogRecord sanitize(LogRecord record) {
+    var processed = inner?.sanitize(record) ?? record;
+    return processed.copyWith(attributes: {
+      ...processed.attributes,
+      'testRunId': testRunId,
+    });
+  }
+}
+```
+
+- [ ] Enable `BackendLogSink` when `--dart-define SOLIPLEX_SHIP_LOGS=true`
+- [ ] Add `dumpArtifactBundle(String testName)` method that writes:
+  - `logs.jsonl` — all MemorySink records as JSON
+  - `breadcrumbs.json` — last 20 records before failure
+  - `metadata.json` — testRunId, device, timestamps, test name
+
+### Step 3: Add OIDC helpers to test config
+
+**File:** `integration_test/patrol_test_config.dart`
+
+- [ ] Add compile-time constants for OIDC credentials:
+
+```dart
+const oidcUsername = String.fromEnvironment('SOLIPLEX_OIDC_USERNAME');
+const oidcPassword = String.fromEnvironment('SOLIPLEX_OIDC_PASSWORD');
+const shipLogs = bool.fromEnvironment('SOLIPLEX_SHIP_LOGS');
+```
+
+- [ ] Add `fetchOidcConfig(String backendUrl)` — fetches provider config from
+  `GET /api/login`, returns `serverUrl`, `clientId`, `scope`
+- [ ] Add `seedAuthTokens(PatrolTester $)` — performs ROPC token exchange with
+  Keycloak and injects tokens into `AuthNotifier` via `injectTestTokens`
+- [ ] Derive token endpoint from OIDC discovery
+  (`serverUrl/.well-known/openid-configuration`) rather than hardcoding
+  Keycloak-specific paths
+
+### Step 4: Create authenticated test
+
+**File:** `integration_test/authenticated_test.dart`
+
+- [ ] `patrolTest('authenticated rooms load', ...)`
+- [ ] Initialize `TestLogHarness` with `testRunId` for Logfire correlation
+- [ ] Call `verifyBackendOrFail(backendUrl)`
+- [ ] Pump app with **in-memory auth storage** override (prevents Keychain
+  state leaks from stale tokens)
+- [ ] Wait for auth state to leave `AuthLoading` (restore completes)
+- [ ] Call `seedAuthTokens($)` to obtain and inject ROPC tokens
+- [ ] Use `harness.waitForLog('HTTP', 'GET /rooms')` to detect room load
+- [ ] Assert at least one room is present
+- [ ] **White-box:** `harness.expectLog('Auth', 'Authenticated')` to verify
+  token injection worked
+- [ ] On failure: `harness.dumpArtifactBundle('authenticated_rooms_load')`
+
+### Step 5: Create CI workflow
+
+**File:** `.github/workflows/patrol-integration.yml`
+
+```yaml
+name: Patrol Integration Tests
+
+on:
+  push:
+    branches: [main, feat/patrol-integration]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  integration-test:
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install Patrol CLI
+        run: |
+          dart pub global activate patrol_cli
+          echo "$HOME/.pub-cache/bin" >> $GITHUB_PATH
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Install CocoaPods
+        run: pod install --project-directory=macos
+
+      - name: Backend health check
+        env:
+          BACKEND_URL: ${{ secrets.STAGING_BACKEND_URL }}
+        run: |
+          curl -f -s --connect-timeout 10 \
+            "$BACKEND_URL/api/login" || \
+            (echo "::error::Backend unreachable at $BACKEND_URL" && exit 1)
+
+      - name: Run Patrol tests
+        run: |
+          patrol test \
+            --target integration_test/ \
+            --dart-define SOLIPLEX_BACKEND_URL=${{ secrets.STAGING_BACKEND_URL }} \
+            --dart-define SOLIPLEX_OIDC_USERNAME=${{ secrets.OIDC_TEST_USERNAME }} \
+            --dart-define SOLIPLEX_OIDC_PASSWORD=${{ secrets.OIDC_TEST_PASSWORD }} \
+            --dart-define SOLIPLEX_SHIP_LOGS=true
+
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: patrol-failure-bundle
+          path: |
+            build/patrol/screenshots/
+            build/patrol/logs/
+          retention-days: 7
+```
+
+### Step 6: Document required GitHub secrets
+
+| Secret | Description |
+|--------|-------------|
+| `STAGING_BACKEND_URL` | Backend URL with Keycloak auth enabled |
+| `OIDC_TEST_USERNAME` | Keycloak test user username |
+| `OIDC_TEST_PASSWORD` | Keycloak test user password |
+
+### Step 7: Run and verify
+
+```bash
+# Local (authenticated, with Logfire shipping)
+patrol test --target integration_test/authenticated_test.dart \
+  --dart-define SOLIPLEX_BACKEND_URL=http://localhost:8000 \
+  --dart-define SOLIPLEX_OIDC_USERNAME=patrol-test \
+  --dart-define SOLIPLEX_OIDC_PASSWORD=testpass \
+  --dart-define SOLIPLEX_SHIP_LOGS=true
+
+# Verify no-auth tests still pass
+patrol test --target integration_test/smoke_test.dart \
+  --dart-define SOLIPLEX_BACKEND_URL=http://localhost:8000
+
+# Verify testRunId appears in Logfire
+# Search: testRunId="<uuid from test output>"
+```
+
+## Logfire Correlation
+
+When `SOLIPLEX_SHIP_LOGS=true`:
+
+1. `TestLogHarness` generates a `testRunId` (UUID) and prints it to console
+2. Every `LogRecord` gets `testRunId` injected via sanitizer
+3. `BackendLogSink` ships records to backend → Logfire
+4. In Logfire, query `testRunId="<uuid>"` to see:
+   - All client-side logs (HTTP, auth, router, activeRun)
+   - All server-side logs (if backend also tags with the ID via HTTP header)
+   - Full distributed timeline of the test run
+
+## Out of Scope
+
+- `$.native` browser automation (deferred to hardening phase)
+- Tool calling tests (add after auth is stable)
+- Token refresh testing (unit-tested separately)
+- Logout/re-auth flow
+- iOS/Android CI runners
+- `runStep()` instrumentation (deferred to future)
+- Performance regression detection (deferred to future)
+
+## Review Gate
+
+**Tool:** `mcp__gemini__read_files` with `gemini-3-pro-preview`
+
+**Files:** `lib/core/auth/auth_notifier.dart`,
+`integration_test/test_log_harness.dart`,
+`integration_test/patrol_test_config.dart`,
+`integration_test/authenticated_test.dart`,
+`.github/workflows/patrol-integration.yml`,
+`lib/core/logging/logging_provider.dart`,
+`docs/planning/patrol/phase-c-oidc-ci.md`
+
+**Prompt:**
+
+```text
+Review the OIDC token seeding, Logfire correlation, and CI pipeline
+against the Phase C spec.
+
+Check:
+1. injectTestTokens uses @visibleForTesting correctly
+2. Race condition with _restoreSession() is addressed
+3. TestCorrelationSanitizer injects testRunId into LogRecord.attributes
+4. testRunId flows through BackendLogSink to Logfire
+5. ROPC token endpoint derived from OIDC discovery (not hardcoded)
+6. CI workflow includes CocoaPods install step
+7. CI uploads both screenshots and log artifacts on failure
+8. SOLIPLEX_SHIP_LOGS flag controls BackendLogSink in tests
+9. Credentials passed via --dart-define (not hardcoded)
+
+Report PASS or list specific issues.
+```
+
+## Success Criteria
+
+- [ ] Authenticated test passes against Keycloak-protected backend
+- [ ] ROPC token exchange works with "Direct Access Grants" enabled
+- [ ] `testRunId` appears in Logfire when `SOLIPLEX_SHIP_LOGS=true`
+- [ ] Failure artifact bundle produced (logs.jsonl, breadcrumbs, metadata)
+- [ ] No-auth tests still pass (no regressions)
+- [ ] CI workflow syntax is valid
+- [ ] Zero analyzer issues

--- a/docs/planning/patrol/phase-d-log-hardening.md
+++ b/docs/planning/patrol/phase-d-log-hardening.md
@@ -1,0 +1,213 @@
+# Phase D: Log-Driven Test Hardening
+
+**Status:** pending
+**Depends on:** Phase C
+**Logging level:** 5-7 (error sentinels, performance bounds, structured audit)
+
+## Objective
+
+Exploit the full `soliplex_logging` subsystem in Patrol tests. Phases A-C
+used only 4 of 9 available loggers, never checked log levels, and ignored
+timestamps. Phase D turns every silent failure into a test failure and
+establishes performance baselines.
+
+## Current Logging Coverage (Post Phase C)
+
+| Logger | Used | How |
+|--------|------|-----|
+| `Auth` | No | - |
+| `HTTP` | Partial | Route path assertions only |
+| `ActiveRun` | Yes | Lifecycle events (RUN_STARTED, TEXT_START, RUN_FINISHED) |
+| `Chat` | No | - |
+| `Room` | Partial | "Rooms loaded:" assertion only |
+| `Router` | Partial | "redirect called" assertion only |
+| `Quiz` | No | - |
+| `Config` | No | - |
+| `UI` | No | - |
+
+### Unused LogRecord Fields
+
+- `level` — never checked (error vs warning vs info)
+- `timestamp` — never used for timing
+- `error` / `stackTrace` — never inspected
+- Negative assertions — never assert something was NOT logged
+- Count-based assertions — never check occurrence counts
+
+## Deliverables
+
+### 1. Error Sentinel — `expectNoErrors()`
+
+Add to `TestLogHarness`:
+
+```dart
+void expectNoErrors({List<String> allowedPatterns = const []}) {
+  final errors = sink.records.where((r) => r.level >= LogLevel.error);
+  final unexpected = errors.where(
+    (r) => !allowedPatterns.any((p) => r.message.contains(p)),
+  );
+  if (unexpected.isNotEmpty) {
+    dumpLogs(last: 50);
+    fail(
+      '${unexpected.length} unexpected error(s):\n'
+      '${unexpected.map((r) => '  [${r.loggerName}] ${r.message}').join('\n')}',
+    );
+  }
+}
+```
+
+**Apply to:** Every test's `finally` block. Catches `LateInitializationError`,
+unhandled exceptions, and any silent crash that swallows errors.
+
+### 2. Auth Lifecycle Assertions (OIDC test)
+
+Verify the `Auth` logger shows the expected state path:
+
+- **No-auth tests:** `expectNoLog('Auth', ...)` — auth logger should be silent
+  (proves `NoAuthNotifier` bypass is clean)
+- **OIDC test:** `expectLog('Auth', 'Authenticated')` or verify auth state
+  was set without triggering `_restoreSession`
+- **Negative:** `expectNoLog('Auth', 'restore')` — proves
+  `PreAuthenticatedNotifier` skipped the restore path
+
+### 3. HTTP Audit Assertions
+
+Assert no unexpected HTTP error responses during a test:
+
+```dart
+void expectNoHttpErrors({List<int> allowedStatuses = const [404]}) {
+  final httpErrors = sink.records.where(
+    (r) => r.loggerName == 'HTTP' && _isHttpError(r.message),
+  );
+  // ...
+}
+```
+
+- No 401/403 in OIDC test (proves Bearer token valid throughout)
+- No 5xx in any test (backend health)
+
+### 4. Performance Bounds
+
+Measure time between log events and fail if outside bounds:
+
+```dart
+Duration measureLogDelta(String startLogger, String startPattern,
+    String endLogger, String endPattern) {
+  final start = sink.records.firstWhere(
+    (r) => r.loggerName == startLogger && r.message.contains(startPattern),
+  );
+  final end = sink.records.firstWhere(
+    (r) => r.loggerName == endLogger && r.message.contains(endPattern),
+  );
+  return end.timestamp.difference(start.timestamp);
+}
+```
+
+Use cases:
+
+- `RUN_STARTED` to `RUN_FINISHED` < 30s (detect backend regressions)
+- Room load time (HTTP request to "Rooms loaded") < 5s
+- App boot to Router redirect < 3s
+
+### 5. Negative Assertions — `expectNoLog()`
+
+Add to `TestLogHarness`:
+
+```dart
+void expectNoLog(String loggerName, String messagePattern) {
+  final found = sink.records.any(
+    (r) => r.loggerName == loggerName && r.message.contains(messagePattern),
+  );
+  if (found) {
+    dumpLogs(last: 30);
+    fail('Unexpected log found: [$loggerName] containing "$messagePattern"');
+  }
+}
+```
+
+Use cases:
+
+- `expectNoLog('Auth', 'LateInitializationError')` — in OIDC test
+- `expectNoLog('Auth', 'Unhandled restore error')` — in all tests
+- `expectNoLog('HTTP', '401')` — in OIDC test
+
+### 6. Config Logger Assertions
+
+Verify the app picked up the correct runtime configuration:
+
+- `expectLog('Config', backendUrl)` — proves dart-define reached the app
+- Useful for CI where misconfigured env vars silently use defaults
+
+### 7. HTTP Inspector Navigation Test
+
+Navigate to the Network Inspector screen and exercise the UI filters — a "meta"
+test that validates the log viewer itself:
+
+- Tap `Network Requests` tile in settings (text: `'Network Requests'`)
+- Verify `'Requests (N)'` header shows a non-zero count
+- Tap an `HttpEventTile` to open request detail
+- Cycle through all 3 tabs: `'Request'`, `'Response'`, `'curl'`
+- Verify the curl tab contains a copyable command
+- Tap `'Clear all requests'` button and verify the list empties
+
+Widget finders:
+
+| Target | Finder |
+|--------|--------|
+| Network Requests tile | `find.text('Network Requests')` |
+| Request count header | `find.textContaining('Requests (')` |
+| Request tile | `find.byType(HttpEventTile)` |
+| Tab: Request | `find.text('Request')` |
+| Tab: Response | `find.text('Response')` |
+| Tab: curl | `find.text('curl')` |
+| Clear button | `find.byTooltip('Clear all requests')` |
+| Empty state | `find.text('No HTTP requests yet')` |
+
+## Implementation Order
+
+| Step | Deliverable | Files | Effort |
+|------|-------------|-------|--------|
+| 1 | `expectNoErrors()` + apply to all tests | `test_log_harness.dart`, all `*_test.dart` | Small |
+| 2 | `expectNoLog()` + negative assertions | `test_log_harness.dart`, `oidc_test.dart` | Small |
+| 3 | Auth lifecycle assertions | `oidc_test.dart`, `smoke_test.dart` | Small |
+| 4 | HTTP audit assertions | `test_log_harness.dart`, `oidc_test.dart` | Medium |
+| 5 | `measureLogDelta()` + perf bounds | `test_log_harness.dart`, `live_chat_test.dart` | Medium |
+| 6 | Config logger assertions | `smoke_test.dart` | Small |
+| 7 | HTTP Inspector navigation test | `settings_test.dart` | Medium |
+
+## Review Gate
+
+| Gate | Tool | What |
+|------|------|------|
+| **Automated** | CLI | `flutter analyze` = 0, all 6 patrol tests green |
+| **Sentinel** | Manual | Inject a deliberate `Loggers.auth.error(...)` call and verify `expectNoErrors()` catches it |
+| **Perf** | Manual | Verify `measureLogDelta` produces reasonable values against live backend |
+
+## Prerequisite: Structured HTTP Status Logging
+
+The `HTTP` logger currently logs `debug('200 response')` — the status code is
+embedded in a free-text message with no structured field. This makes it hard to
+grep for 401/403 errors programmatically.
+
+**Action:** Update `http_log_provider.dart` to include the status code as a
+parseable prefix or add it to a structured log field:
+
+```dart
+// Before:
+Loggers.http.debug('${event.statusCode} response');
+
+// After:
+Loggers.http.debug('HTTP ${event.statusCode} ${event.method} ${event.uri}');
+```
+
+This gives `expectNoLog('HTTP', 'HTTP 401')` a reliable pattern to match.
+
+## Risks
+
+- **False positives from `expectNoErrors()`** — some `error`-level logs may be
+  expected (e.g., keychain unavailable in debug builds). Mitigated by
+  `allowedPatterns` parameter.
+- **Flaky perf bounds** — backend response times vary. Use generous thresholds
+  (3x normal) and focus on detecting regressions, not absolute targets.
+- **Log format coupling** — assertions depend on log message strings. If
+  `Loggers.*` messages change, tests break. Acceptable tradeoff for white-box
+  observability.

--- a/docs/planning/patrol/phase-e-agent-loop.md
+++ b/docs/planning/patrol/phase-e-agent-loop.md
@@ -1,0 +1,250 @@
+# Phase E: Agent-in-the-Loop Testing
+
+**Status:** draft
+**Depends on:** Phase D (Log Hardening)
+
+## Objective
+
+Enable an AI agent to run, observe, diagnose, and fix Patrol E2E tests
+through Soliplex's own chat UI. The app tests itself through a "Test Runner"
+room backed by the same pydantic\_ai agent infrastructure that powers all
+other rooms.
+
+## Soliplex Room Architecture (Context)
+
+Every Soliplex room is defined in `~/dev/soliplex/example/rooms/<id>/`:
+
+```yaml
+# room_config.yaml
+id: "patrol"
+name: "Patrol Test Runner"
+agent:
+  template_id: "default_chat"
+  system_prompt: "./prompt.txt"
+tools:
+  - tool_name: "soliplex.tools.run_patrol_test"   # native Python tool
+  - tool_name: "soliplex.tools.read_test_file"
+mcp_client_toolsets:
+  dart_tools:                                       # dart-tools MCP server
+    kind: "stdio"
+    command: "dart"
+    args: ["run", "dart_mcp_server"]
+```
+
+Tools are async Python functions registered via `tool_name` paths. The agent
+(pydantic\_ai) calls them during conversation and streams results via AG-UI
+`text_delta` events. MCP toolsets are wired in directly — the dart-tools
+server becomes available as tools the agent can call.
+
+## Key Architectural Decision: Skill-First, Room-Second
+
+The **Patrol skill** (`.claude/skills/patrol/SKILL.md`) documents the
+patterns. The room's system prompt references the same knowledge. This means:
+
+- The skill works standalone (Claude Code CLI) when the app is broken
+- The room adds AG-UI chat streaming on top
+- Both share the same test patterns and troubleshooting knowledge
+
+```text
++-------------------+     +--------------------+
+| Claude Code CLI   |     | Patrol Room (UI)   |
+| (skill-first)     |     | (AG-UI streaming)  |
++--------+----------+     +--------+-----------+
+         |                          |
+         v                          v
++--------+----------+     +--------+-----------+
+| patrol CLI        |     | pydantic_ai Agent  |
+| dart-tools MCP    |     |  + native tools    |
+| file edit         |     |  + dart-tools MCP  |
++-------------------+     +--------------------+
+         |                          |
+         v                          v
++------------------------------------------------+
+|              Test App Instance                  |
+|        (spawned by patrol / MCP launch)         |
++------------------------------------------------+
+```
+
+## Two-App Model
+
+Patrol owns the test app's VM service during execution. Concurrent MCP
+attachment would create contention. Therefore:
+
+- **Control App**: Instance the user chats in
+- **Test App**: Ephemeral instance spawned by `patrol test`
+- **MCP inspection is post-mortem**: After failure, agent launches a fresh
+  app via `test_driver/app.dart` for interactive debugging
+
+## Milestones
+
+### v1 — Run and Report (MVP)
+
+Agent runs tests and streams results to the chat room.
+
+**Room config:**
+
+```yaml
+# ~/dev/soliplex/example/rooms/patrol/room_config.yaml
+id: "patrol"
+name: "Patrol Test Runner"
+description: "Run and debug E2E tests from chat"
+suggestions:
+  - "Run the settings test"
+  - "Run all no-auth tests"
+  - "What tests are available?"
+agent:
+  template_id: "default_chat"
+  system_prompt: "./prompt.txt"
+tools:
+  - tool_name: "soliplex.patrol_tools.patrol_run"
+```
+
+**Native tool** (`soliplex/patrol_tools.py`) — prototype implemented:
+
+- Allowlist validation blocks shell injection via chat
+- Returns `ToolReturn` with `StateDeltaEvent` updating `state.patrol`
+- OIDC credentials from environment variables (room secrets)
+- `PATROL_CLI` and `FLUTTER_PROJECT` configurable via env vars
+- See `~/dev/soliplex/src/soliplex/patrol_tools.py` for implementation
+
+The agent receives the tool result and streams it to chat via AG-UI. The
+pydantic\_ai framework handles the `text_delta` streaming automatically —
+the tool just returns a string.
+
+**System prompt** (`prompt.txt`):
+
+```text
+You are the Patrol Test Runner for the Soliplex Flutter app.
+
+Available tests:
+- smoke_test.dart — app boot, log harness (no-auth, localhost:8000)
+- live_chat_test.dart — rooms, chat send/receive (no-auth, localhost:8000)
+- settings_test.dart — settings tiles, network log viewer (no-auth)
+- oidc_test.dart — OIDC auth via ROPC (requires credentials)
+
+When asked to run a test, use the patrol_run tool with the target filename.
+Report results clearly: which tests passed, which failed, and why.
+```
+
+**Example interaction:**
+
+```text
+User: run the settings test
+Agent: Running settings_test.dart... [calls patrol_run tool]
+Agent: Both tests in settings_test.dart PASSED:
+  - settings - navigate and verify tiles (6.1s)
+  - settings - network log viewer tabs (8.3s)
+```
+
+### v2 — Diagnose via MCP
+
+Wire the dart-tools MCP server into the room for post-mortem inspection.
+
+**Room config addition:**
+
+```yaml
+mcp_client_toolsets:
+  dart_tools:
+    kind: "stdio"
+    command: "dart"
+    args: ["run", "dart_mcp_server"]
+    env:
+      DART_TOOLING_DAEMON_PORT: "0"
+```
+
+This gives the agent access to `launch_app`, `flutter_driver` (screenshot,
+tap, get\_widget\_tree), `hot_reload`, and `get_runtime_errors` — all as
+callable tools during conversation.
+
+**New deliverables:**
+
+1. **Post-mortem inspection** — on failure, agent uses MCP to launch app
+   via `test_driver/app.dart`, navigates to the failure point, takes a
+   screenshot, and sends the image in chat
+2. **Widget tree analysis** — agent inspects `get_widget_tree` to diagnose
+   finder mismatches (e.g., "the Back button tooltip matches the
+   inspector's back-to-settings, not a detail page back")
+3. **Log correlation** — agent reads MemorySink dump from test output and
+   identifies where behavior diverged
+
+### v3 — Self-Healing
+
+Add file read/write tools and guardrails for autonomous fixes.
+
+**Additional tools:**
+
+```yaml
+tools:
+  - tool_name: "soliplex.tools.patrol_run"
+  - tool_name: "soliplex.tools.patrol_read_file"
+  - tool_name: "soliplex.tools.patrol_write_file"
+```
+
+**Guardrails:**
+
+1. `patrol_write_file` restricted to `integration_test/` and
+   `.claude/skills/` paths only
+2. Agent shows diff in chat, waits for user confirmation
+3. Max 2 fix-and-retry attempts per session
+4. Rollback if other tests regress after a fix
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| App broken, room UI fails | High | Skill-first: CLI fallback works standalone |
+| Infinite fix-fail loop | Medium | Max 2 retries per command |
+| Port conflicts | Medium | Test app uses `--dart-define` isolation |
+| MCP contention during test | High | Post-mortem only (v2) |
+| Unsafe code mutation | High | Scope restriction + diff preview + rollback |
+| Shell injection via chat | High | `patrol_run` tool validates `target` against allowlist |
+| Dev-only feature leaks | Low | Room only loaded when `SOLIPLEX_DEV_MODE=true` |
+
+## Review Gates
+
+### v1 Gate
+
+| Gate | Criteria |
+|------|----------|
+| **Room loads** | Patrol room appears in room list, agent responds to messages |
+| **Tool call** | "Run smoke test" triggers `patrol_run` tool, output streams to chat |
+| **Pass/Fail** | Agent correctly reports pass/fail status from tool result |
+
+### v2 Gate
+
+| Gate | Criteria |
+|------|----------|
+| **MCP wired** | dart-tools MCP toolset available in room agent |
+| **Screenshot** | Agent takes screenshot of running app and shows in chat |
+| **Diagnosis** | Agent uses widget tree to explain a finder mismatch |
+
+### v3 Gate
+
+| Gate | Criteria |
+|------|----------|
+| **Diff preview** | Agent shows proposed edit before writing |
+| **Scope guard** | Agent refuses to modify `lib/` without explicit approval |
+| **Green** | Agent fixes a finder error and re-runs to green |
+
+## Resolved Questions
+
+1. **dart-tools MCP stdio launch**: `dart mcp-server`. Room config:
+
+   ```yaml
+   mcp_client_toolsets:
+     dart_tools:
+       kind: "stdio"
+       command: "dart"
+       args: ["mcp-server"]
+   ```
+
+2. **AG-UI image support**: Yes — screenshots stream as inline images
+   via `STATE_DELTA` events from the server.
+3. **Tool output streaming**: Yes — use `STATE_DELTA` events to stream
+   partial stdout during long-running `patrol test` (30-60s) instead of
+   blocking until completion. **Prototype required** to validate the
+   pydantic\_ai tool → AG-UI state delta pipeline.
+4. **OIDC room credentials**: Environment variables. Soliplex rooms have
+   a mechanism to inject secrets into room config from the installation
+   environment. The `patrol_run` tool reads credentials from env vars
+   and passes them as `--dart-define` flags.


### PR DESCRIPTION
## Summary
- Planning documents for the 5-phase Patrol E2E integration test strategy
- Covers setup/smoke (A), live chat (B), OIDC (C), log hardening (D), agent-in-loop (E)
- Includes client-side tool calling plan for Phase E

## Changes
- **docs/planning/patrol/**: OVERVIEW, PLAN, per-phase specs (A-E)
- **docs/planning/patrol/client-tools-plan.md**: Client-side tool execution design
- **docs/patrol-analysis.md**: Patrol analysis summary

## Test plan
- [x] Docs only — no code changes
- [x] Markdown lint clean

Replaces the docs portion of #235. Code changes split into per-phase PRs.