### PR TITLE
feat(patrol): Phase B — live chat tests + patrol skill

### DIFF
--- a/.claude/skills/patrol/SKILL.md
+++ b/.claude/skills/patrol/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: patrol
+description: Run Patrol E2E integration tests on macOS. Use when writing, running, or debugging Patrol tests.
+argument-hint: "[test-file|all]"
+allowed-tools: Bash, Read, Edit, Write, Glob, Grep
+---
+
+# Patrol E2E Test Skill
+
+Run and manage Patrol integration tests for this Flutter macOS project.
+
+## Running Tests
+
+**CLI location:** `patrol`
+
+Always use `--device macos` to avoid the interactive device selection prompt:
+
+```bash
+# Run a specific test file
+patrol test \
+  --device macos \
+  --target integration_test/$ARGUMENTS \
+  --dart-define SOLIPLEX_BACKEND_URL=http://localhost:8000
+
+# Run all integration tests
+patrol test \
+  --device macos \
+  --target integration_test/ \
+  --dart-define SOLIPLEX_BACKEND_URL=http://localhost:8000
+```
+
+If `$ARGUMENTS` is empty or "all", run against `integration_test/` (all tests).
+If `$ARGUMENTS` is a filename like `smoke_test.dart`, run that specific file.
+
+## Pre-flight Checks
+
+Before running tests, verify:
+
+1. **Backend is running** in `--no-auth-mode` at the URL above
+2. **patrol CLI is installed**: `patrol --version`
+3. **Code compiles**: Run `dart analyze integration_test/` first
+4. **test_bundle.dart is current**: Patrol auto-generates this — if tests are missing from the bundle, delete it and let `patrol test` regenerate
+
+## macOS-Specific Constraints
+
+### Window size is fixed (~800x600)
+
+The macOS test window runs BELOW the 840px desktop breakpoint (`SoliplexBreakpoints.desktop`). This means:
+
+- **HistoryPanel renders in the drawer**, not as an inline sidebar
+- `WidgetTester.setSurfaceSize()` does NOT work in integration tests (real macOS window, not test binding)
+- To access drawer content, tap the hamburger menu icon first
+- After tapping a button inside a drawer, the drawer does NOT auto-close
+
+**Strategy:** Avoid drawer interactions when possible. The ChatPanel body renders regardless of drawer state, and threads auto-select when entering a room.
+
+### Entitlements
+
+Both the app AND the test runner need their own entitlements:
+
+| Binary | Entitlements file | Required keys |
+|--------|-------------------|---------------|
+| Runner (app) | `macos/Runner/DebugProfile.entitlements` | `network.client`, `network.server` |
+| RunnerUITests | `macos/RunnerUITests/RunnerUITests.entitlements` | `network.client`, `network.server`, `app-sandbox` |
+
+**Debugging:** `codesign -d --entitlements :- <path-to-binary>` shows actual signed entitlements.
+
+**After changing entitlements**, re-approve Accessibility permissions in System Settings.
+
+### Keyboard assertions
+
+macOS has a Flutter keyboard assertion bug. All tests must call `ignoreKeyboardAssertions()` early.
+
+## Test Patterns
+
+### Never use pumpAndSettle
+
+SSE streams prevent settling. Use these instead:
+
+1. **`waitForCondition`** — polling-based, for UI states
+2. **`harness.waitForLog`** — stream-based, for async events (preferred)
+3. **`tester.pump(duration)`** — fixed delays, only for brief rendering pauses
+
+### Standard test structure
+
+```dart
+patrolTest('description', ($) async {
+  await verifyBackendOrFail(backendUrl);
+  ignoreKeyboardAssertions();
+
+  final harness = TestLogHarness();
+  await harness.initialize();
+
+  try {
+    await pumpTestApp($, harness);
+    // ... test body ...
+  } catch (e) {
+    harness.dumpLogs(last: 50);
+    rethrow;
+  } finally {
+    harness.dispose();
+  }
+});
+```
+
+### Widget finders reference
+
+| Target | Finder |
+|--------|--------|
+| Room list items | `find.byType(RoomListTile)` |
+| Chat input | `find.byType(TextField)` |
+| Send button | `find.byTooltip('Send message')` |
+| Chat messages | `find.byType(ChatMessageWidget)` |
+| Settings icon | `find.byIcon(Icons.settings)` |
+
+**Avoid** `find.bySemanticsLabel` for text entry — it can resolve to the Semantics wrapper instead of the TextField, causing `enterText` to fail.
+
+### Log patterns for assertions
+
+| Logger | Pattern | Meaning |
+|--------|---------|---------|
+| `Router` | `redirect called` | App booted, router active |
+| `HTTP` | `/api/v1/rooms` | Rooms API called |
+| `Room` | `Rooms loaded:` | Rooms parsed successfully |
+| `ActiveRun` | `RUN_STARTED` | AG-UI SSE stream opened |
+| `ActiveRun` | `TEXT_START:` | First text chunk received |
+| `ActiveRun` | `RUN_FINISHED` | SSE stream completed |
+
+## Debugging: Two-Phase Workflow
+
+### Phase 1: Discover (dart MCP — `flutter run`)
+
+Use `mcp__dart-tools__launch_app` to start the app, then inspect the live
+widget tree and logs to find the right finders and log patterns for your test.
+
+```text
+mcp__dart-tools__launch_app   → starts app, returns DTD URI
+mcp__dart-tools__connect_dart_tooling_daemon → connect to running app
+mcp__dart-tools__get_widget_tree(summaryOnly: true) → see real widget hierarchy
+mcp__dart-tools__get_app_logs(pid, maxLines: 50)    → see stdout log output
+mcp__dart-tools__get_runtime_errors                  → check for exceptions
+```
+
+Stdout logs appear as `[DEBUG] Router: redirect called for /` — use these
+to identify the logger name and message pattern for `harness.expectLog()`.
+
+The widget tree shows actual `widgetRuntimeType` values — use these for
+`find.byType()` finders.
+
+### Phase 2: Assert (TestLogHarness — patrol run)
+
+Patrol launches the app through xcodebuild, which does **not** expose a
+DTD URI. The dart MCP tools cannot connect during a patrol test run.
+
+Instead, all test assertions use **`TestLogHarness`** which captures logs
+in-process via `MemorySink`:
+
+- `harness.expectLog('Router', 'redirect called')` — synchronous check
+- `harness.waitForLog('ActiveRun', 'RUN_FINISHED')` — stream-based wait
+- `harness.dumpLogs(last: 50)` — dump to console on failure
+
+The harness sees the same `[DEBUG]` logs that appear in `get_app_logs`,
+but accessed in-process rather than via stdout.
+
+## Git Worktree Caveat
+
+This repo is a git worktree. Pre-commit hooks that invoke `flutter`/`dart` must `unset GIT_DIR` first, otherwise Flutter reports version `0.0.0-unknown`. Wrapper scripts in `scripts/` handle this.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| "Multiple devices found" prompt | Missing `--device` flag | Add `--device macos` |
+| `command not found: patrol` | Not on PATH | Use full path `patrol` |
+| Test hangs on "Waiting for app" | Entitlements missing/wrong | Check both Runner and RunnerUITests entitlements |
+| `0.0.0-unknown` version | GIT_DIR set in worktree | Use `scripts/flutter-analyze.sh` wrapper |
+| "did not appear within 10s" | Widget in drawer, not body | Check if window < 840px breakpoint |
+| `Bad state: No element` on enterText | Finder matched Semantics, not TextField | Use `find.byType(TextField)` instead |
+| Accessibility permission denied | Entitlements changed | Re-approve in System Settings > Privacy > Accessibility |

--- a/integration_test/live_chat_test.dart
+++ b/integration_test/live_chat_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:patrol/patrol.dart';
+import 'package:soliplex_frontend/features/chat/widgets/chat_message_widget.dart';
+import 'package:soliplex_frontend/features/rooms/widgets/room_list_tile.dart';
+
+import 'patrol_helpers.dart';
+import 'patrol_test_config.dart';
+import 'test_log_harness.dart';
+
+void main() {
+  late TestLogHarness harness;
+
+  patrolTest('rooms - load from backend', ($) async {
+    await verifyBackendOrFail(backendUrl);
+    ignoreKeyboardAssertions();
+
+    harness = TestLogHarness();
+    await harness.initialize();
+
+    try {
+      await pumpTestApp($, harness);
+
+      // Wait for room list to render (router redirects / → /rooms).
+      await waitForCondition(
+        $.tester,
+        condition: () => $.tester.any(find.byType(RoomListTile)),
+        timeout: const Duration(seconds: 10),
+        failureMessage: 'RoomListTile did not appear within 10s',
+      );
+
+      expect(find.byType(RoomListTile), findsWidgets);
+
+      // White-box: verify HTTP call and room loading via logs.
+      harness
+        ..expectLog('HTTP', '/api/v1/rooms')
+        ..expectLog('Room', 'Rooms loaded:');
+
+      // Pump extra frames for macOS rendering.
+      await $.tester.pump(const Duration(seconds: 1));
+    } catch (e) {
+      harness.dumpLogs(last: 50);
+      rethrow;
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  patrolTest('chat - send message and receive response', ($) async {
+    await verifyBackendOrFail(backendUrl);
+    ignoreKeyboardAssertions();
+
+    harness = TestLogHarness();
+    await harness.initialize();
+
+    try {
+      await pumpTestApp($, harness);
+
+      // Wait for rooms to load.
+      await waitForCondition(
+        $.tester,
+        condition: () => $.tester.any(find.byType(RoomListTile)),
+        timeout: const Duration(seconds: 10),
+        failureMessage: 'RoomListTile did not appear within 10s',
+      );
+
+      // Tap the first room to navigate to /rooms/:roomId.
+      await $.tester.tap(find.byType(RoomListTile).first);
+      await $.tester.pump(const Duration(milliseconds: 500));
+
+      // Wait for room screen to load — thread auto-selects, enabling
+      // the chat input. On macOS the test window is below the 840px
+      // desktop breakpoint so HistoryPanel is in the drawer; the chat
+      // input is in the body and accessible without opening the drawer.
+      final chatInputFinder = find.byType(TextField);
+      await waitForCondition(
+        $.tester,
+        condition: () => $.tester.any(chatInputFinder),
+        timeout: const Duration(seconds: 10),
+        failureMessage: 'Chat TextField did not appear within 10s',
+      );
+
+      // Enter a unique test message.
+      final testMessage =
+          'patrol-test-${DateTime.now().millisecondsSinceEpoch}';
+
+      await $.tester.enterText(chatInputFinder, testMessage);
+      await $.tester.pump(const Duration(milliseconds: 200));
+
+      // Tap send button.
+      await $.tester.tap(find.byTooltip('Send message'));
+      await $.tester.pump(const Duration(milliseconds: 200));
+
+      // Log-driven wait for the AG-UI run to complete.
+      await harness.waitForLog(
+        'ActiveRun',
+        'RUN_FINISHED',
+        timeout: const Duration(seconds: 30),
+      );
+
+      // Pump to let UI update with response.
+      await $.tester.pump(const Duration(milliseconds: 500));
+
+      // At least 2 messages: user message + assistant response.
+      expect(
+        find.byType(ChatMessageWidget),
+        findsAtLeast(2),
+      );
+
+      // White-box: verify AG-UI lifecycle events in logs.
+      harness
+        ..expectLog('ActiveRun', 'RUN_STARTED')
+        ..expectLog('ActiveRun', 'TEXT_START:')
+        ..expectLog('ActiveRun', 'RUN_FINISHED');
+
+      // Pump extra frames for macOS rendering.
+      await $.tester.pump(const Duration(seconds: 1));
+    } catch (e) {
+      harness.dumpLogs(last: 50);
+      rethrow;
+    } finally {
+      harness.dispose();
+    }
+  });
+}

--- a/integration_test/patrol_helpers.dart
+++ b/integration_test/patrol_helpers.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:patrol/patrol.dart';
+import 'package:soliplex_frontend/app.dart';
+import 'package:soliplex_frontend/core/auth/auth_notifier.dart';
+import 'package:soliplex_frontend/core/auth/auth_provider.dart';
+import 'package:soliplex_frontend/core/auth/auth_state.dart';
+import 'package:soliplex_frontend/core/logging/logging_provider.dart';
+import 'package:soliplex_frontend/core/models/logo_config.dart';
+import 'package:soliplex_frontend/core/models/soliplex_config.dart';
+import 'package:soliplex_frontend/core/providers/config_provider.dart';
+import 'package:soliplex_frontend/core/providers/shell_config_provider.dart';
+
+import 'patrol_test_config.dart';
+import 'test_log_harness.dart';
+
+/// No-auth notifier that immediately resolves to [NoAuthRequired].
+///
+/// Skips the real [AuthNotifier.build] which fires _restoreSession and
+/// needs storage/refresh providers. Safe because no-auth mode never
+/// calls signIn/signOut/tryRefresh.
+class NoAuthNotifier extends AuthNotifier {
+  @override
+  AuthState build() => const NoAuthRequired();
+}
+
+/// Pump [SoliplexApp] with no-auth provider overrides.
+///
+/// Standard set of 5 overrides for Patrol E2E tests running against a
+/// `--no-auth-mode` backend.
+Future<void> pumpTestApp(
+  PatrolIntegrationTester $,
+  TestLogHarness harness,
+) async {
+  await $.pumpWidget(
+    ProviderScope(
+      overrides: [
+        preloadedPrefsProvider.overrideWithValue(harness.prefs),
+        memorySinkProvider.overrideWithValue(harness.sink),
+        shellConfigProvider.overrideWithValue(
+          const SoliplexConfig(
+            logo: LogoConfig.soliplex,
+            oauthRedirectScheme: 'ai.soliplex.client',
+          ),
+        ),
+        preloadedBaseUrlProvider.overrideWithValue(backendUrl),
+        authProvider.overrideWith(NoAuthNotifier.new),
+      ],
+      child: const SoliplexApp(),
+    ),
+  );
+}

--- a/integration_test/smoke_test.dart
+++ b/integration_test/smoke_test.dart
@@ -1,29 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:patrol/patrol.dart';
-import 'package:soliplex_frontend/app.dart';
-import 'package:soliplex_frontend/core/auth/auth_notifier.dart';
-import 'package:soliplex_frontend/core/auth/auth_provider.dart';
-import 'package:soliplex_frontend/core/auth/auth_state.dart';
-import 'package:soliplex_frontend/core/logging/logging_provider.dart';
-import 'package:soliplex_frontend/core/models/logo_config.dart';
-import 'package:soliplex_frontend/core/models/soliplex_config.dart';
-import 'package:soliplex_frontend/core/providers/config_provider.dart';
-import 'package:soliplex_frontend/core/providers/shell_config_provider.dart';
 
+import 'patrol_helpers.dart';
 import 'patrol_test_config.dart';
 import 'test_log_harness.dart';
-
-/// No-auth notifier that immediately resolves to [NoAuthRequired].
-///
-/// Skips the real [AuthNotifier.build] which fires _restoreSession and
-/// needs storage/refresh providers. Safe because no-auth mode never
-/// calls signIn/signOut/tryRefresh.
-class _NoAuthNotifier extends AuthNotifier {
-  @override
-  AuthState build() => const NoAuthRequired();
-}
 
 void main() {
   late TestLogHarness harness;
@@ -36,23 +17,7 @@ void main() {
     await harness.initialize();
 
     try {
-      await $.pumpWidget(
-        ProviderScope(
-          overrides: [
-            preloadedPrefsProvider.overrideWithValue(harness.prefs),
-            memorySinkProvider.overrideWithValue(harness.sink),
-            shellConfigProvider.overrideWithValue(
-              const SoliplexConfig(
-                logo: LogoConfig.soliplex,
-                oauthRedirectScheme: 'ai.soliplex.client',
-              ),
-            ),
-            preloadedBaseUrlProvider.overrideWithValue(backendUrl),
-            authProvider.overrideWith(_NoAuthNotifier.new),
-          ],
-          child: const SoliplexApp(),
-        ),
-      );
+      await pumpTestApp($, harness);
 
       // Pump frames to let the app initialize and route.
       // Cannot use pumpAndSettle — SSE streams prevent settling.


### PR DESCRIPTION
## Summary
- Live chat integration test: room navigation, message send/receive via SSE
- Patrol helpers extracted from smoke test (shared utilities)
- Claude Code skill file for Patrol test workflow

## Changes
- **integration_test/live_chat_test.dart**: Room entry, chat send, SSE message receive
- **integration_test/patrol_helpers.dart**: Shared helpers (waitForCondition, pumpTestApp, etc.)
- **integration_test/smoke_test.dart**: Refactored to use extracted helpers
- **.claude/skills/patrol/SKILL.md**: Patrol skill documentation

## Test plan
- [x] `patrol test --device macos --target integration_test/live_chat_test.dart` passes
- [x] Dart analyze clean

~321 lines. Stacks on #241 (Phase A).