### PR TITLE
test(logging): sink integration tests + ADR update (2c/5)

### DIFF
--- a/docs/adr/002-backend-log-shipping.md
+++ b/docs/adr/002-backend-log-shipping.md
@@ -15,10 +15,10 @@ screen-sharing or reading console output. This approach fails when:
 - The app crashes (logs lost with the process)
 - The user is offline or on a flaky connection (logs never seen)
 - Support engineers need historical context across sessions and devices
-- Government deployments require audit trails
+- Deployments require audit trails
 
 We needed centralized, persistent log shipping that works within our
-self-hosted DoD-compliant environment (no commercial SaaS).
+self-hosted environment.
 
 ## Decisions
 
@@ -94,6 +94,9 @@ within the same trust boundary.
 
 - `installId` (stable UUID per install) identifies the device across sessions
 - `sessionId` (new UUID per launch) groups logs within a single app run
+- Each session gets a memorable alias (e.g. `glad-raven-tundra`) derived
+  deterministically from the install ID, making it easy to find and correlate
+  sessions in Logfire without copying raw UUIDs
 - Resource attributes enable filtering in Logfire by OS, version, etc.
 - Follows OTel semantic conventions for future compatibility
 

--- a/packages/soliplex_logging/test/integration/backend_sink_pipeline_test.dart
+++ b/packages/soliplex_logging/test/integration/backend_sink_pipeline_test.dart
@@ -1,0 +1,116 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart' as http_testing;
+import 'package:soliplex_logging/soliplex_logging.dart';
+import 'package:soliplex_logging/src/sinks/disk_queue_io.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('pipeline_test_');
+    LogManager.instance.reset();
+  });
+
+  tearDown(() {
+    LogManager.instance.reset();
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  test('full pipeline: Logger → LogManager → BackendLogSink → HTTP', () async {
+    final captured = <http.Request>[];
+    final mockClient = http_testing.MockClient((request) async {
+      captured.add(request);
+      return http.Response('', 200);
+    });
+
+    final diskQueue = PlatformDiskQueue(directoryPath: tempDir.path);
+    final sink = BackendLogSink(
+      endpoint: 'https://api.example.com/logs',
+      client: mockClient,
+      installId: 'i-1',
+      sessionId: 's-1',
+      diskQueue: diskQueue,
+      userId: 'u-1',
+      flushInterval: const Duration(hours: 1),
+    );
+
+    LogManager.instance
+      ..minimumLevel = LogLevel.trace
+      ..addSink(sink);
+
+    LogManager.instance.getLogger('Integration')
+      ..info('Hello from pipeline', attributes: {'view': 'home'})
+      ..warning('Something suspect');
+
+    await LogManager.instance.flush();
+
+    expect(captured, hasLength(1));
+    final body = jsonDecode(captured.first.body) as Map<String, Object?>;
+    final logs = body['logs']! as List;
+    expect(logs, hasLength(2));
+
+    final first = logs[0] as Map<String, Object?>;
+    expect(first['message'], 'Hello from pipeline');
+    expect(first['level'], 'info');
+    expect(first['logger'], 'Integration');
+    expect(first['installId'], 'i-1');
+    expect(
+      (first['attributes']! as Map<String, Object?>)['view'],
+      'home',
+    );
+
+    final second = logs[1] as Map<String, Object?>;
+    expect(second['message'], 'Something suspect');
+    expect(second['level'], 'warning');
+
+    await sink.close();
+  });
+
+  test('crash recovery: records persist across instances', () async {
+    final captured = <http.Request>[];
+    final mockClient = http_testing.MockClient((request) async {
+      captured.add(request);
+      return http.Response('', 200);
+    });
+
+    // Simulate crash: write directly to DiskQueue then close it,
+    // bypassing BackendLogSink.close() which would flush.
+    final queue1 = PlatformDiskQueue(directoryPath: tempDir.path);
+    await queue1.append({
+      'timestamp': DateTime.now().toUtc().toIso8601String(),
+      'level': 'info',
+      'logger': 'Test',
+      'message': 'Before crash',
+      'attributes': <String, Object?>{},
+      'installId': 'i-1',
+      'sessionId': 's-1',
+    });
+    await queue1.close();
+
+    // New instance picks up pending records.
+    final queue2 = PlatformDiskQueue(directoryPath: tempDir.path);
+    final sink2 = BackendLogSink(
+      endpoint: 'https://api.example.com/logs',
+      client: mockClient,
+      installId: 'i-1',
+      sessionId: 's-2',
+      diskQueue: queue2,
+      flushInterval: const Duration(hours: 1),
+    );
+    await sink2.flush();
+
+    expect(captured, hasLength(1));
+    final body = jsonDecode(captured.first.body) as Map<String, Object?>;
+    final logs = body['logs']! as List;
+    expect(logs, hasLength(1));
+    expect((logs[0] as Map<String, Object?>)['message'], 'Before crash');
+
+    await sink2.close();
+  });
+}


### PR DESCRIPTION
## Summary
- End-to-end pipeline integration tests for the full log shipping stack
- ADR-002 text updates (session alias, environment wording)

## Changes
- **backend_sink_pipeline_test.dart**: Full pipeline test (Logger → LogManager → BackendLogSink → HTTP) and crash recovery test verifying DiskQueue persistence across instances
- **002-backend-log-shipping.md**: Add session alias description, simplify environment wording

## Test plan
- [x] `dart test test/integration/backend_sink_pipeline_test.dart` — 2/2 pass
- [x] `dart test` (full suite) — 199/199 pass
- [x] `dart analyze` — 0 issues
- [x] Pre-commit hooks pass