### PR TITLE
fix(hooks): analyze sub-packages in pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,10 +3,10 @@ repos:
     rev: v6.0.0 # Use the latest stable version
     hooks:
       - id: no-commit-to-branch
-        args: ["--branch", "main", "--branch", "master"]      
+        args: ["--branch", "main", "--branch", "master"]
       - id: check-merge-conflict
       - id: check-toml
-      - id: check-yaml      
+      - id: check-yaml
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.21.2
     hooks:
@@ -22,5 +22,10 @@ repos:
       - id: flutter-analyze
         name: flutter analyze
         entry: flutter analyze --fatal-infos
+        language: system
+        pass_filenames: false
+      - id: dart-analyze-packages
+        name: dart analyze packages
+        entry: python3 tool/analyze_packages.py
         language: system
         pass_filenames: false

--- a/tool/analyze_packages.py
+++ b/tool/analyze_packages.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Run dart analyze --fatal-infos on every sub-package in packages/."""
+
+import os
+import subprocess
+import sys
+
+
+def main() -> int:
+    packages_dir = os.path.join(os.path.dirname(__file__), os.pardir, "packages")
+    packages_dir = os.path.normpath(packages_dir)
+
+    failed = []
+    for name in sorted(os.listdir(packages_dir)):
+        pkg_path = os.path.join(packages_dir, name)
+        if not os.path.isfile(os.path.join(pkg_path, "pubspec.yaml")):
+            continue
+        print(f"Analyzing {name}...")
+        result = subprocess.run(
+            ["dart", "analyze", "--fatal-infos", pkg_path],
+        )
+        if result.returncode != 0:
+            failed.append(name)
+
+    if failed:
+        print(f"\nAnalysis failed for: {', '.join(failed)}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- `flutter analyze` at the repo root doesn't analyze `packages/` sub-directories locally, causing lint issues (e.g. `prefer_foreach`) to pass pre-commit but fail CI
- Add a cross-platform Python script and pre-commit hook that runs `dart analyze --fatal-infos` on every sub-package

## Changes
- **tool/analyze_packages.py**: Cross-platform script that discovers and analyzes all packages in `packages/`
- **.pre-commit-config.yaml**: Add `dart-analyze-packages` hook

## Context
Discovered when #250 passed local pre-commit but failed CI due to `prefer_foreach` info lint in `packages/soliplex_logging/`. Uses Python (not bash) for Windows developer compatibility.

Note: #246 fixes a different pre-commit issue (git worktree `GIT_DIR` confusion). These are independent fixes.

## Test plan
- [x] `python3 tool/analyze_packages.py` — analyzes all 3 sub-packages
- [x] Pre-commit hooks pass (including new `dart analyze packages` hook)
- [x] Verified script runs cross-platform (uses only Python stdlib + `dart` CLI)