### PR TITLE
refactor(chat): extract ChatController from ChatPanel

### DIFF
--- a/lib/core/providers/threads_provider.dart
+++ b/lib/core/providers/threads_provider.dart
@@ -265,7 +265,7 @@ void selectAndPersistThread({
     setLastViewedThread(
       roomId: roomId,
       threadId: threadId,
-      invalidate: invalidateLastViewed(ref),
+      invalidate: (roomId) => ref.invalidate(lastViewedThreadProvider(roomId)),
     ).catchError((Object e) {
       Loggers.room.warning('Failed to persist last viewed thread: $e');
     }),
@@ -304,20 +304,6 @@ final lastViewedThreadProvider = FutureProvider.family<LastViewed, String>((
 
 /// Callback for invalidating the last viewed thread provider.
 typedef InvalidateLastViewed = void Function(String roomId);
-
-/// Creates an [InvalidateLastViewed] callback from a ref.
-///
-/// Use this to pass to [setLastViewedThread] or [clearLastViewedThread]:
-/// ```dart
-/// setLastViewedThread(
-///   roomId: roomId,
-///   threadId: threadId,
-///   invalidate: invalidateLastViewed(ref),
-/// );
-/// ```
-InvalidateLastViewed invalidateLastViewed(WidgetRef ref) {
-  return (roomId) => ref.invalidate(lastViewedThreadProvider(roomId));
-}
 
 /// Saves the last viewed thread for a room.
 ///

--- a/lib/features/chat/chat_controller.dart
+++ b/lib/features/chat/chat_controller.dart
@@ -1,0 +1,189 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:soliplex_client/soliplex_client.dart';
+
+import 'package:soliplex_frontend/core/logging/loggers.dart';
+import 'package:soliplex_frontend/core/providers/active_run_provider.dart';
+import 'package:soliplex_frontend/core/providers/rooms_provider.dart';
+import 'package:soliplex_frontend/core/providers/selected_documents_provider.dart';
+import 'package:soliplex_frontend/core/providers/threads_provider.dart';
+import 'package:soliplex_frontend/features/chat/send_message_provider.dart';
+
+/// Result of [ChatController.send].
+@immutable
+sealed class SendResult {
+  const SendResult();
+}
+
+/// Message sent to an existing thread.
+class MessageSent extends SendResult {
+  const MessageSent();
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is MessageSent;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString() => 'MessageSent()';
+}
+
+/// A new thread was created. The widget should navigate to it.
+class ThreadCreated extends SendResult {
+  const ThreadCreated({required this.roomId, required this.threadId});
+
+  final String roomId;
+  final String threadId;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ThreadCreated &&
+          roomId == other.roomId &&
+          threadId == other.threadId;
+
+  @override
+  int get hashCode => Object.hash(roomId, threadId);
+
+  @override
+  String toString() => 'ThreadCreated(roomId: $roomId, threadId: $threadId)';
+}
+
+/// Sending failed. The widget should display [message].
+class SendFailed extends SendResult {
+  const SendFailed(this.message);
+
+  final String message;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is SendFailed && message == other.message;
+
+  @override
+  int get hashCode => message.hashCode;
+
+  @override
+  String toString() => 'SendFailed($message)';
+}
+
+/// Orchestrates chat actions: sending messages, retrying, and
+/// managing pending document selections.
+///
+/// State is `Set<RagDocument>` — the pending documents held before
+/// a thread exists. [send] returns a [SendResult] so the widget
+/// can perform navigation or show errors.
+class ChatController extends Notifier<Set<RagDocument>> {
+  @override
+  Set<RagDocument> build() {
+    ref.listen(currentRoomIdProvider, (previous, next) {
+      if (previous != next && state.isNotEmpty) {
+        state = {};
+      }
+    });
+
+    return {};
+  }
+
+  /// Sends a message, creating a new thread if needed.
+  Future<SendResult> send(String text) async {
+    final room = ref.read(currentRoomProvider);
+    if (room == null) {
+      return const SendFailed('No room selected');
+    }
+
+    final thread = ref.read(currentThreadProvider);
+    final selection = ref.read(threadSelectionProvider);
+
+    try {
+      final result = await ref.read(sendMessageProvider).call(
+            roomId: room.id,
+            text: text,
+            pendingDocuments: state,
+            currentThread: thread,
+            isNewThreadIntent: selection is NewThreadIntent,
+          );
+
+      if (result.isNewThread) {
+        ref
+            .read(threadSelectionProvider.notifier)
+            .set(ThreadSelected(result.threadId));
+
+        unawaited(
+          setLastViewedThread(
+            roomId: room.id,
+            threadId: result.threadId,
+            invalidate: (roomId) =>
+                ref.invalidate(lastViewedThreadProvider(roomId)),
+          ).catchError((Object e) {
+            Loggers.room.warning(
+              'Failed to persist last viewed thread: $e',
+            );
+          }),
+        );
+
+        if (state.isNotEmpty) {
+          state = {};
+        }
+
+        ref.invalidate(threadsProvider(room.id));
+
+        return ThreadCreated(roomId: room.id, threadId: result.threadId);
+      }
+
+      return const MessageSent();
+    } on NetworkException catch (e, stackTrace) {
+      Loggers.chat.error(
+        'Failed to send message: Network error',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return SendFailed('Network error: ${e.message}');
+    } on AuthException catch (e, stackTrace) {
+      Loggers.chat.error(
+        'Failed to send message: Auth error',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return SendFailed('Authentication error: ${e.message}');
+    } catch (e, stackTrace) {
+      Loggers.chat.error(
+        'Failed to send message',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return SendFailed('Failed to send message: $e');
+    }
+  }
+
+  /// Resets the active run after an error.
+  Future<void> retry() async {
+    await ref.read(activeRunNotifierProvider.notifier).reset();
+  }
+
+  /// Updates document selection.
+  ///
+  /// If a thread is active, delegates to the document selection provider.
+  /// Otherwise, stores in pending state until a thread is created.
+  void updateDocuments(Set<RagDocument> documents) {
+    final roomId = ref.read(currentRoomIdProvider);
+    final threadId = ref.read(currentThreadIdProvider);
+
+    if (roomId != null && threadId != null) {
+      ref
+          .read(selectedDocumentsNotifierProvider.notifier)
+          .setForThread(roomId, threadId, documents);
+    } else {
+      state = documents;
+    }
+  }
+}
+
+/// Provider for [ChatController].
+final chatControllerProvider =
+    NotifierProvider<ChatController, Set<RagDocument>>(
+  ChatController.new,
+);

--- a/lib/features/chat/chat_panel.dart
+++ b/lib/features/chat/chat_panel.dart
@@ -4,14 +4,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:soliplex_client/soliplex_client.dart';
 
-import 'package:soliplex_frontend/core/logging/loggers.dart';
 import 'package:soliplex_frontend/core/models/active_run_state.dart';
 import 'package:soliplex_frontend/core/providers/active_run_provider.dart';
 import 'package:soliplex_frontend/core/providers/rooms_provider.dart';
 import 'package:soliplex_frontend/core/providers/selected_documents_provider.dart';
 import 'package:soliplex_frontend/core/providers/threads_provider.dart';
 import 'package:soliplex_frontend/design/design.dart';
-import 'package:soliplex_frontend/features/chat/send_message_provider.dart';
+import 'package:soliplex_frontend/features/chat/chat_controller.dart';
 import 'package:soliplex_frontend/features/chat/widgets/chat_input.dart';
 import 'package:soliplex_frontend/features/chat/widgets/message_list.dart';
 import 'package:soliplex_frontend/features/chat/widgets/status_indicator.dart';
@@ -19,22 +18,10 @@ import 'package:soliplex_frontend/shared/widgets/error_display.dart';
 
 /// Main chat panel that combines message list and input.
 ///
-/// This panel:
-/// - Displays messages from the current thread
-/// - Provides input for sending new messages
-/// - Handles thread creation for new conversations
-/// - Handles errors with ErrorDisplay
-/// - Supports document selection for narrowing RAG searches
-///
-/// The panel integrates with:
-/// - [currentThreadProvider] for the active thread
-/// - [activeRunNotifierProvider] for streaming state
-/// - [threadSelectionProvider] for thread selection state
-///
-/// Example:
-/// ```dart
-/// ChatPanel()
-/// ```
+/// Delegates actions to [ChatController] and handles UI side-effects
+/// (navigation, error display) based on [SendResult]. Display state
+/// (messages, streaming, run state) is still watched directly —
+/// consolidation into a `ChatViewState` is tracked in issue #207.
 class ChatPanel extends ConsumerStatefulWidget {
   /// Creates a chat panel.
   const ChatPanel({super.key});
@@ -44,11 +31,20 @@ class ChatPanel extends ConsumerStatefulWidget {
 }
 
 class _ChatPanelState extends ConsumerState<ChatPanel> {
-  /// Pending document selection for when no thread exists yet.
-  ///
-  /// This holds the selection temporarily until a thread is created,
-  /// at which point it's transferred to the provider.
-  Set<RagDocument> _pendingDocuments = {};
+  Future<void> _handleSend(String text) async {
+    final result = await ref.read(chatControllerProvider.notifier).send(text);
+    if (!mounted) return;
+    switch (result) {
+      case MessageSent():
+        break;
+      case ThreadCreated(:final roomId, :final threadId):
+        context.go('/rooms/$roomId?thread=$threadId');
+      case SendFailed(:final message):
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(message)),
+        );
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -57,21 +53,16 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
     final messagesAsync = ref.watch(allMessagesProvider);
     final isStreaming = ref.watch(isStreamingProvider);
     final currentThreadId = ref.watch(currentThreadIdProvider);
+    final pendingDocs = ref.watch(chatControllerProvider);
+    final controller = ref.watch(chatControllerProvider.notifier);
 
-    // Clear pending documents when room changes to prevent carrying
-    // selections across rooms
-    ref.listen(currentRoomIdProvider, (previous, next) {
-      if (previous != next && _pendingDocuments.isNotEmpty) {
-        setState(() {
-          _pendingDocuments = {};
-        });
-      }
-    });
-
-    // Show suggestions only when thread is empty and not streaming
     final messages =
         messagesAsync.hasValue ? messagesAsync.value! : <ChatMessage>[];
     final showSuggestions = messages.isEmpty && !isStreaming;
+
+    final selectedDocs = (currentThreadId != null)
+        ? ref.watch(currentSelectedDocumentsProvider)
+        : pendingDocs;
 
     return LayoutBuilder(
       builder: (context, constraints) {
@@ -102,7 +93,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
                         ErrorDisplay(
                           error: errorMessage,
                           stackTrace: stackTrace ?? StackTrace.empty,
-                          onRetry: () => _handleRetry(ref),
+                          onRetry: controller.retry,
                         ),
                       _ => const MessageList(),
                     },
@@ -114,15 +105,10 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
 
                   // Input
                   ChatInput(
-                    onSend: (text) => _handleSend(context, ref, text),
+                    onSend: _handleSend,
                     roomId: room?.id,
-                    selectedDocuments:
-                        _getSelectedDocuments(room?.id, currentThreadId),
-                    onDocumentsChanged: (docs) => _updateSelectedDocuments(
-                      room?.id,
-                      currentThreadId,
-                      docs,
-                    ),
+                    selectedDocuments: selectedDocs,
+                    onDocumentsChanged: controller.updateDocuments,
                     suggestions: room?.suggestions ?? const [],
                     showSuggestions: showSuggestions,
                   ),
@@ -133,133 +119,5 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
         );
       },
     );
-  }
-
-  /// Gets the selected documents for display.
-  ///
-  /// If a thread exists, reads from the provider. Otherwise, uses pending
-  /// documents stored locally until a thread is created.
-  Set<RagDocument> _getSelectedDocuments(String? roomId, String? threadId) {
-    if (roomId != null && threadId != null) {
-      return ref.watch(currentSelectedDocumentsProvider);
-    }
-    return _pendingDocuments;
-  }
-
-  /// Updates document selection.
-  ///
-  /// If a thread exists, updates the provider. Otherwise, stores in local
-  /// pending state until a thread is created.
-  void _updateSelectedDocuments(
-    String? roomId,
-    String? threadId,
-    Set<RagDocument> documents,
-  ) {
-    if (roomId != null && threadId != null) {
-      ref
-          .read(selectedDocumentsNotifierProvider.notifier)
-          .setForThread(roomId, threadId, documents);
-    } else {
-      setState(() {
-        _pendingDocuments = documents;
-      });
-    }
-  }
-
-  /// Handles sending a message.
-  Future<void> _handleSend(
-    BuildContext context,
-    WidgetRef ref,
-    String text,
-  ) async {
-    final room = ref.read(currentRoomProvider);
-    if (room == null) {
-      if (context.mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(const SnackBar(content: Text('No room selected')));
-      }
-      return;
-    }
-
-    final thread = ref.read(currentThreadProvider);
-    final selection = ref.read(threadSelectionProvider);
-
-    try {
-      final result = await ref.read(sendMessageProvider).call(
-            roomId: room.id,
-            text: text,
-            pendingDocuments: _pendingDocuments,
-            currentThread: thread,
-            isNewThreadIntent: selection is NewThreadIntent,
-          );
-
-      if (result.isNewThread) {
-        // Update selection to the new thread
-        ref
-            .read(threadSelectionProvider.notifier)
-            .set(ThreadSelected(result.threadId));
-
-        // Clear pending documents now that they've been transferred
-        if (_pendingDocuments.isNotEmpty) {
-          setState(() {
-            _pendingDocuments = {};
-          });
-        }
-
-        // Persist last viewed and update URL
-        await setLastViewedThread(
-          roomId: room.id,
-          threadId: result.threadId,
-          invalidate: invalidateLastViewed(ref),
-        );
-        if (context.mounted) {
-          context.go('/rooms/${room.id}?thread=${result.threadId}');
-        }
-
-        // Refresh threads list
-        ref.invalidate(threadsProvider(room.id));
-      }
-    } on NetworkException catch (e, stackTrace) {
-      Loggers.chat.error(
-        'Failed to send message: Network error',
-        error: e,
-        stackTrace: stackTrace,
-      );
-      if (context.mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(
-          SnackBar(content: Text('Network error: ${e.message}')),
-        );
-      }
-    } on AuthException catch (e, stackTrace) {
-      Loggers.chat.error(
-        'Failed to send message: Auth error',
-        error: e,
-        stackTrace: stackTrace,
-      );
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Authentication error: ${e.message}')),
-        );
-      }
-    } catch (e, stackTrace) {
-      Loggers.chat.error(
-        'Failed to send message',
-        error: e,
-        stackTrace: stackTrace,
-      );
-      if (context.mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text('Failed to send message: $e')));
-      }
-    }
-  }
-
-  /// Handles retrying after an error.
-  Future<void> _handleRetry(WidgetRef ref) async {
-    await ref.read(activeRunNotifierProvider.notifier).reset();
   }
 }

--- a/test/core/providers/last_viewed_thread_test.dart
+++ b/test/core/providers/last_viewed_thread_test.dart
@@ -186,12 +186,12 @@ void main() {
     });
   });
 
-  group('invalidateLastViewed', () {
+  group('invalidation callback', () {
     setUp(() {
       SharedPreferences.setMockInitialValues({});
     });
 
-    testWidgets('creates working callback from WidgetRef', (tester) async {
+    testWidgets('inline callback invalidates provider', (tester) async {
       // Track invalidation calls
       final invalidateCalls = <String>[];
 
@@ -202,16 +202,12 @@ void main() {
               builder: (context, ref, _) {
                 return ElevatedButton(
                   onPressed: () async {
-                    // Use the actual invalidateLastViewed helper
-                    final invalidate = invalidateLastViewed(ref);
-
-                    // Call setLastViewedThread with the helper
                     await setLastViewedThread(
                       roomId: 'room-1',
                       threadId: 'thread-widget-test',
                       invalidate: (roomId) {
                         invalidateCalls.add(roomId);
-                        invalidate(roomId);
+                        ref.invalidate(lastViewedThreadProvider(roomId));
                       },
                     );
                   },
@@ -251,7 +247,9 @@ void main() {
                         await setLastViewedThread(
                           roomId: 'room-2',
                           threadId: 'thread-new',
-                          invalidate: invalidateLastViewed(ref),
+                          invalidate: (roomId) => ref.invalidate(
+                            lastViewedThreadProvider(roomId),
+                          ),
                         );
                       },
                       child: const Text('Write'),

--- a/test/features/chat/chat_controller_test.dart
+++ b/test/features/chat/chat_controller_test.dart
@@ -1,0 +1,392 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_client/soliplex_client.dart';
+import 'package:soliplex_frontend/core/models/active_run_state.dart';
+import 'package:soliplex_frontend/core/providers/active_run_notifier.dart';
+import 'package:soliplex_frontend/core/providers/active_run_provider.dart';
+import 'package:soliplex_frontend/core/providers/api_provider.dart';
+import 'package:soliplex_frontend/core/providers/rooms_provider.dart';
+import 'package:soliplex_frontend/core/providers/selected_documents_provider.dart';
+import 'package:soliplex_frontend/core/providers/shell_config_provider.dart';
+import 'package:soliplex_frontend/core/providers/threads_provider.dart';
+import 'package:soliplex_frontend/features/chat/chat_controller.dart';
+import 'package:soliplex_frontend/features/chat/send_message.dart';
+import 'package:soliplex_frontend/features/chat/send_message_provider.dart';
+
+import '../../helpers/test_helpers.dart';
+
+/// Fake SendMessage that records calls and returns configurable results.
+class _FakeSendMessage implements SendMessage {
+  SendMessageResult? resultToReturn;
+  Object? exceptionToThrow;
+  final List<
+      ({
+        String roomId,
+        String text,
+        Set<RagDocument> pendingDocuments,
+        ThreadInfo? currentThread,
+        bool isNewThreadIntent,
+      })> calls = [];
+
+  @override
+  Future<SendMessageResult> call({
+    required String roomId,
+    required String text,
+    required Set<RagDocument> pendingDocuments,
+    ThreadInfo? currentThread,
+    bool isNewThreadIntent = false,
+  }) async {
+    calls.add(
+      (
+        roomId: roomId,
+        text: text,
+        pendingDocuments: pendingDocuments,
+        currentThread: currentThread,
+        isNewThreadIntent: isNewThreadIntent,
+      ),
+    );
+    final error = exceptionToThrow;
+    if (error is Exception) throw error;
+    if (error is Error) throw error;
+    if (resultToReturn == null) {
+      throw StateError(
+        '_FakeSendMessage: set resultToReturn or '
+        'exceptionToThrow before calling',
+      );
+    }
+    return resultToReturn!;
+  }
+}
+
+/// Tracking notifier for thread selection verification.
+class _TrackingThreadSelectionNotifier extends Notifier<ThreadSelection>
+    implements ThreadSelectionNotifier {
+  _TrackingThreadSelectionNotifier({required this.initialSelection});
+
+  final ThreadSelection initialSelection;
+
+  @override
+  ThreadSelection build() => initialSelection;
+
+  @override
+  void set(ThreadSelection value) => state = value;
+}
+
+/// Tracking notifier for active run verification.
+class _TrackingActiveRunNotifier extends Notifier<ActiveRunState>
+    implements ActiveRunNotifier {
+  bool resetCalled = false;
+
+  @override
+  ActiveRunState build() => const IdleState();
+
+  @override
+  Future<void> startRun({
+    required String roomId,
+    required String threadId,
+    required String userMessage,
+    String? existingRunId,
+    Map<String, dynamic>? initialState,
+  }) async {}
+
+  @override
+  Future<void> cancelRun() async {}
+
+  @override
+  Future<void> reset() async {
+    resetCalled = true;
+  }
+}
+
+void main() {
+  late _FakeSendMessage fakeSendMessage;
+  late _TrackingThreadSelectionNotifier trackingThreadSelection;
+  late _TrackingActiveRunNotifier trackingActiveRun;
+  late MockSoliplexApi mockApi;
+
+  setUp(() async {
+    await initTestPrefs();
+    fakeSendMessage = _FakeSendMessage();
+    trackingThreadSelection = _TrackingThreadSelectionNotifier(
+      initialSelection: const NoThreadSelected(),
+    );
+    trackingActiveRun = _TrackingActiveRunNotifier();
+    mockApi = MockSoliplexApi();
+  });
+
+  /// Creates a [ProviderContainer] with standard test overrides.
+  ///
+  /// [room] controls currentRoomProvider. Null means no room selected.
+  /// [thread] controls currentThreadProvider lookup.
+  /// [threadSelection] overrides the initial thread selection state.
+  ProviderContainer createContainer({
+    Room? room,
+    ThreadInfo? thread,
+    ThreadSelection? threadSelection,
+  }) {
+    if (threadSelection != null) {
+      trackingThreadSelection = _TrackingThreadSelectionNotifier(
+        initialSelection: threadSelection,
+      );
+    }
+
+    final container = ProviderContainer(
+      overrides: [
+        shellConfigProvider.overrideWithValue(testSoliplexConfig),
+        sendMessageProvider.overrideWithValue(fakeSendMessage),
+        apiProvider.overrideWithValue(mockApi),
+        activeRunNotifierProvider.overrideWith(() => trackingActiveRun),
+        threadSelectionProvider.overrideWith(
+          () => trackingThreadSelection,
+        ),
+        currentRoomProvider.overrideWith((ref) => room),
+        currentRoomIdProvider.overrideWith(
+          () => MockCurrentRoomIdNotifier(initialRoomId: room?.id),
+        ),
+        currentThreadProvider.overrideWith((ref) => thread),
+        currentThreadIdProvider.overrideWith((ref) => thread?.id),
+        if (room != null)
+          threadsProvider(room.id).overrideWith(
+            (ref) async => thread != null ? [thread] : [],
+          ),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  group('ChatController', () {
+    group('send()', () {
+      test('calls SendMessage with existing thread', () async {
+        final room = TestData.createRoom(id: 'room-1');
+        final thread = TestData.createThread(id: 'thread-1', roomId: 'room-1');
+        fakeSendMessage.resultToReturn = (
+          threadId: 'thread-1',
+          roomId: 'room-1',
+          isNewThread: false,
+        );
+
+        final container = createContainer(
+          room: room,
+          thread: thread,
+          threadSelection: const ThreadSelected('thread-1'),
+        );
+
+        final controller = container.read(chatControllerProvider.notifier);
+        final result = await controller.send('Hello');
+
+        expect(fakeSendMessage.calls, hasLength(1));
+        expect(fakeSendMessage.calls.first.roomId, 'room-1');
+        expect(fakeSendMessage.calls.first.text, 'Hello');
+        expect(fakeSendMessage.calls.first.isNewThreadIntent, isFalse);
+        expect(result, const MessageSent());
+      });
+
+      test('returns ThreadCreated for new thread', () async {
+        final room = TestData.createRoom(id: 'room-1');
+        fakeSendMessage.resultToReturn = (
+          threadId: 'new-thread',
+          roomId: 'room-1',
+          isNewThread: true,
+        );
+
+        final container = createContainer(room: room);
+
+        final controller = container.read(chatControllerProvider.notifier);
+        final result = await controller.send('Hello');
+
+        expect(
+          result,
+          const ThreadCreated(roomId: 'room-1', threadId: 'new-thread'),
+        );
+      });
+
+      test('selects new thread after creation', () async {
+        final room = TestData.createRoom(id: 'room-1');
+        fakeSendMessage.resultToReturn = (
+          threadId: 'new-thread',
+          roomId: 'room-1',
+          isNewThread: true,
+        );
+
+        final container = createContainer(room: room);
+
+        final controller = container.read(chatControllerProvider.notifier);
+        await controller.send('Hello');
+
+        expect(
+          container.read(threadSelectionProvider),
+          const ThreadSelected('new-thread'),
+        );
+      });
+
+      test('clears pending documents after new thread', () async {
+        final room = TestData.createRoom(id: 'room-1');
+        final doc = TestData.createDocument(id: 'doc-1');
+        fakeSendMessage.resultToReturn = (
+          threadId: 'new-thread',
+          roomId: 'room-1',
+          isNewThread: true,
+        );
+
+        final container = createContainer(room: room);
+
+        final controller = container.read(chatControllerProvider.notifier)
+          ..updateDocuments({doc});
+        expect(container.read(chatControllerProvider), {doc});
+
+        await controller.send('Hello');
+
+        expect(container.read(chatControllerProvider), isEmpty);
+      });
+
+      test('passes NewThreadIntent to SendMessage', () async {
+        final room = TestData.createRoom(id: 'room-1');
+        final thread = TestData.createThread(id: 'thread-1', roomId: 'room-1');
+        fakeSendMessage.resultToReturn = (
+          threadId: 'new-thread',
+          roomId: 'room-1',
+          isNewThread: true,
+        );
+
+        final container = createContainer(
+          room: room,
+          thread: thread,
+          threadSelection: const NewThreadIntent(),
+        );
+
+        final controller = container.read(chatControllerProvider.notifier);
+        await controller.send('Hello');
+
+        expect(fakeSendMessage.calls.first.isNewThreadIntent, isTrue);
+      });
+
+      test('returns SendFailed when no room selected', () async {
+        final container = createContainer();
+
+        final controller = container.read(chatControllerProvider.notifier);
+        final result = await controller.send('Hello');
+
+        expect(fakeSendMessage.calls, isEmpty);
+        expect(result, const SendFailed('No room selected'));
+      });
+
+      test('returns SendFailed on NetworkException', () async {
+        final room = TestData.createRoom(id: 'room-1');
+        fakeSendMessage.exceptionToThrow = const NetworkException(
+          message: 'timeout',
+        );
+
+        final container = createContainer(room: room);
+
+        final controller = container.read(chatControllerProvider.notifier);
+        final result = await controller.send('Hello');
+
+        expect(result, const SendFailed('Network error: timeout'));
+      });
+
+      test('returns SendFailed on AuthException', () async {
+        final room = TestData.createRoom(id: 'room-1');
+        fakeSendMessage.exceptionToThrow = const AuthException(
+          message: 'expired token',
+        );
+
+        final container = createContainer(room: room);
+
+        final controller = container.read(chatControllerProvider.notifier);
+        final result = await controller.send('Hello');
+
+        expect(
+          result,
+          const SendFailed('Authentication error: expired token'),
+        );
+      });
+
+      test('returns SendFailed on unexpected exception', () async {
+        final room = TestData.createRoom(id: 'room-1');
+        fakeSendMessage.exceptionToThrow = StateError('unexpected');
+
+        final container = createContainer(room: room);
+
+        final controller = container.read(chatControllerProvider.notifier);
+        final result = await controller.send('Hello');
+
+        expect(
+          result,
+          isA<SendFailed>().having(
+            (f) => f.message,
+            'message',
+            contains('Failed to send message'),
+          ),
+        );
+      });
+    });
+
+    group('retry()', () {
+      test('resets the active run', () async {
+        final container = createContainer(
+          room: TestData.createRoom(id: 'room-1'),
+        );
+
+        final controller = container.read(chatControllerProvider.notifier);
+        await controller.retry();
+
+        expect(trackingActiveRun.resetCalled, isTrue);
+      });
+    });
+
+    group('updateDocuments()', () {
+      test('stores documents in state when no thread', () {
+        final doc = TestData.createDocument(id: 'doc-1');
+        final container = createContainer();
+
+        container.read(chatControllerProvider.notifier).updateDocuments({doc});
+
+        expect(container.read(chatControllerProvider), {doc});
+      });
+
+      test('delegates to selectedDocumentsNotifier when thread exists', () {
+        final room = TestData.createRoom(id: 'room-1');
+        final thread = TestData.createThread(id: 'thread-1', roomId: 'room-1');
+        final doc = TestData.createDocument(id: 'doc-1');
+
+        final container = createContainer(
+          room: room,
+          thread: thread,
+          threadSelection: const ThreadSelected('thread-1'),
+        );
+
+        container.read(chatControllerProvider.notifier).updateDocuments({doc});
+
+        // State should still be empty (pending docs unchanged)
+        expect(container.read(chatControllerProvider), isEmpty);
+        // The document should be in the selected documents notifier
+        final stored = container
+            .read(selectedDocumentsNotifierProvider.notifier)
+            .getForThread('room-1', 'thread-1');
+        expect(stored, {doc});
+      });
+    });
+
+    group('room change listener', () {
+      test('clears pending documents when room changes', () async {
+        final doc = TestData.createDocument(id: 'doc-1');
+
+        final container = createContainer(
+          room: TestData.createRoom(id: 'room-1'),
+        );
+
+        container.read(chatControllerProvider.notifier).updateDocuments({doc});
+        expect(container.read(chatControllerProvider), {doc});
+
+        // Change room
+        container.read(currentRoomIdProvider.notifier).set('room-2');
+
+        // Allow listeners to fire
+        await Future<void>.delayed(Duration.zero);
+
+        expect(container.read(chatControllerProvider), isEmpty);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Extract orchestration logic from `ChatPanel` into a `ChatController` Riverpod Notifier
- `ChatController` owns: `send()`, `retry()`, `updateDocuments()`, pending document state, and room-change listener
- `ChatPanel` becomes a thin UI shell — delegates to controller, handles navigation and snackbars via `SendResult` pattern matching
- `SendResult` sealed class (`MessageSent`, `ThreadCreated`, `SendFailed`) with equality/hashCode/toString
- Remove `invalidateLastViewed(WidgetRef)` factory — both call sites now inline the lambda
- 13 unit tests for `ChatController` using `ProviderContainer` (no widget pumping needed)

## Test plan

- [x] 13 ChatController unit tests pass (send, retry, updateDocuments, room-change listener, error handling)
- [x] 22 existing ChatPanel widget tests pass unchanged
- [x] 11 last-viewed-thread tests pass with updated call sites
- [x] `dart format` — 0 changes
- [x] `flutter analyze --fatal-infos` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)