### PR TITLE
fix(patrol): increase RUN_FINISHED timeout to 60s

### DIFF
--- a/integration_test/live_chat_test.dart
+++ b/integration_test/live_chat_test.dart
@@ -95,7 +95,7 @@ void main() {
       await harness.waitForLog(
         'ActiveRun',
         'RUN_FINISHED',
-        timeout: const Duration(seconds: 30),
+        timeout: const Duration(seconds: 60),
       );
 
       // Pump to let UI update with response.


### PR DESCRIPTION
## Summary
- Increase `waitForLog('ActiveRun', 'RUN_FINISHED')` timeout from 30s to 60s

## Changes
- **`integration_test/live_chat_test.dart`**: 30s → 60s for remote LLM backends

## Test plan
- [x] Patrol tests pass locally