### PR TITLE
feat(patrol): add iOS simulator E2E test support

### DIFF
--- a/.claude/skills/patrol/SKILL.md
+++ b/.claude/skills/patrol/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: patrol
-description: Run Patrol E2E integration tests on macOS or Chrome. Use when writing, running, or debugging Patrol tests.
+description: Run Patrol E2E integration tests on macOS, iOS, or Chrome. Use when writing, running, or debugging Patrol tests.
 argument-hint: "[test-file|all]"
 allowed-tools: Bash, Read, Edit, Write, Glob, Grep
 ---
 
 # Patrol E2E Test Skill
 
-Run and manage Patrol integration tests for this Flutter project (macOS and Chrome).
+Run and manage Patrol integration tests for this Flutter project (macOS, iOS, and Chrome).
 
 ## Running Tests
 
@@ -30,6 +30,28 @@ patrol test \
   --target integration_test/ \
   --dart-define SOLIPLEX_BACKEND_URL=http://localhost:8000
 ```
+
+### iOS (simulator)
+
+Use a booted simulator's device ID or name. The `--ios` flag specifies the OS
+version (defaults to `latest` — must match the simulator's OS).
+
+```bash
+# Run on a specific iOS simulator
+patrol test \
+  --device <DEVICE_ID> \
+  --target integration_test/$ARGUMENTS \
+  --dart-define SOLIPLEX_BACKEND_URL=http://localhost:8000
+
+# If simulator OS != latest SDK, specify explicitly
+patrol test \
+  --device <DEVICE_ID> \
+  --ios=18.6 \
+  --target integration_test/$ARGUMENTS \
+  --dart-define SOLIPLEX_BACKEND_URL=http://localhost:8000
+```
+
+Use `xcrun simctl list devices booted` to find the device ID and OS version.
 
 ### Chrome (web)
 
@@ -98,6 +120,25 @@ Both the app AND the test runner need their own entitlements:
 ### Keyboard assertions
 
 macOS has a Flutter keyboard assertion bug. All tests must call `ignoreKeyboardAssertions()` early. On web, the function is a no-op (`kIsWeb` guard).
+
+## iOS Constraints
+
+### RunnerUITests target required
+
+The iOS Xcode project needs a `RunnerUITests` UI test bundle target
+(same pattern as macOS). The target, scheme entry, and Podfile entry
+are already configured in this repo.
+
+### Simulator OS version must match
+
+Patrol uses `--ios=<version>` (defaults to `latest`). If the booted
+simulator runs an older iOS than the latest installed SDK, pass the
+version explicitly: `--ios=18.6`.
+
+### Keyboard assertions
+
+`ignoreKeyboardAssertions()` applies on iOS too (same Flutter bug as
+macOS). No changes needed — the function works on both platforms.
 
 ## Chrome (Web) Constraints
 
@@ -227,3 +268,5 @@ This repo is a git worktree. Pre-commit hooks that invoke `flutter`/`dart` must 
 | Chrome: CORS error in test | Backend missing CORS headers | Configure backend `Access-Control-Allow-Origin` for test origin |
 | Chrome: "Failed to fetch" on `verifyBackendOrFail` | Backend offline or CORS block | Start backend; check browser console for CORS errors |
 | `command not found: patrol` | `~/.pub-cache/bin` not on PATH | Add to PATH or use full path `~/.pub-cache/bin/patrol` |
+| iOS: xcodebuild exit code 70 | `OS=latest` doesn't match simulator | Use `--ios=18.6` (match simulator OS) |
+| iOS: "Device ... is not attached" | Wrong device ID format | Use UUID from `xcrun simctl list devices booted` |

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -34,6 +34,9 @@ target 'Runner' do
   target 'RunnerTests' do
     inherit! :search_paths
   end
+  target 'RunnerUITests' do
+    inherit! :search_paths
+  end
 end
 
 post_install do |installer|

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -7,8 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		06EF87B3FB2EB61F77D635CF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 780E2A820C726DD8FDAEB680 /* Foundation.framework */; };
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		2B4ACE6F50A6EFCB0E0C0547 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5745C985B3669745D344C182 /* Pods_Runner.framework */; };
+		3078122261FCA7CBF3036451 /* RunnerUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = BF1B89308E5B9BE2E0D93C68 /* RunnerUITests.m */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
@@ -17,10 +19,18 @@
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		D311D678413B021670AEB834 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80E47FDDA0555EB08DD13525 /* Pods_RunnerTests.framework */; };
+		D428152A59609653EC733D2B /* Pods_RunnerUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90891332F487EDCA70DD685C /* Pods_RunnerUITests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
 		331C8085294A63A400263BE5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 97C146E61CF9000F007C117D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 97C146ED1CF9000F007C117D;
+			remoteInfo = Runner;
+		};
+		9DC548B4ED3BEA340ACB3810 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 97C146E61CF9000F007C117D /* Project object */;
 			proxyType = 1;
@@ -43,6 +53,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		01B58AEFB3C43BAF9E87ACF1 /* RunnerUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1271E755AB9578F160485C96 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
@@ -52,13 +63,17 @@
 		4229C7B3DB3D3CC50B75994F /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		43CFFD9A7ED666A35AA21322 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		5745C985B3669745D344C182 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5D703A789BE86BDC65B03AB9 /* Pods-RunnerUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerUITests.release.xcconfig"; path = "Target Support Files/Pods-RunnerUITests/Pods-RunnerUITests.release.xcconfig"; sourceTree = "<group>"; };
 		704143BA97518BCC43565BB8 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		780E2A820C726DD8FDAEB680 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		7CB6EEFC3FDE3687503AADB2 /* Pods-RunnerUITests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerUITests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerUITests/Pods-RunnerUITests.profile.xcconfig"; sourceTree = "<group>"; };
 		80E47FDDA0555EB08DD13525 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		82AFE7545CD65490FC50F643 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		90891332F487EDCA70DD685C /* Pods_RunnerUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -66,9 +81,11 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		BF1B89308E5B9BE2E0D93C68 /* RunnerUITests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RunnerUITests.m; sourceTree = "<group>"; };
 		D8999C64B753BCD580645B86 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		E4A5F1B82D4C8A0100SIGNING /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		E4A5F1B92D4C8A0100SIGNING /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		FE26D30C75BBFA674A5FD2AE /* Pods-RunnerUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerUITests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerUITests/Pods-RunnerUITests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -88,6 +105,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		B49D63BC41289958CB0E2A96 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				06EF87B3FB2EB61F77D635CF /* Foundation.framework in Frameworks */,
+				D428152A59609653EC733D2B /* Pods_RunnerUITests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -99,13 +125,32 @@
 			path = RunnerTests;
 			sourceTree = "<group>";
 		};
+		400F36193376C1516AFD82C4 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				780E2A820C726DD8FDAEB680 /* Foundation.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
 		446B0B8EB443AD1C8F3D19B3 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
 				5745C985B3669745D344C182 /* Pods_Runner.framework */,
 				80E47FDDA0555EB08DD13525 /* Pods_RunnerTests.framework */,
+				400F36193376C1516AFD82C4 /* iOS */,
+				90891332F487EDCA70DD685C /* Pods_RunnerUITests.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		5A96019A95AF0B07A8305FEA /* RunnerUITests */ = {
+			isa = PBXGroup;
+			children = (
+				BF1B89308E5B9BE2E0D93C68 /* RunnerUITests.m */,
+			);
+			name = RunnerUITests;
+			path = RunnerUITests;
 			sourceTree = "<group>";
 		};
 		97083D6FA629E052C3429784 /* Pods */ = {
@@ -117,6 +162,9 @@
 				D8999C64B753BCD580645B86 /* Pods-RunnerTests.debug.xcconfig */,
 				1271E755AB9578F160485C96 /* Pods-RunnerTests.release.xcconfig */,
 				4229C7B3DB3D3CC50B75994F /* Pods-RunnerTests.profile.xcconfig */,
+				5D703A789BE86BDC65B03AB9 /* Pods-RunnerUITests.release.xcconfig */,
+				FE26D30C75BBFA674A5FD2AE /* Pods-RunnerUITests.debug.xcconfig */,
+				7CB6EEFC3FDE3687503AADB2 /* Pods-RunnerUITests.profile.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -141,6 +189,7 @@
 				331C8082294A63A400263BE5 /* RunnerTests */,
 				97083D6FA629E052C3429784 /* Pods */,
 				446B0B8EB443AD1C8F3D19B3 /* Frameworks */,
+				5A96019A95AF0B07A8305FEA /* RunnerUITests */,
 			);
 			sourceTree = "<group>";
 		};
@@ -149,6 +198,7 @@
 			children = (
 				97C146EE1CF9000F007C117D /* Runner.app */,
 				331C8081294A63A400263BE5 /* RunnerTests.xctest */,
+				01B58AEFB3C43BAF9E87ACF1 /* RunnerUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -182,6 +232,25 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		060F7614AD2E7FCD9C03C325 /* RunnerUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E62667E1110C290E0D230E2D /* Build configuration list for PBXNativeTarget "RunnerUITests" */;
+			buildPhases = (
+				F78F8B5D83EDB12FFFDDF44A /* [CP] Check Pods Manifest.lock */,
+				D4C3491D053A1BCD8518C31E /* Sources */,
+				B49D63BC41289958CB0E2A96 /* Frameworks */,
+				BA2BA2D71AA12F2E173BE73D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D50897A4510F8D1AAF614AA3 /* PBXTargetDependency */,
+			);
+			name = RunnerUITests;
+			productName = RunnerUITests;
+			productReference = 01B58AEFB3C43BAF9E87ACF1 /* RunnerUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 		331C8080294A63A400263BE5 /* RunnerTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
@@ -233,6 +302,10 @@
 				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
+					060F7614AD2E7FCD9C03C325 = {
+						CreatedOnToolsVersion = 14.0;
+						TestTargetID = 97C146ED1CF9000F007C117D;
+					};
 					331C8080294A63A400263BE5 = {
 						CreatedOnToolsVersion = 14.0;
 						TestTargetID = 97C146ED1CF9000F007C117D;
@@ -258,6 +331,7 @@
 			targets = (
 				97C146ED1CF9000F007C117D /* Runner */,
 				331C8080294A63A400263BE5 /* RunnerTests */,
+				060F7614AD2E7FCD9C03C325 /* RunnerUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -278,6 +352,13 @@
 				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
 				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BA2BA2D71AA12F2E173BE73D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -376,6 +457,28 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		F78F8B5D83EDB12FFFDDF44A /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerUITests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -397,6 +500,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D4C3491D053A1BCD8518C31E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3078122261FCA7CBF3036451 /* RunnerUITests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -404,6 +515,12 @@
 			isa = PBXTargetDependency;
 			target = 97C146ED1CF9000F007C117D /* Runner */;
 			targetProxy = 331C8085294A63A400263BE5 /* PBXContainerItemProxy */;
+		};
+		D50897A4510F8D1AAF614AA3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Runner;
+			target = 97C146ED1CF9000F007C117D /* Runner */;
+			targetProxy = 9DC548B4ED3BEA340ACB3810 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -550,6 +667,55 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
+			};
+			name = Profile;
+		};
+		3E6489DD6701B52BE1D30996 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FE26D30C75BBFA674A5FD2AE /* Pods-RunnerUITests.debug.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+					"$(FRAMEWORK_SEARCH_PATHS)",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = ai.soliplex.client.RunnerUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				TEST_TARGET_NAME = Runner;
+			};
+			name = Debug;
+		};
+		53A271891B78DD3DF41967D4 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7CB6EEFC3FDE3687503AADB2 /* Pods-RunnerUITests.profile.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+					"$(FRAMEWORK_SEARCH_PATHS)",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = ai.soliplex.client.RunnerUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				TEST_TARGET_NAME = Runner;
+				VALIDATE_PRODUCT = YES;
 			};
 			name = Profile;
 		};
@@ -713,6 +879,31 @@
 			};
 			name = Release;
 		};
+		A15154456EDCFD477640A315 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5D703A789BE86BDC65B03AB9 /* Pods-RunnerUITests.release.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+					"$(FRAMEWORK_SEARCH_PATHS)",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = ai.soliplex.client.RunnerUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				TEST_TARGET_NAME = Runner;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -742,6 +933,16 @@
 				97C147061CF9000F007C117D /* Debug */,
 				97C147071CF9000F007C117D /* Release */,
 				249021D4217E4FDB00AE95B9 /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E62667E1110C290E0D230E2D /* Build configuration list for PBXNativeTarget "RunnerUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A15154456EDCFD477640A315 /* Release */,
+				3E6489DD6701B52BE1D30996 /* Debug */,
+				53A271891B78DD3DF41967D4 /* Profile */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -49,6 +49,17 @@
                ReferencedContainer = "container:Runner.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "060F7614AD2E7FCD9C03C325"
+               BuildableName = "RunnerUITests.xctest"
+               BlueprintName = "RunnerUITests"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/ios/RunnerUITests/RunnerUITests.m
+++ b/ios/RunnerUITests/RunnerUITests.m
@@ -1,0 +1,5 @@
+@import XCTest;
+@import patrol;
+@import ObjectiveC.runtime;
+
+PATROL_INTEGRATION_TEST_IOS_RUNNER(RunnerUITests)


### PR DESCRIPTION
## Summary
- Add iOS as a third Patrol E2E test platform (alongside macOS and Chrome)
- Add `RunnerUITests` UI test bundle target to the iOS Xcode project
- Existing no-auth tests pass on iOS simulator without code changes

## Changes
- **`ios/RunnerUITests/RunnerUITests.m`**: Patrol iOS test runner using `PATROL_INTEGRATION_TEST_IOS_RUNNER` macro
- **`ios/Runner.xcodeproj/project.pbxproj`**: Register `RunnerUITests` native target (UI test bundle, depends on Runner)
- **`ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme`**: Add `RunnerUITests` to test action testables
- **`ios/Podfile`**: Add `RunnerUITests` target with `inherit! :search_paths`
- **`.claude/skills/patrol/SKILL.md`**: iOS test commands, `--ios` flag docs, constraints, troubleshooting

## Test plan
- [x] `patrol test --device <sim-id> --target integration_test/smoke_test.dart` — passed on iPhone 17 Pro (iOS 26.2)
- [x] `patrol test --device <sim-id> --target integration_test/live_chat_test.dart` — both tests passed (rooms load + chat send/receive with full AG-UI lifecycle)
- [x] Pre-commit hooks pass (format, analyze, secrets)
- [x] macOS tests unaffected (no integration_test/ code changes)
- [x] Chrome tests unaffected