### PR TITLE
feat(patrol): add flutter_driver entry point for interactive debugging

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -280,7 +280,7 @@ packages:
     source: hosted
     version: "11.0.0"
   flutter_driver:
-    dependency: transitive
+    dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,8 @@ dependencies:
   web: ^1.1.1
 
 dev_dependencies:
+  flutter_driver:
+    sdk: flutter
   flutter_launcher_icons: ^0.14.4
   flutter_native_splash: ^2.4.7
   flutter_test:

--- a/test_driver/app.dart
+++ b/test_driver/app.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_driver/driver_extension.dart';
+import 'package:soliplex_frontend/soliplex_frontend.dart';
+
+/// Driver-enabled entry point for interactive testing via dart-tools MCP.
+///
+/// Launch with:
+///   mcp__dart-tools__launch_app(target: "test_driver/app.dart")
+///
+/// Then connect to the DTD and use flutter_driver commands to interact.
+Future<void> main() async {
+  enableFlutterDriverExtension();
+  await runSoliplexApp(
+    config: const SoliplexConfig(
+      logo: LogoConfig.soliplex,
+      oauthRedirectScheme: 'ai.soliplex.client',
+    ),
+  );
+}


### PR DESCRIPTION
## Summary
- Driver-enabled entry point for interactive testing via dart-tools MCP
- Adds flutter_driver as explicit dev dependency

## Changes
- **test_driver/app.dart**: New — enableFlutterDriverExtension() + runSoliplexApp()
- **pubspec.yaml**: Add flutter_driver SDK dev dependency
- **pubspec.lock**: Updated

## Test plan
- [x] `flutter analyze` clean
- [x] App launches via `mcp__dart-tools__launch_app(target: "test_driver/app.dart")`