### PR TITLE
docs(patrol): update skill, add Phase C/D plans, remove vendor names

### DIFF
--- a/.claude/skills/patrol/SKILL.md
+++ b/.claude/skills/patrol/SKILL.md
@@ -9,6 +9,15 @@ allowed-tools: Bash, Read, Edit, Write, Glob, Grep
 
 Run and manage Patrol integration tests for this Flutter project (macOS, iOS, Android, and Chrome).
 
+## Test Inventory
+
+| File | Auth | Backend | Tests |
+|------|------|---------|-------|
+| `smoke_test.dart` | no-auth | localhost:8000 | App boot, log harness |
+| `live_chat_test.dart` | no-auth | localhost:8000 | Rooms, chat send/receive |
+| `settings_test.dart` | no-auth | localhost:8000 | Settings navigation, tiles |
+| `oidc_test.dart` | OIDC | my.soliplex.com | ROPC rooms+chat, settings auth |
+
 ## Running Tests
 
 **CLI location:** `patrol`
@@ -18,17 +27,23 @@ Always use `--device` to avoid the interactive device selection prompt.
 ### macOS (default)
 
 ```bash
-# Run a specific test file
+# Run a specific no-auth test
 patrol test \
   --device macos \
-  --target integration_test/$ARGUMENTS \
-  --dart-define SOLIPLEX_BACKEND_URL=http://localhost:8000
+  --target integration_test/$ARGUMENTS
 
-# Run all integration tests
+# Run all no-auth tests (smoke, live_chat, settings)
 patrol test \
   --device macos \
-  --target integration_test/ \
-  --dart-define SOLIPLEX_BACKEND_URL=http://localhost:8000
+  --target integration_test/smoke_test.dart
+
+patrol test \
+  --device macos \
+  --target integration_test/live_chat_test.dart
+
+patrol test \
+  --device macos \
+  --target integration_test/settings_test.dart
 ```
 
 **First-time setup:** See [macOS Setup Guide](./setup/macos-setup.md) for entitlements and window constraints.
@@ -106,14 +121,31 @@ patrol test \
 
 **First-time setup:** See [Web Setup Guide](./setup/web-setup.md) for Node.js, CORS, and viewport details.
 
-If `$ARGUMENTS` is empty or "all", run against `integration_test/` (all tests).
+### OIDC tests (against my.soliplex.com)
+
+```bash
+patrol test \
+  --device macos \
+  --target integration_test/oidc_test.dart \
+  --dart-define SOLIPLEX_BACKEND_URL=https://my.soliplex.com \
+  --dart-define SOLIPLEX_OIDC_USERNAME=patrol \
+  --dart-define SOLIPLEX_OIDC_PASSWORD=patrol
+```
+
+OIDC tests **require** credentials via `--dart-define`. Without them the test
+calls `requireOidcCredentials()` and fails immediately.
+
+Optional: `--dart-define SOLIPLEX_OIDC_ISSUER_ID=oidc-client-name` (defaults to `oidc-client-name`).
+
+If `$ARGUMENTS` is empty or "all", run against `integration_test/` (all no-auth tests).
 If `$ARGUMENTS` is a filename like `smoke_test.dart`, run that specific file.
+If `$ARGUMENTS` is `oidc_test.dart`, use the OIDC command above.
 
 ## Pre-flight Checks
 
 Before running tests, verify:
 
-1. **Backend is running** in `--no-auth-mode` at the URL above
+1. **Backend is running** — localhost:8000 for no-auth, my.soliplex.com for OIDC
 2. **patrol CLI is installed**: `patrol --version`
 3. **Code compiles**: Run `dart analyze integration_test/` first
 4. **test_bundle.dart is current**: Patrol auto-generates this — if tests are missing from the bundle, delete it and let `patrol test` regenerate
@@ -128,7 +160,7 @@ SSE streams prevent settling. Use these instead:
 2. **`harness.waitForLog`** — stream-based, for async events (preferred)
 3. **`tester.pump(duration)`** — fixed delays, only for brief rendering pauses
 
-### Standard test structure
+### Standard no-auth test structure
 
 ```dart
 patrolTest('description', ($) async {
@@ -150,6 +182,41 @@ patrolTest('description', ($) async {
 });
 ```
 
+### Authenticated (OIDC) test structure
+
+```dart
+patrolTest('oidc - description', ($) async {
+  requireOidcCredentials();
+  await verifyBackendOrFail(backendUrl);
+  ignoreKeyboardAssertions();
+
+  final harness = TestLogHarness();
+  await harness.initialize();
+
+  try {
+    final tokens = await performRopcExchange(
+      baseUrl: backendUrl,
+      username: oidcUsername,
+      password: oidcPassword,
+      issuerId: oidcIssuerId,
+    );
+    await pumpAuthenticatedTestApp($, harness, tokens: tokens);
+    // ... test body ...
+  } catch (e) {
+    harness.dumpLogs(last: 50);
+    rethrow;
+  } finally {
+    harness.dispose();
+  }
+});
+```
+
+Key helpers for OIDC tests:
+
+- **`requireOidcCredentials()`** — fails fast if `--dart-define` creds missing
+- **`performRopcExchange()`** — HTTP POST `grant_type=password` to Keycloak token endpoint, returns `Authenticated` state
+- **`pumpAuthenticatedTestApp()`** — boots app with `PreAuthenticatedNotifier` injecting real OIDC tokens
+
 ### Widget finders reference
 
 | Target | Finder |
@@ -158,9 +225,12 @@ patrolTest('description', ($) async {
 | Chat input | `find.byType(TextField)` |
 | Send button | `find.byTooltip('Send message')` |
 | Chat messages | `find.byType(ChatMessageWidget)` |
-| Settings icon | `find.byIcon(Icons.settings)` |
+| Settings button | `find.byTooltip('Open settings')` |
+| Room search field | `find.byWidgetPredicate((w) => w is TextField && w.decoration?.hintText?.contains('Search') == true)` |
 
 **Avoid** `find.bySemanticsLabel` for text entry — it can resolve to the Semantics wrapper instead of the TextField, causing `enterText` to fail.
+
+**ListView.builder gotcha:** Off-screen items are not in the widget tree. Use the in-app search toolbar to filter items instead of scrolling.
 
 ### Log patterns for assertions
 
@@ -172,6 +242,16 @@ patrolTest('description', ($) async {
 | `ActiveRun` | `RUN_STARTED` | AG-UI SSE stream opened |
 | `ActiveRun` | `TEXT_START:` | First text chunk received |
 | `ActiveRun` | `RUN_FINISHED` | SSE stream completed |
+
+### UI visibility pump pattern
+
+Single `pump(Duration(seconds: 1))` renders only ONE frame. Use a loop for actual UI painting:
+
+```dart
+for (var i = 0; i < 5; i++) {
+  await $.tester.pump(const Duration(milliseconds: 200));
+}
+```
 
 ## Debugging: Two-Phase Workflow
 
@@ -209,6 +289,135 @@ in-process via `MemorySink`:
 The harness sees the same `[DEBUG]` logs that appear in `get_app_logs`,
 but accessed in-process rather than via stdout.
 
+## Interactive Debugging with flutter_driver
+
+Instead of writing blind Patrol tests, you can launch the app and interact
+with it in real time — seeing screenshots, inspecting the widget tree, and
+tapping/typing via `flutter_driver`.
+
+### When to use
+
+- **Debugging a failing Patrol test** — see what's actually on screen at the
+  point of failure
+- **Exploring UI for new test coverage** — discover widget types, tooltips,
+  and text before writing finders
+- **Rapid prototyping** — try a click sequence interactively before coding it
+
+### Setup: driver-enabled entry point
+
+The app needs `flutter_driver` extension enabled. Use `test_driver/app.dart`:
+
+```dart
+import 'package:flutter_driver/driver_extension.dart';
+import 'package:soliplex_frontend/soliplex_frontend.dart';
+
+Future<void> main() async {
+  enableFlutterDriverExtension();
+  await runSoliplexApp(
+    config: const SoliplexConfig(
+      logo: LogoConfig.soliplex,
+      oauthRedirectScheme: 'ai.soliplex.client',
+    ),
+  );
+}
+```
+
+`flutter_driver` is already in `dev_dependencies`.
+
+### Workflow
+
+**1. Launch the app:**
+
+```text
+mcp__dart-tools__launch_app(root: "...", device: "macos", target: "test_driver/app.dart")
+```
+
+Returns `dtdUri` and `pid`.
+
+**2. Connect to the Dart Tooling Daemon:**
+
+```text
+mcp__dart-tools__connect_dart_tooling_daemon(uri: <dtdUri>)
+```
+
+**3. Health check (confirms driver is active):**
+
+```text
+mcp__dart-tools__flutter_driver(command: "get_health")
+```
+
+**4. See the screen:**
+
+```text
+mcp__dart-tools__flutter_driver(command: "screenshot")
+```
+
+Returns a visual screenshot of the running app.
+
+**5. Inspect the widget tree:**
+
+```text
+mcp__dart-tools__get_widget_tree(summaryOnly: true)
+```
+
+Shows the full widget hierarchy with types, text content, and structure.
+
+**6. Interact — tap, type, wait:**
+
+```bash
+# Tap by text
+flutter_driver(command: "tap", finderType: "ByText", text: "Connect")
+
+# Tap by tooltip
+flutter_driver(command: "tap", finderType: "ByTooltipMessage", text: "Open settings")
+
+# Tap by widget type
+flutter_driver(command: "tap", finderType: "ByType", type: "TextFormField")
+
+# Enter text (tap the field first)
+flutter_driver(command: "enter_text", text: "http://localhost:8000")
+
+# Wait for a widget to appear
+flutter_driver(command: "waitFor", finderType: "ByText", text: "Rooms")
+
+# Get text from a widget
+flutter_driver(command: "get_text", finderType: "ByType", type: "Text")
+```
+
+**7. Stop the app:**
+
+```text
+mcp__dart-tools__stop_app(pid: <pid>)
+```
+
+### Available finder types
+
+| Finder | Required params |
+|--------|----------------|
+| `ByText` | `text` |
+| `ByTooltipMessage` | `text` |
+| `ByType` | `type` (widget runtime type) |
+| `ByValueKey` | `keyValueString`, `keyValueType` |
+| `BySemanticsLabel` | `label` |
+| `PageBack` | (none) |
+| `Ancestor` | `of`, `matching`, `matchRoot`, `firstMatchOnly` |
+| `Descendant` | `of`, `matching`, `matchRoot`, `firstMatchOnly` |
+
+### Capabilities vs limitations
+
+| Feature | Works | Notes |
+|---------|-------|-------|
+| Screenshot | Yes | Visual image of app state |
+| Widget tree | Yes | Full hierarchy via DTD |
+| Tap | Yes | By text, tooltip, type, key |
+| Enter text | Yes | Tap field first, then enter_text |
+| Wait for widget | Yes | `waitFor` / `waitForAbsent` |
+| Scroll | Yes | `scroll` with dx/dy/duration |
+| Hot reload | Yes | `mcp__dart-tools__hot_reload` |
+| Hot restart | Yes | `mcp__dart-tools__hot_restart` |
+| Widget selection | Yes | `set_widget_selection_mode` + `get_selected_widget` |
+| Multiple apps | No | One DTD connection at a time |
+
 ## Git Worktree Caveat
 
 This repo is a git worktree. Pre-commit hooks that invoke `flutter`/`dart` must `unset GIT_DIR` first, otherwise Flutter reports version `0.0.0-unknown`. Wrapper scripts in `scripts/` handle this.
@@ -232,3 +441,6 @@ This repo is a git worktree. Pre-commit hooks that invoke `flutter`/`dart` must 
 | Chrome: "Cannot find module playwright" | Node.js not installed | See [Web setup](./setup/web-setup.md) |
 | Chrome: CORS error in test | Backend missing CORS headers | See [Web setup](./setup/web-setup.md) |
 | Chrome: "Failed to fetch" on `verifyBackendOrFail` | Backend offline or CORS block | Start backend; check browser console |
+| OIDC test fails immediately | Missing `--dart-define` creds | Add `SOLIPLEX_OIDC_USERNAME` and `SOLIPLEX_OIDC_PASSWORD` |
+| 401 on OIDC test | Wrong issuer selected | Add `--dart-define SOLIPLEX_OIDC_ISSUER_ID=oidc-client-name` |
+| Room not found in list | ListView.builder — off-screen | Use room search toolbar instead of scrolling |

--- a/docs/planning/patrol/PLAN.md
+++ b/docs/planning/patrol/PLAN.md
@@ -1,0 +1,138 @@
+# Patrol E2E Integration - Plan
+
+## Strategy
+
+Get to a working Patrol E2E test as fast as possible. Start with
+`--no-auth-mode` to eliminate auth complexity, prove the toolchain, then layer
+on OIDC and CI. Leverage the existing logging system (`soliplex_logging`) for
+white-box observability, event-driven waits, and self-documenting failures.
+
+## Phases
+
+| Phase | Focus | Auth | Outcome |
+|-------|-------|------|---------|
+| **A** | [Setup + Smoke](./phase-a-setup-smoke.md) | no-auth | Patrol runs, app boots with logging, backend reachable |
+| **B** | [Live Chat](./phase-b-live-chat.md) | no-auth | Rooms load, chat send/receive with log-driven waits |
+| **C** | [OIDC + CI](./phase-c-oidc-ci.md) | oidc | Token-seeded auth via ROPC |
+| **D** | [Log Hardening](./phase-d-log-hardening.md) | both | Error sentinels, perf bounds, HTTP audit, negative assertions |
+
+## Dependency Graph
+
+```text
+Phase A (Setup + Smoke + TestLogHarness)
+└── Phase B (Live Chat, log-driven waits)
+    └── Phase C (OIDC auth via ROPC)
+        └── Phase D (Log hardening: sentinels, perf, audit)
+```
+
+## Progress
+
+- [x] Phase A — Setup + Smoke
+- [x] Phase B — Live Chat (no-auth)
+- [x] Phase C — OIDC auth via ROPC
+- [ ] Phase D — Log Hardening
+
+## Key Design Decisions
+
+### No-Auth First
+
+All initial tests run against a backend in `--no-auth-mode`. This removes every
+auth-related concern (Keycloak, tokens, provider overrides) from the critical
+path to a working test.
+
+### Token Seeding for OIDC (Not $.native)
+
+When we add OIDC in Phase C, we use **direct Keycloak ROPC token exchange** +
+provider override injection. We do NOT fight `ASWebAuthenticationSession` on
+macOS — it resists automation by design. `$.native` browser driving is deferred
+to a future hardening phase.
+
+**Keycloak requirement:** The test client must have "Direct Access Grants"
+enabled. See [Phase C](./phase-c-oidc-ci.md#keycloak-configuration).
+
+### Logging as Test Infrastructure
+
+The `soliplex_logging` package provides white-box observability inside E2E
+tests. This is the key differentiator of our Patrol rig:
+
+| Capability | Logging Component | Phase |
+|------------|-------------------|-------|
+| Event-driven waits (replace polling) | `MemorySink.onRecord` stream | A, B |
+| Internal pipeline assertions | `MemorySink.records` query | B |
+| Auto-diagnostics on failure | `MemorySink` dump (last 2000 records) | A |
+| Logfire correlation (`testRunId`) | `LogSanitizer` attribute injection | C |
+| CI failure artifacts | `logs.jsonl` + breadcrumbs bundle | C |
+| Performance regression detection | `LogRecord.timestamp` diffs | Future |
+
+### Logging Exploitation Levels
+
+```text
+Level 1: Free observation (read existing Loggers.* calls)      ← Phase A
+Level 2: Event-driven waits (MemorySink.onRecord stream)       ← Phase B
+Level 3: Structured event assertions (attribute-based)          ← Phase B
+Level 4: Logfire correlation (testRunId across client+server)   ← Phase C
+Level 5: Error sentinels (expectNoErrors across all tests)       ← Phase D
+Level 6: Negative/audit assertions (HTTP 401, auth restore)     ← Phase D
+Level 7: Performance regression detection (timestamp diffs)     ← Phase D
+```
+
+### Streaming-Safe Pumping
+
+`pumpAndSettle()` hangs on SSE streams. Phase A uses condition-based polling
+via `waitForCondition`. Phase B upgrades to log-driven waits via
+`harness.waitForLog()` where possible.
+
+### Minimal Harness, Grown Incrementally
+
+Phase A introduces `TestLogHarness` with just enough to boot the app with
+logging and dump diagnostics on failure. Each subsequent phase adds only what
+it needs.
+
+## Deferred (Future Phases)
+
+Intentionally deferred until the core test suite is stable:
+
+| Item | Reason to Defer |
+|------|-----------------|
+| `$.native` browser automation | Blocked by macOS `ASWebAuthenticationSession` |
+| Tool calling tests | Add after chat tests are stable |
+| Dual auth modes | One mode at a time is fine |
+| Dot-separated test IDs | Normal names until >5 tests |
+| `integration_test/README.md` | Write when there are real tests to document |
+| iOS targeting | Minimal config delta from macOS; add after macOS is green |
+| `runStep()` instrumentation | Add when >3 tests need timing |
+| Performance regression detection | Add when baseline established |
+
+## Review Gates
+
+Each phase must pass its gates before the next phase begins.
+Maximum 3 review/revise cycles per gate.
+
+### Phase A Gates
+
+| Gate | Tool | What |
+|------|------|------|
+| **Automated** | CLI | `flutter pub get`, `flutter analyze` = 0, `patrol --version`, `patrol doctor`, `flutter test` passes, smoke test green |
+| **Logging** | Manual | TestLogHarness initializes MemorySink, failure dumps last N records to console |
+| **Gemini Critique** | `read_files` / `gemini-3-pro-preview` | Review pubspec, harness, smoke test, logging_provider against spec |
+
+### Phase B Gates
+
+| Gate | Tool | What |
+|------|------|------|
+| **Automated** | CLI | `flutter analyze` = 0, both patrol tests green, no `pumpAndSettle` anywhere |
+| **Logging** | Manual | `waitForLog()` for SSE completion, `expectLog()` verifies HTTP + ActiveRun, `dumpLogs()` on failure |
+| **Gemini Critique** | `read_files` / `gemini-3-pro-preview` | Review test file, harness, config, loggers.dart against spec |
+| **Codex Cross-Validation** | `mcp__codex__codex` / `read-only` | Architecture review: does TestLogHarness + log-driven waits hold up? Provider override strategy correct? Anything brittle before adding auth? |
+
+Phase B gets both Gemini AND Codex review because it is the architectural
+pivot point — the harness, provider overrides, and log-driven wait pattern
+established here carry forward into Phase C and all future tests.
+
+### Phase C Gates
+
+| Gate | Tool | What |
+|------|------|------|
+| **Automated** | CLI | `flutter analyze` = 0, authenticated test green, no-auth tests still green, CI YAML valid |
+| **Logging** | Manual | `testRunId` in all LogRecords, queryable in Logfire with `SOLIPLEX_SHIP_LOGS=true`, failure artifact bundle produced |
+| **Gemini Critique** | `read_files` / `gemini-3-pro-preview` | Review auth_notifier, harness, config, authenticated test, CI workflow, logging_provider against spec |

--- a/docs/planning/patrol/phase-d-log-hardening.md
+++ b/docs/planning/patrol/phase-d-log-hardening.md
@@ -1,0 +1,213 @@
+# Phase D: Log-Driven Test Hardening
+
+**Status:** pending
+**Depends on:** Phase C
+**Logging level:** 5-7 (error sentinels, performance bounds, structured audit)
+
+## Objective
+
+Exploit the full `soliplex_logging` subsystem in Patrol tests. Phases A-C
+used only 4 of 9 available loggers, never checked log levels, and ignored
+timestamps. Phase D turns every silent failure into a test failure and
+establishes performance baselines.
+
+## Current Logging Coverage (Post Phase C)
+
+| Logger | Used | How |
+|--------|------|-----|
+| `Auth` | No | - |
+| `HTTP` | Partial | Route path assertions only |
+| `ActiveRun` | Yes | Lifecycle events (RUN_STARTED, TEXT_START, RUN_FINISHED) |
+| `Chat` | No | - |
+| `Room` | Partial | "Rooms loaded:" assertion only |
+| `Router` | Partial | "redirect called" assertion only |
+| `Quiz` | No | - |
+| `Config` | No | - |
+| `UI` | No | - |
+
+### Unused LogRecord Fields
+
+- `level` — never checked (error vs warning vs info)
+- `timestamp` — never used for timing
+- `error` / `stackTrace` — never inspected
+- Negative assertions — never assert something was NOT logged
+- Count-based assertions — never check occurrence counts
+
+## Deliverables
+
+### 1. Error Sentinel — `expectNoErrors()`
+
+Add to `TestLogHarness`:
+
+```dart
+void expectNoErrors({List<String> allowedPatterns = const []}) {
+  final errors = sink.records.where((r) => r.level >= LogLevel.error);
+  final unexpected = errors.where(
+    (r) => !allowedPatterns.any((p) => r.message.contains(p)),
+  );
+  if (unexpected.isNotEmpty) {
+    dumpLogs(last: 50);
+    fail(
+      '${unexpected.length} unexpected error(s):\n'
+      '${unexpected.map((r) => '  [${r.loggerName}] ${r.message}').join('\n')}',
+    );
+  }
+}
+```
+
+**Apply to:** Every test's `finally` block. Catches `LateInitializationError`,
+unhandled exceptions, and any silent crash that swallows errors.
+
+### 2. Auth Lifecycle Assertions (OIDC test)
+
+Verify the `Auth` logger shows the expected state path:
+
+- **No-auth tests:** `expectNoLog('Auth', ...)` — auth logger should be silent
+  (proves `NoAuthNotifier` bypass is clean)
+- **OIDC test:** `expectLog('Auth', 'Authenticated')` or verify auth state
+  was set without triggering `_restoreSession`
+- **Negative:** `expectNoLog('Auth', 'restore')` — proves
+  `PreAuthenticatedNotifier` skipped the restore path
+
+### 3. HTTP Audit Assertions
+
+Assert no unexpected HTTP error responses during a test:
+
+```dart
+void expectNoHttpErrors({List<int> allowedStatuses = const [404]}) {
+  final httpErrors = sink.records.where(
+    (r) => r.loggerName == 'HTTP' && _isHttpError(r.message),
+  );
+  // ...
+}
+```
+
+- No 401/403 in OIDC test (proves Bearer token valid throughout)
+- No 5xx in any test (backend health)
+
+### 4. Performance Bounds
+
+Measure time between log events and fail if outside bounds:
+
+```dart
+Duration measureLogDelta(String startLogger, String startPattern,
+    String endLogger, String endPattern) {
+  final start = sink.records.firstWhere(
+    (r) => r.loggerName == startLogger && r.message.contains(startPattern),
+  );
+  final end = sink.records.firstWhere(
+    (r) => r.loggerName == endLogger && r.message.contains(endPattern),
+  );
+  return end.timestamp.difference(start.timestamp);
+}
+```
+
+Use cases:
+
+- `RUN_STARTED` to `RUN_FINISHED` < 30s (detect backend regressions)
+- Room load time (HTTP request to "Rooms loaded") < 5s
+- App boot to Router redirect < 3s
+
+### 5. Negative Assertions — `expectNoLog()`
+
+Add to `TestLogHarness`:
+
+```dart
+void expectNoLog(String loggerName, String messagePattern) {
+  final found = sink.records.any(
+    (r) => r.loggerName == loggerName && r.message.contains(messagePattern),
+  );
+  if (found) {
+    dumpLogs(last: 30);
+    fail('Unexpected log found: [$loggerName] containing "$messagePattern"');
+  }
+}
+```
+
+Use cases:
+
+- `expectNoLog('Auth', 'LateInitializationError')` — in OIDC test
+- `expectNoLog('Auth', 'Unhandled restore error')` — in all tests
+- `expectNoLog('HTTP', '401')` — in OIDC test
+
+### 6. Config Logger Assertions
+
+Verify the app picked up the correct runtime configuration:
+
+- `expectLog('Config', backendUrl)` — proves dart-define reached the app
+- Useful for CI where misconfigured env vars silently use defaults
+
+### 7. HTTP Inspector Navigation Test
+
+Navigate to the Network Inspector screen and exercise the UI filters — a "meta"
+test that validates the log viewer itself:
+
+- Tap `Network Requests` tile in settings (text: `'Network Requests'`)
+- Verify `'Requests (N)'` header shows a non-zero count
+- Tap an `HttpEventTile` to open request detail
+- Cycle through all 3 tabs: `'Request'`, `'Response'`, `'curl'`
+- Verify the curl tab contains a copyable command
+- Tap `'Clear all requests'` button and verify the list empties
+
+Widget finders:
+
+| Target | Finder |
+|--------|--------|
+| Network Requests tile | `find.text('Network Requests')` |
+| Request count header | `find.textContaining('Requests (')` |
+| Request tile | `find.byType(HttpEventTile)` |
+| Tab: Request | `find.text('Request')` |
+| Tab: Response | `find.text('Response')` |
+| Tab: curl | `find.text('curl')` |
+| Clear button | `find.byTooltip('Clear all requests')` |
+| Empty state | `find.text('No HTTP requests yet')` |
+
+## Implementation Order
+
+| Step | Deliverable | Files | Effort |
+|------|-------------|-------|--------|
+| 1 | `expectNoErrors()` + apply to all tests | `test_log_harness.dart`, all `*_test.dart` | Small |
+| 2 | `expectNoLog()` + negative assertions | `test_log_harness.dart`, `oidc_test.dart` | Small |
+| 3 | Auth lifecycle assertions | `oidc_test.dart`, `smoke_test.dart` | Small |
+| 4 | HTTP audit assertions | `test_log_harness.dart`, `oidc_test.dart` | Medium |
+| 5 | `measureLogDelta()` + perf bounds | `test_log_harness.dart`, `live_chat_test.dart` | Medium |
+| 6 | Config logger assertions | `smoke_test.dart` | Small |
+| 7 | HTTP Inspector navigation test | `settings_test.dart` | Medium |
+
+## Review Gate
+
+| Gate | Tool | What |
+|------|------|------|
+| **Automated** | CLI | `flutter analyze` = 0, all 6 patrol tests green |
+| **Sentinel** | Manual | Inject a deliberate `Loggers.auth.error(...)` call and verify `expectNoErrors()` catches it |
+| **Perf** | Manual | Verify `measureLogDelta` produces reasonable values against live backend |
+
+## Prerequisite: Structured HTTP Status Logging
+
+The `HTTP` logger currently logs `debug('200 response')` — the status code is
+embedded in a free-text message with no structured field. This makes it hard to
+grep for 401/403 errors programmatically.
+
+**Action:** Update `http_log_provider.dart` to include the status code as a
+parseable prefix or add it to a structured log field:
+
+```dart
+// Before:
+Loggers.http.debug('${event.statusCode} response');
+
+// After:
+Loggers.http.debug('HTTP ${event.statusCode} ${event.method} ${event.uri}');
+```
+
+This gives `expectNoLog('HTTP', 'HTTP 401')` a reliable pattern to match.
+
+## Risks
+
+- **False positives from `expectNoErrors()`** — some `error`-level logs may be
+  expected (e.g., keychain unavailable in debug builds). Mitigated by
+  `allowedPatterns` parameter.
+- **Flaky perf bounds** — backend response times vary. Use generous thresholds
+  (3x normal) and focus on detecting regressions, not absolute targets.
+- **Log format coupling** — assertions depend on log message strings. If
+  `Loggers.*` messages change, tests break. Acceptable tradeoff for white-box
+  observability.

--- a/packages/soliplex_client/test/api/fetch_auth_providers_test.dart
+++ b/packages/soliplex_client/test/api/fetch_auth_providers_test.dart
@@ -40,10 +40,10 @@ void main() {
             'client_id': 'my-client',
             'scope': 'openid email profile',
           },
-          'pydio': {
-            'title': 'Pydio SSO',
-            'server_url': 'https://sso.pydio.com/auth',
-            'client_id': 'pydio-client',
+          'oidc-client-name': {
+            'title': 'Corporate SSO',
+            'server_url': 'https://sso.example.com/auth',
+            'client_id': 'oidc-client',
             'scope': 'openid',
           },
         },
@@ -62,11 +62,11 @@ void main() {
       expect(keycloak.clientId, equals('my-client'));
       expect(keycloak.scope, equals('openid email profile'));
 
-      final pydio = providers.firstWhere((p) => p.id == 'pydio');
-      expect(pydio.name, equals('Pydio SSO'));
-      expect(pydio.serverUrl, equals('https://sso.pydio.com/auth'));
-      expect(pydio.clientId, equals('pydio-client'));
-      expect(pydio.scope, equals('openid'));
+      final oidc = providers.firstWhere((p) => p.id == 'oidc-client-name');
+      expect(oidc.name, equals('Corporate SSO'));
+      expect(oidc.serverUrl, equals('https://sso.example.com/auth'));
+      expect(oidc.clientId, equals('oidc-client'));
+      expect(oidc.scope, equals('openid'));
     });
 
     test('returns empty list when no providers configured', () async {


### PR DESCRIPTION
## Summary
- Update patrol SKILL.md with OIDC patterns, test inventory, flutter_driver debugging workflow
- Add patrol PLAN.md (phases A-D tracker) and Phase D log-hardening spec
- Remove pydio/enfoldsystems references from test fixtures

## Changes
- **.claude/skills/patrol/SKILL.md**: OIDC test structure, interactive debugging, troubleshooting additions
- **docs/planning/patrol/PLAN.md**: New — phase tracker with dependency graph
- **docs/planning/patrol/phase-d-log-hardening.md**: New — Phase D spec (error sentinels, perf bounds, HTTP audit)
- **packages/soliplex_client/test/api/fetch_auth_providers_test.dart**: Replace vendor-specific test fixture names

## Test plan
- [x] Markdown lint clean
- [x] `flutter analyze` clean
- [x] `dart test` in soliplex_client passes (7/7)