### PR TITLE
docs(patrol): consolidate skills, plans, and flutter_driver setup

### DIFF
--- a/.claude/skills/debugging/SKILL.md
+++ b/.claude/skills/debugging/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: debugging
+description: Debug Flutter UI issues using the widget inspector. Use when a finder fails, a widget isn't rendering as expected, you need to verify text values, or you're investigating runtime errors.
+allowed-tools: Bash, Read, Glob, Grep
+---
+
+# Flutter Debugging Skill
+
+Debug Flutter UI issues by inspecting and interacting with a live app via
+the Dart Tooling Daemon (DTD) and flutter_driver.
+
+- **Inspection** (widget tree, errors, logs) works with any running app.
+- **Interaction** (tap, enter text, scroll) requires flutter_driver.
+
+## CRITICAL PROTOCOL
+
+**YOU MUST** run `mcp__dart-tools__get_widget_tree` before writing a
+single line of test code or modifying an existing finder.
+
+**DO NOT GUESS** widget text or types based on Dart source code.
+
+1. Source code shows variables (e.g., `room.name`).
+2. Widget tree shows reality (e.g., `"Gemini 2.5 Flash"`).
+3. If you write a finder without inspecting the tree first, you are
+   breaking protocol.
+
+## Relationship to Other Skills
+
+This skill provides the tools for **Phase 1 (Discover)** of the Patrol
+E2E testing workflow. You MUST use the tools here (`get_widget_tree`,
+`get_app_logs`) to gather the correct finders and log patterns *before*
+writing or modifying a Patrol test in Phase 2.
+
+The `logging` skill defines the log message conventions that produce the
+`[DEBUG]` patterns you will see in `get_app_logs` and assert against in
+`harness.expectLog()`.
+
+## Workflow
+
+### 1. Launch the app
+
+For **inspection only** (widget tree, logs, errors):
+
+```text
+mcp__dart-tools__launch_app(root, device: "macos")
+```
+
+For **inspection + interaction** (tap, enter text, scroll):
+
+```text
+mcp__dart-tools__launch_app(root, device: "macos",
+    target: "test_driver/app.dart")
+```
+
+The `test_driver/app.dart` entry point calls
+`enableFlutterDriverExtension()` which enables flutter_driver commands.
+Requires `flutter_driver` as a dev dependency in `pubspec.yaml`.
+
+Returns `dtdUri` and `pid`. The app opens on the target device.
+
+### 2. Connect to the Dart Tooling Daemon
+
+```text
+mcp__dart-tools__connect_dart_tooling_daemon(uri: <dtdUri>)
+```
+
+One connection per session. If already connected, skip this step.
+
+### 3. Inspect the widget tree
+
+```text
+mcp__dart-tools__get_widget_tree(summaryOnly: true)
+```
+
+- `summaryOnly: true` returns only user-created widgets (skips framework
+  internals).
+- **Extract the exact `widgetRuntimeType` string.** Use this directly
+  in your `find.byType(WidgetType)` finder.
+- **Extract the exact `textPreview` string.** Use this to determine if
+  you need an exact match or a substring match with
+  `findByTextContaining`. This step prevents exact-match bugs like the
+  "Gemini" vs "Gemini 2.5 Flash" failure.
+
+### 4. Check for errors
+
+```text
+mcp__dart-tools__get_runtime_errors()
+mcp__dart-tools__get_app_logs(pid: <pid>, maxLines: 50)
+```
+
+- `get_runtime_errors` shows uncaught exceptions in the running app.
+- `get_app_logs` shows stdout output including `[DEBUG]` log lines.
+- Copy the specific `[DEBUG]` log pattern (logger name + message) into
+  your `harness.expectLog` or `harness.waitForLog` call.
+
+### 5. Interactive debugging with flutter_driver
+
+Requires launching with `target: "test_driver/app.dart"`.
+
+**Health check (confirms driver is active):**
+
+```text
+mcp__dart-tools__flutter_driver(command: "get_health")
+```
+
+**Screenshot:**
+
+```text
+mcp__dart-tools__flutter_driver(command: "screenshot")
+```
+
+**Interact — tap, type, wait:**
+
+```text
+# Tap by text
+flutter_driver(command: "tap", finderType: "ByText", text: "Connect")
+
+# Tap by tooltip
+flutter_driver(command: "tap", finderType: "ByTooltipMessage",
+    text: "Open settings")
+
+# Tap by widget type
+flutter_driver(command: "tap", finderType: "ByType",
+    type: "TextFormField")
+
+# Enter text (tap the field first)
+flutter_driver(command: "enter_text", text: "http://localhost:8000")
+
+# Wait for a widget to appear
+flutter_driver(command: "waitFor", finderType: "ByText", text: "Rooms")
+
+# Get text from a widget
+flutter_driver(command: "get_text", finderType: "ByType", type: "Text")
+```
+
+**Available finder types:**
+
+| Finder | Required params |
+|--------|----------------|
+| `ByText` | `text` |
+| `ByTooltipMessage` | `text` |
+| `ByType` | `type` (widget runtime type) |
+| `ByValueKey` | `keyValueString`, `keyValueType` |
+| `BySemanticsLabel` | `label` |
+| `PageBack` | (none) |
+| `Ancestor` | `of`, `matching`, `matchRoot`, `firstMatchOnly` |
+| `Descendant` | `of`, `matching`, `matchRoot`, `firstMatchOnly` |
+
+### 6. Interactive widget selection (optional)
+
+```text
+mcp__dart-tools__set_widget_selection_mode(enabled: true)
+```
+
+Ask the user to tap a widget in the running app, then:
+
+```text
+mcp__dart-tools__get_selected_widget()
+```
+
+Returns full details of what the user selected. Useful when the tree is
+large and you need to locate a specific widget.
+
+### 7. Clean up
+
+```text
+mcp__dart-tools__stop_app(pid: <pid>)
+```
+
+**ALWAYS check for lingering processes** after stopping:
+
+```bash
+ps aux | grep "Soliplex.app" | grep -v grep
+```
+
+Kill any orphaned processes. The DTD `stop_app` call does not always
+terminate the macOS process cleanly.
+
+Also run `mcp__dart-tools__list_running_apps` before launching to avoid
+starting duplicate instances.
+
+## Capabilities
+
+| Feature | Works | Notes |
+|---------|-------|-------|
+| Screenshot | Yes | Visual image of app state |
+| Widget tree | Yes | Full hierarchy via DTD |
+| Tap | Yes | By text, tooltip, type, key |
+| Enter text | Yes | Tap field first, then enter_text |
+| Wait for widget | Yes | `waitFor` / `waitForAbsent` |
+| Scroll | Yes | `scroll` with dx/dy/duration |
+| Hot reload | Yes | `mcp__dart-tools__hot_reload` |
+| Hot restart | Yes | `mcp__dart-tools__hot_restart` |
+| Widget selection | Yes | `set_widget_selection_mode` + `get_selected_widget` |
+| Multiple apps | No | One DTD connection at a time |
+
+## When to Use This Skill
+
+- A `find.byType` or `find.widgetWithText` finder isn't matching
+- You need to see what text a widget actually displays
+- A widget isn't rendering or is in an unexpected state
+- You're writing new finders and want to verify the widget hierarchy
+- You're investigating runtime errors or unexpected behavior
+- The `patrol` skill directs you here for Phase 1 Discovery
+
+## Anti-Patterns
+
+1. **GUESSING FINDERS**: Never write a finder based on reading Dart
+   source code. The rendered UI is the only source of truth.
+   Action: Run `get_widget_tree` first.
+
+2. **SKIPPING INSPECTION**: Do not fix a failing test by tweaking the
+   finder repeatedly. This is inefficient.
+   Action: Stop, launch the app, inspect the tree, find the correct
+   value in one step.
+
+3. **LEAVING ORPHAN PROCESSES**: `stop_app` can fail to terminate the
+   app. A lingering process will interfere with the next run.
+   Action: After `stop_app`, ALWAYS run
+   `ps aux | grep "Soliplex.app"` and kill any remaining processes.
+
+4. **MULTIPLE INSTANCES**: Launching the app without checking if one
+   is already running creates confusion and port conflicts.
+   Action: Run `list_running_apps` before `launch_app`.

--- a/.claude/skills/logging/SKILL.md
+++ b/.claude/skills/logging/SKILL.md
@@ -34,8 +34,10 @@ fit, add a new static field to `Loggers`.
 
 ### Message Style and Stack Traces
 
-Messages state **what happened** and **to what**. Always use
-`catch (e, s)` and pass both to the logger.
+Your log message MUST state **what happened** and **to what entity**.
+When logging an error, you MUST use a `catch (e, s)` block and pass
+both the `error` and `stackTrace` objects to the logger. Losing the
+stack trace is a critical error.
 
 ```dart
 // Good
@@ -67,3 +69,26 @@ paths. Filter by `loggerName` to isolate a feature.
 
 Circular buffer (2000 records) via `memorySinkProvider`. Oldest
 records evicted when full.
+
+## Usage in Patrol E2E Tests
+
+Patrol tests **cannot** see internal app state. They rely entirely on
+logs captured by the `TestLogHarness` via `MemorySink`.
+
+- **Assert:** `harness.expectLog('ActiveRun', 'RUN_FINISHED')` verifies
+  an operation happened.
+- **Wait:** `harness.waitForLog('ActiveRun', 'RUN_FINISHED')` blocks
+  until an async process completes.
+- **Debug:** `harness.dumpLogs(last: 50)` dumps recent logs on failure.
+
+**Workflow for discovering log patterns:**
+
+1. Run the app manually (via `debugging` skill).
+2. Perform the action you want to test.
+3. Call `mcp__dart-tools__get_app_logs` to see the `[DEBUG]` output.
+4. Copy the exact logger name and message pattern into your
+   `harness.expectLog` or `harness.waitForLog` call.
+
+**Write clear, unique, and predictable log messages to create stable,
+non-flaky tests.** Vague messages like `'done'` make test assertions
+impossible to write.

--- a/.claude/skills/patrol/SKILL.md
+++ b/.claude/skills/patrol/SKILL.md
@@ -7,7 +7,25 @@ allowed-tools: Bash, Read, Edit, Write, Glob, Grep
 
 # Patrol E2E Test Skill
 
-Run and manage Patrol integration tests for this Flutter project (macOS, iOS, Android, and Chrome).
+**PREREQUISITE:** If you are writing a NEW test or fixing a broken finder,
+you MUST load the `debugging` skill first.
+
+1. **Load:** `debugging` skill.
+2. **Inspect:** Run `mcp__dart-tools__get_widget_tree` to see reality.
+3. **Write:** Return here to write the Patrol test using the exact
+   strings you found.
+
+Run and manage Patrol integration tests for this Flutter project
+(macOS, iOS, Android, and Chrome).
+
+## Test Inventory
+
+| File | Auth | Backend | Tests |
+|------|------|---------|-------|
+| `smoke_test.dart` | no-auth | localhost:8000 | App boot, log harness |
+| `live_chat_test.dart` | no-auth | localhost:8000 | Rooms, chat send/receive |
+| `settings_test.dart` | no-auth | localhost:8000 | Settings navigation, tiles |
+| `oidc_test.dart` | OIDC | configurable | ROPC rooms+chat, settings auth |
 
 ## Running Tests
 
@@ -18,17 +36,24 @@ Always use `--device` to avoid the interactive device selection prompt.
 ### macOS (default)
 
 ```bash
-# Run a specific test file
+# Run a specific no-auth test
 patrol test \
   --device macos \
   --target integration_test/$ARGUMENTS \
   --dart-define SOLIPLEX_BACKEND_URL=http://localhost:8000
 
-# Run all integration tests
+# Run all no-auth tests
 patrol test \
   --device macos \
-  --target integration_test/ \
-  --dart-define SOLIPLEX_BACKEND_URL=http://localhost:8000
+  --target integration_test/smoke_test.dart
+
+patrol test \
+  --device macos \
+  --target integration_test/live_chat_test.dart
+
+patrol test \
+  --device macos \
+  --target integration_test/settings_test.dart
 ```
 
 **First-time setup:** See [macOS Setup Guide](./setup/macos-setup.md) for entitlements and window constraints.
@@ -106,19 +131,65 @@ patrol test \
 
 **First-time setup:** See [Web Setup Guide](./setup/web-setup.md) for Node.js, CORS, and viewport details.
 
-If `$ARGUMENTS` is empty or "all", run against `integration_test/` (all tests).
+### OIDC tests
+
+```bash
+patrol test \
+  --device macos \
+  --target integration_test/oidc_test.dart \
+  --dart-define SOLIPLEX_BACKEND_URL=https://my.soliplex.com \
+  --dart-define SOLIPLEX_OIDC_USERNAME=patrol \
+  --dart-define SOLIPLEX_OIDC_PASSWORD=patrol \
+  --dart-define SOLIPLEX_OIDC_ISSUER_ID=<issuer-key>
+```
+
+OIDC tests **require** all three credentials via `--dart-define`. Without
+them the test calls `requireOidcCredentials()` and fails immediately.
+
+If `$ARGUMENTS` is empty or "all", run against `integration_test/` (all no-auth tests).
 If `$ARGUMENTS` is a filename like `smoke_test.dart`, run that specific file.
+If `$ARGUMENTS` is `oidc_test.dart`, use the OIDC command above.
 
 ## Pre-flight Checks
 
 Before running tests, verify:
 
-1. **Backend is running** in `--no-auth-mode` at the URL above
+1. **Backend is running** — localhost:8000 for no-auth, or the OIDC backend URL
 2. **patrol CLI is installed**: `patrol --version`
 3. **Code compiles**: Run `dart analyze integration_test/` first
 4. **test_bundle.dart is current**: Patrol auto-generates this — if tests are missing from the bundle, delete it and let `patrol test` regenerate
 
+## FORBIDDEN PATTERNS
+
+Read this BEFORE writing any test code.
+
+1. **The "Exact Match" Trap:**
+   - FORBIDDEN: `find.widgetWithText(RoomListTile, 'Gemini')`
+   - Why: Fails because the widget renders "Gemini 2.5 Flash".
+   - REQUIRED: `findByTextContaining(RoomListTile, 'Gemini')`
+
+2. **The "Blind Finder" Trap:**
+   - FORBIDDEN: Writing `find.byType(MyWidget)` based on reading source.
+   - Why: The runtime widget may be wrapped in `Semantics`, `Padding`,
+     or `GestureDetector` that obscures the type.
+   - REQUIRED: Run `mcp__dart-tools__get_widget_tree` and copy the
+     exact `widgetRuntimeType`.
+
+3. **The "Pump" Trap:**
+   - FORBIDDEN: `await $.pumpAndSettle()`
+   - Why: SSE streams keep the app "active" indefinitely.
+   - REQUIRED: Use `harness.waitForLog(...)` or `waitForCondition(...)`.
+
+4. **The "Semantics" Trap:**
+   - FORBIDDEN: `find.bySemanticsLabel` for text entry targets.
+   - Why: Resolves to the Semantics wrapper, not the TextField.
+   - REQUIRED: Use `find.byType(TextField)`.
+
 ## Test Patterns
+
+**Core Rule: Inspect Before You Write.** Before adding or changing any
+finder, follow the debugging workflow below. Guessing finders from source
+code is the most common cause of test failures.
 
 ### Never use pumpAndSettle
 
@@ -128,7 +199,7 @@ SSE streams prevent settling. Use these instead:
 2. **`harness.waitForLog`** — stream-based, for async events (preferred)
 3. **`tester.pump(duration)`** — fixed delays, only for brief rendering pauses
 
-### Standard test structure
+### Standard no-auth test structure
 
 ```dart
 patrolTest('description', ($) async {
@@ -150,17 +221,66 @@ patrolTest('description', ($) async {
 });
 ```
 
+### Authenticated (OIDC) test structure
+
+```dart
+patrolTest('oidc - description', ($) async {
+  requireOidcCredentials();
+  await verifyBackendOrFail(backendUrl);
+  ignoreKeyboardAssertions();
+
+  final harness = TestLogHarness();
+  await harness.initialize();
+
+  try {
+    final tokens = await performRopcExchange(
+      baseUrl: backendUrl,
+      username: oidcUsername,
+      password: oidcPassword,
+      issuerId: oidcIssuerId,
+    );
+    await pumpAuthenticatedTestApp($, harness, tokens: tokens);
+    // ... test body ...
+  } catch (e) {
+    harness.dumpLogs(last: 50);
+    rethrow;
+  } finally {
+    harness.dispose();
+  }
+});
+```
+
+Key helpers for OIDC tests:
+
+- **`requireOidcCredentials()`** — fails fast if `--dart-define` creds missing
+- **`performRopcExchange()`** — HTTP POST `grant_type=password` to Keycloak
+  token endpoint, returns `Authenticated` state
+- **`pumpAuthenticatedTestApp()`** — boots app with
+  `PreAuthenticatedNotifier` injecting real OIDC tokens
+
 ### Widget finders reference
 
 | Target | Finder |
 |--------|--------|
 | Room list items | `find.byType(RoomListTile)` |
+| Room by name (substring) | `findByTextContaining(RoomListTile, 'Gemini')` |
 | Chat input | `find.byType(TextField)` |
 | Send button | `find.byTooltip('Send message')` |
 | Chat messages | `find.byType(ChatMessageWidget)` |
-| Settings icon | `find.byIcon(Icons.settings)` |
+| Settings button | `find.byTooltip('Open settings')` |
+| Room search field | `find.byWidgetPredicate((w) => w is TextField && w.decoration?.hintText?.contains('Search') == true)` |
 
-**Avoid** `find.bySemanticsLabel` for text entry — it can resolve to the Semantics wrapper instead of the TextField, causing `enterText` to fail.
+**Text Matching Protocol:**
+
+1. **DEFAULT** to `findByTextContaining(WidgetType, 'Substring')`.
+   UI text often contains version numbers, status, or whitespace
+   (e.g., "Gemini 2.5 Flash" vs "Gemini").
+2. **ONLY** use exact matching if you have verified the `textPreview`
+   in the widget tree is static and will not change.
+3. `findByTextContaining` is defined in `patrol_test_config.dart`.
+
+**ListView.builder gotcha:** Off-screen items are not in the widget tree.
+Use the in-app search toolbar to filter items instead of scrolling.
 
 ### Log patterns for assertions
 
@@ -173,26 +293,37 @@ patrolTest('description', ($) async {
 | `ActiveRun` | `TEXT_START:` | First text chunk received |
 | `ActiveRun` | `RUN_FINISHED` | SSE stream completed |
 
-## Debugging: Two-Phase Workflow
+### UI visibility pump pattern
 
-### Phase 1: Discover (dart MCP — `flutter run`)
+Single `pump(Duration(seconds: 1))` renders only ONE frame. Use a loop
+for actual UI painting:
 
-Use `mcp__dart-tools__launch_app` to start the app, then inspect the live
-widget tree and logs to find the right finders and log patterns for your test.
-
-```text
-mcp__dart-tools__launch_app   → starts app, returns DTD URI
-mcp__dart-tools__connect_dart_tooling_daemon → connect to running app
-mcp__dart-tools__get_widget_tree(summaryOnly: true) → see real widget hierarchy
-mcp__dart-tools__get_app_logs(pid, maxLines: 50)    → see stdout log output
-mcp__dart-tools__get_runtime_errors                  → check for exceptions
+```dart
+for (var i = 0; i < 5; i++) {
+  await $.tester.pump(const Duration(milliseconds: 200));
+}
 ```
 
-Stdout logs appear as `[DEBUG] Router: redirect called for /` — use these
-to identify the logger name and message pattern for `harness.expectLog()`.
+## Debugging: Two-Phase Workflow
 
-The widget tree shows actual `widgetRuntimeType` values — use these for
-`find.byType()` finders.
+### Phase 1: MANDATORY Discovery
+
+**STOP. Do not write any finders yet.**
+
+Use the `debugging` skill to launch the app and inspect the widget tree.
+
+1. Run `mcp__dart-tools__launch_app` to start the app.
+2. Run `mcp__dart-tools__connect_dart_tooling_daemon` with the DTD URI.
+3. Run `mcp__dart-tools__get_widget_tree(summaryOnly: true)`.
+4. **READ the `textPreview`** of the target widget — this is your
+   source of truth for text finders.
+5. **COPY the `widgetRuntimeType`** directly into your test code.
+6. Run `mcp__dart-tools__get_app_logs` to see `[DEBUG]` log patterns
+   for `harness.expectLog()` assertions.
+
+For interactive debugging (tap, enter text, scroll), launch with
+`target: "test_driver/app.dart"` which enables flutter_driver commands.
+See the `debugging` skill for the full flutter_driver workflow.
 
 ### Phase 2: Assert (TestLogHarness — patrol run)
 
@@ -232,3 +363,6 @@ This repo is a git worktree. Pre-commit hooks that invoke `flutter`/`dart` must 
 | Chrome: "Cannot find module playwright" | Node.js not installed | See [Web setup](./setup/web-setup.md) |
 | Chrome: CORS error in test | Backend missing CORS headers | See [Web setup](./setup/web-setup.md) |
 | Chrome: "Failed to fetch" on `verifyBackendOrFail` | Backend offline or CORS block | Start backend; check browser console |
+| OIDC test fails immediately | Missing `--dart-define` creds | Add `SOLIPLEX_OIDC_USERNAME`, `SOLIPLEX_OIDC_PASSWORD`, `SOLIPLEX_OIDC_ISSUER_ID` |
+| 401 on OIDC test | Wrong issuer selected | Check `--dart-define SOLIPLEX_OIDC_ISSUER_ID` matches backend |
+| Room not found in list | ListView.builder — off-screen | Use room search toolbar instead of scrolling |

--- a/docs/planning/patrol/PLAN.md
+++ b/docs/planning/patrol/PLAN.md
@@ -1,0 +1,138 @@
+# Patrol E2E Integration - Plan
+
+## Strategy
+
+Get to a working Patrol E2E test as fast as possible. Start with
+`--no-auth-mode` to eliminate auth complexity, prove the toolchain, then layer
+on OIDC and CI. Leverage the existing logging system (`soliplex_logging`) for
+white-box observability, event-driven waits, and self-documenting failures.
+
+## Phases
+
+| Phase | Focus | Auth | Outcome |
+|-------|-------|------|---------|
+| **A** | [Setup + Smoke](./phase-a-setup-smoke.md) | no-auth | Patrol runs, app boots with logging, backend reachable |
+| **B** | [Live Chat](./phase-b-live-chat.md) | no-auth | Rooms load, chat send/receive with log-driven waits |
+| **C** | [OIDC + CI](./phase-c-oidc-ci.md) | oidc | Token-seeded auth via ROPC |
+| **D** | [Log Hardening](./phase-d-log-hardening.md) | both | Error sentinels, perf bounds, HTTP audit, negative assertions |
+
+## Dependency Graph
+
+```text
+Phase A (Setup + Smoke + TestLogHarness)
+└── Phase B (Live Chat, log-driven waits)
+    └── Phase C (OIDC auth via ROPC)
+        └── Phase D (Log hardening: sentinels, perf, audit)
+```
+
+## Progress
+
+- [x] Phase A — Setup + Smoke
+- [x] Phase B — Live Chat (no-auth)
+- [x] Phase C — OIDC auth via ROPC
+- [ ] Phase D — Log Hardening
+
+## Key Design Decisions
+
+### No-Auth First
+
+All initial tests run against a backend in `--no-auth-mode`. This removes every
+auth-related concern (Keycloak, tokens, provider overrides) from the critical
+path to a working test.
+
+### Token Seeding for OIDC (Not $.native)
+
+When we add OIDC in Phase C, we use **direct Keycloak ROPC token exchange** +
+provider override injection. We do NOT fight `ASWebAuthenticationSession` on
+macOS — it resists automation by design. `$.native` browser driving is deferred
+to a future hardening phase.
+
+**Keycloak requirement:** The test client must have "Direct Access Grants"
+enabled. See [Phase C](./phase-c-oidc-ci.md#keycloak-configuration).
+
+### Logging as Test Infrastructure
+
+The `soliplex_logging` package provides white-box observability inside E2E
+tests. This is the key differentiator of our Patrol rig:
+
+| Capability | Logging Component | Phase |
+|------------|-------------------|-------|
+| Event-driven waits (replace polling) | `MemorySink.onRecord` stream | A, B |
+| Internal pipeline assertions | `MemorySink.records` query | B |
+| Auto-diagnostics on failure | `MemorySink` dump (last 2000 records) | A |
+| Logfire correlation (`testRunId`) | `LogSanitizer` attribute injection | C |
+| CI failure artifacts | `logs.jsonl` + breadcrumbs bundle | C |
+| Performance regression detection | `LogRecord.timestamp` diffs | Future |
+
+### Logging Exploitation Levels
+
+```text
+Level 1: Free observation (read existing Loggers.* calls)      <- Phase A
+Level 2: Event-driven waits (MemorySink.onRecord stream)       <- Phase B
+Level 3: Structured event assertions (attribute-based)          <- Phase B
+Level 4: Logfire correlation (testRunId across client+server)   <- Phase C
+Level 5: Error sentinels (expectNoErrors across all tests)       <- Phase D
+Level 6: Negative/audit assertions (HTTP 401, auth restore)     <- Phase D
+Level 7: Performance regression detection (timestamp diffs)     <- Phase D
+```
+
+### Streaming-Safe Pumping
+
+`pumpAndSettle()` hangs on SSE streams. Phase A uses condition-based polling
+via `waitForCondition`. Phase B upgrades to log-driven waits via
+`harness.waitForLog()` where possible.
+
+### Minimal Harness, Grown Incrementally
+
+Phase A introduces `TestLogHarness` with just enough to boot the app with
+logging and dump diagnostics on failure. Each subsequent phase adds only what
+it needs.
+
+## Deferred (Future Phases)
+
+Intentionally deferred until the core test suite is stable:
+
+| Item | Reason to Defer |
+|------|-----------------|
+| `$.native` browser automation | Blocked by macOS `ASWebAuthenticationSession` |
+| Tool calling tests | Add after chat tests are stable |
+| Dual auth modes | One mode at a time is fine |
+| Dot-separated test IDs | Normal names until >5 tests |
+| `integration_test/README.md` | Write when there are real tests to document |
+| iOS targeting | Minimal config delta from macOS; add after macOS is green |
+| `runStep()` instrumentation | Add when >3 tests need timing |
+| Performance regression detection | Add when baseline established |
+
+## Review Gates
+
+Each phase must pass its gates before the next phase begins.
+Maximum 3 review/revise cycles per gate.
+
+### Phase A Gates
+
+| Gate | Tool | What |
+|------|------|------|
+| **Automated** | CLI | `flutter pub get`, `flutter analyze` = 0, `patrol --version`, `patrol doctor`, `flutter test` passes, smoke test green |
+| **Logging** | Manual | TestLogHarness initializes MemorySink, failure dumps last N records to console |
+| **Gemini Critique** | `read_files` / `gemini-3-pro-preview` | Review pubspec, harness, smoke test, logging_provider against spec |
+
+### Phase B Gates
+
+| Gate | Tool | What |
+|------|------|------|
+| **Automated** | CLI | `flutter analyze` = 0, both patrol tests green, no `pumpAndSettle` anywhere |
+| **Logging** | Manual | `waitForLog()` for SSE completion, `expectLog()` verifies HTTP + ActiveRun, `dumpLogs()` on failure |
+| **Gemini Critique** | `read_files` / `gemini-3-pro-preview` | Review test file, harness, config, loggers.dart against spec |
+| **Codex Cross-Validation** | `mcp__codex__codex` / `read-only` | Architecture review: does TestLogHarness + log-driven waits hold up? Provider override strategy correct? Anything brittle before adding auth? |
+
+Phase B gets both Gemini AND Codex review because it is the architectural
+pivot point — the harness, provider overrides, and log-driven wait pattern
+established here carry forward into Phase C and all future tests.
+
+### Phase C Gates
+
+| Gate | Tool | What |
+|------|------|------|
+| **Automated** | CLI | `flutter analyze` = 0, authenticated test green, no-auth tests still green, CI YAML valid |
+| **Logging** | Manual | `testRunId` in all LogRecords, queryable in Logfire with `SOLIPLEX_SHIP_LOGS=true`, failure artifact bundle produced |
+| **Gemini Critique** | `read_files` / `gemini-3-pro-preview` | Review auth_notifier, harness, config, authenticated test, CI workflow, logging_provider against spec |

--- a/docs/planning/patrol/phase-d-log-hardening.md
+++ b/docs/planning/patrol/phase-d-log-hardening.md
@@ -1,0 +1,213 @@
+# Phase D: Log-Driven Test Hardening
+
+**Status:** pending
+**Depends on:** Phase C
+**Logging level:** 5-7 (error sentinels, performance bounds, structured audit)
+
+## Objective
+
+Exploit the full `soliplex_logging` subsystem in Patrol tests. Phases A-C
+used only 4 of 9 available loggers, never checked log levels, and ignored
+timestamps. Phase D turns every silent failure into a test failure and
+establishes performance baselines.
+
+## Current Logging Coverage (Post Phase C)
+
+| Logger | Used | How |
+|--------|------|-----|
+| `Auth` | No | - |
+| `HTTP` | Partial | Route path assertions only |
+| `ActiveRun` | Yes | Lifecycle events (RUN_STARTED, TEXT_START, RUN_FINISHED) |
+| `Chat` | No | - |
+| `Room` | Partial | "Rooms loaded:" assertion only |
+| `Router` | Partial | "redirect called" assertion only |
+| `Quiz` | No | - |
+| `Config` | No | - |
+| `UI` | No | - |
+
+### Unused LogRecord Fields
+
+- `level` — never checked (error vs warning vs info)
+- `timestamp` — never used for timing
+- `error` / `stackTrace` — never inspected
+- Negative assertions — never assert something was NOT logged
+- Count-based assertions — never check occurrence counts
+
+## Deliverables
+
+### 1. Error Sentinel — `expectNoErrors()`
+
+Add to `TestLogHarness`:
+
+```dart
+void expectNoErrors({List<String> allowedPatterns = const []}) {
+  final errors = sink.records.where((r) => r.level >= LogLevel.error);
+  final unexpected = errors.where(
+    (r) => !allowedPatterns.any((p) => r.message.contains(p)),
+  );
+  if (unexpected.isNotEmpty) {
+    dumpLogs(last: 50);
+    fail(
+      '${unexpected.length} unexpected error(s):\n'
+      '${unexpected.map((r) => '  [${r.loggerName}] ${r.message}').join('\n')}',
+    );
+  }
+}
+```
+
+**Apply to:** Every test's `finally` block. Catches `LateInitializationError`,
+unhandled exceptions, and any silent crash that swallows errors.
+
+### 2. Auth Lifecycle Assertions (OIDC test)
+
+Verify the `Auth` logger shows the expected state path:
+
+- **No-auth tests:** `expectNoLog('Auth', ...)` — auth logger should be silent
+  (proves `NoAuthNotifier` bypass is clean)
+- **OIDC test:** `expectLog('Auth', 'Authenticated')` or verify auth state
+  was set without triggering `_restoreSession`
+- **Negative:** `expectNoLog('Auth', 'restore')` — proves
+  `PreAuthenticatedNotifier` skipped the restore path
+
+### 3. HTTP Audit Assertions
+
+Assert no unexpected HTTP error responses during a test:
+
+```dart
+void expectNoHttpErrors({List<int> allowedStatuses = const [404]}) {
+  final httpErrors = sink.records.where(
+    (r) => r.loggerName == 'HTTP' && _isHttpError(r.message),
+  );
+  // ...
+}
+```
+
+- No 401/403 in OIDC test (proves Bearer token valid throughout)
+- No 5xx in any test (backend health)
+
+### 4. Performance Bounds
+
+Measure time between log events and fail if outside bounds:
+
+```dart
+Duration measureLogDelta(String startLogger, String startPattern,
+    String endLogger, String endPattern) {
+  final start = sink.records.firstWhere(
+    (r) => r.loggerName == startLogger && r.message.contains(startPattern),
+  );
+  final end = sink.records.firstWhere(
+    (r) => r.loggerName == endLogger && r.message.contains(endPattern),
+  );
+  return end.timestamp.difference(start.timestamp);
+}
+```
+
+Use cases:
+
+- `RUN_STARTED` to `RUN_FINISHED` < 30s (detect backend regressions)
+- Room load time (HTTP request to "Rooms loaded") < 5s
+- App boot to Router redirect < 3s
+
+### 5. Negative Assertions — `expectNoLog()`
+
+Add to `TestLogHarness`:
+
+```dart
+void expectNoLog(String loggerName, String messagePattern) {
+  final found = sink.records.any(
+    (r) => r.loggerName == loggerName && r.message.contains(messagePattern),
+  );
+  if (found) {
+    dumpLogs(last: 30);
+    fail('Unexpected log found: [$loggerName] containing "$messagePattern"');
+  }
+}
+```
+
+Use cases:
+
+- `expectNoLog('Auth', 'LateInitializationError')` — in OIDC test
+- `expectNoLog('Auth', 'Unhandled restore error')` — in all tests
+- `expectNoLog('HTTP', '401')` — in OIDC test
+
+### 6. Config Logger Assertions
+
+Verify the app picked up the correct runtime configuration:
+
+- `expectLog('Config', backendUrl)` — proves dart-define reached the app
+- Useful for CI where misconfigured env vars silently use defaults
+
+### 7. HTTP Inspector Navigation Test
+
+Navigate to the Network Inspector screen and exercise the UI filters — a "meta"
+test that validates the log viewer itself:
+
+- Tap `Network Requests` tile in settings (text: `'Network Requests'`)
+- Verify `'Requests (N)'` header shows a non-zero count
+- Tap an `HttpEventTile` to open request detail
+- Cycle through all 3 tabs: `'Request'`, `'Response'`, `'curl'`
+- Verify the curl tab contains a copyable command
+- Tap `'Clear all requests'` button and verify the list empties
+
+Widget finders:
+
+| Target | Finder |
+|--------|--------|
+| Network Requests tile | `find.text('Network Requests')` |
+| Request count header | `find.textContaining('Requests (')` |
+| Request tile | `find.byType(HttpEventTile)` |
+| Tab: Request | `find.text('Request')` |
+| Tab: Response | `find.text('Response')` |
+| Tab: curl | `find.text('curl')` |
+| Clear button | `find.byTooltip('Clear all requests')` |
+| Empty state | `find.text('No HTTP requests yet')` |
+
+## Implementation Order
+
+| Step | Deliverable | Files | Effort |
+|------|-------------|-------|--------|
+| 1 | `expectNoErrors()` + apply to all tests | `test_log_harness.dart`, all `*_test.dart` | Small |
+| 2 | `expectNoLog()` + negative assertions | `test_log_harness.dart`, `oidc_test.dart` | Small |
+| 3 | Auth lifecycle assertions | `oidc_test.dart`, `smoke_test.dart` | Small |
+| 4 | HTTP audit assertions | `test_log_harness.dart`, `oidc_test.dart` | Medium |
+| 5 | `measureLogDelta()` + perf bounds | `test_log_harness.dart`, `live_chat_test.dart` | Medium |
+| 6 | Config logger assertions | `smoke_test.dart` | Small |
+| 7 | HTTP Inspector navigation test | `settings_test.dart` | Medium |
+
+## Review Gate
+
+| Gate | Tool | What |
+|------|------|------|
+| **Automated** | CLI | `flutter analyze` = 0, all 6 patrol tests green |
+| **Sentinel** | Manual | Inject a deliberate `Loggers.auth.error(...)` call and verify `expectNoErrors()` catches it |
+| **Perf** | Manual | Verify `measureLogDelta` produces reasonable values against live backend |
+
+## Prerequisite: Structured HTTP Status Logging
+
+The `HTTP` logger currently logs `debug('200 response')` — the status code is
+embedded in a free-text message with no structured field. This makes it hard to
+grep for 401/403 errors programmatically.
+
+**Action:** Update `http_log_provider.dart` to include the status code as a
+parseable prefix or add it to a structured log field:
+
+```dart
+// Before:
+Loggers.http.debug('${event.statusCode} response');
+
+// After:
+Loggers.http.debug('HTTP ${event.statusCode} ${event.method} ${event.uri}');
+```
+
+This gives `expectNoLog('HTTP', 'HTTP 401')` a reliable pattern to match.
+
+## Risks
+
+- **False positives from `expectNoErrors()`** — some `error`-level logs may be
+  expected (e.g., keychain unavailable in debug builds). Mitigated by
+  `allowedPatterns` parameter.
+- **Flaky perf bounds** — backend response times vary. Use generous thresholds
+  (3x normal) and focus on detecting regressions, not absolute targets.
+- **Log format coupling** — assertions depend on log message strings. If
+  `Loggers.*` messages change, tests break. Acceptable tradeoff for white-box
+  observability.

--- a/packages/soliplex_client/test/api/fetch_auth_providers_test.dart
+++ b/packages/soliplex_client/test/api/fetch_auth_providers_test.dart
@@ -40,10 +40,10 @@ void main() {
             'client_id': 'my-client',
             'scope': 'openid email profile',
           },
-          'pydio': {
-            'title': 'Pydio SSO',
-            'server_url': 'https://sso.pydio.com/auth',
-            'client_id': 'pydio-client',
+          'oidc-client-name': {
+            'title': 'Corporate SSO',
+            'server_url': 'https://sso.example.com/auth',
+            'client_id': 'oidc-client',
             'scope': 'openid',
           },
         },
@@ -62,11 +62,11 @@ void main() {
       expect(keycloak.clientId, equals('my-client'));
       expect(keycloak.scope, equals('openid email profile'));
 
-      final pydio = providers.firstWhere((p) => p.id == 'pydio');
-      expect(pydio.name, equals('Pydio SSO'));
-      expect(pydio.serverUrl, equals('https://sso.pydio.com/auth'));
-      expect(pydio.clientId, equals('pydio-client'));
-      expect(pydio.scope, equals('openid'));
+      final oidc = providers.firstWhere((p) => p.id == 'oidc-client-name');
+      expect(oidc.name, equals('Corporate SSO'));
+      expect(oidc.serverUrl, equals('https://sso.example.com/auth'));
+      expect(oidc.clientId, equals('oidc-client'));
+      expect(oidc.scope, equals('openid'));
     });
 
     test('returns empty list when no providers configured', () async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -280,7 +280,7 @@ packages:
     source: hosted
     version: "11.0.0"
   flutter_driver:
-    dependency: transitive
+    dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,8 @@ dependencies:
   web: ^1.1.1
 
 dev_dependencies:
+  flutter_driver:
+    sdk: flutter
   flutter_launcher_icons: ^0.14.4
   flutter_native_splash: ^2.4.7
   flutter_test:

--- a/test_driver/app.dart
+++ b/test_driver/app.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_driver/driver_extension.dart';
+import 'package:soliplex_frontend/soliplex_frontend.dart';
+
+/// Driver-enabled entry point for interactive testing via dart-tools MCP.
+///
+/// Launch with:
+///   mcp__dart-tools__launch_app(target: "test_driver/app.dart")
+///
+/// Then connect to the DTD and use flutter_driver commands to interact.
+Future<void> main() async {
+  enableFlutterDriverExtension();
+  await runSoliplexApp(
+    config: const SoliplexConfig(
+      logo: LogoConfig.soliplex,
+      oauthRedirectScheme: 'ai.soliplex.client',
+    ),
+  );
+}


### PR DESCRIPTION
## Summary
- Consolidates PRs #276, #277, #278 into a single PR
- Rewrites all three skill files (patrol, debugging, logging) with active voice, gating, and FORBIDDEN PATTERNS
- Adds flutter_driver entry point and dev dependency for interactive debugging
- Adds Phase D log hardening spec and updates patrol PLAN.md
- Replaces vendor-specific names in test fixtures with generic examples

## Changes
- **patrol/SKILL.md**: Active voice rewrite with PREREQUISITE gate, FORBIDDEN PATTERNS, test inventory, OIDC commands, authenticated test structure, ListView.builder gotcha, UI pump pattern, troubleshooting rows
- **debugging/SKILL.md**: New skill for widget inspector and flutter_driver interactive debugging
- **logging/SKILL.md**: Added Patrol E2E cross-reference section
- **pubspec.yaml**: Added `flutter_driver` SDK dev dependency
- **test_driver/app.dart**: New entry point with `enableFlutterDriverExtension()`
- **docs/planning/patrol/PLAN.md**: Updated phase tracker (A-D)
- **docs/planning/patrol/phase-d-log-hardening.md**: Phase D spec (error sentinels, perf bounds, HTTP audit, negative assertions)
- **fetch_auth_providers_test.dart**: Replaced vendor names (pydio/sso.pydio.com) with generic examples

## Supersedes
- Closes #276 (flutter_driver entry point)
- Closes #277 (skill content + planning docs + vendor cleanup)
- Closes #278 (active voice skill rewrites)

## Test plan
- [x] `dart format .` — no changes
- [x] `flutter analyze --fatal-infos` — 0 issues
- [x] `dart test` on soliplex_client — all 7 auth provider tests pass
- [x] `npx markdownlint-cli` — all markdown files pass
- [x] Pre-commit hooks pass (format, analyze, secrets)