### PR TITLE
fix(client): stream drain fix + tool call unit tests

### DIFF
--- a/lib/core/providers/active_run_notifier.dart
+++ b/lib/core/providers/active_run_notifier.dart
@@ -539,6 +539,10 @@ class ActiveRunNotifier extends Notifier<ActiveRunState> {
     await internal.subscription.cancel();
     if (!ref.mounted) return;
 
+    // Safety 4: If cancelRun() or reset() replaced _internalState during
+    // the stream drain, another owner took over. Do not start Run 2.
+    if (_internalState != internal) return;
+
     await _continueWithToolResults(internal, conversation);
   }
 


### PR DESCRIPTION
## Summary
- Drain Run 1 SSE stream before creating continuation run, fixing HTTP 500 race condition where backend hadn't marked Run 1 as finished
- Add `toolExecutionPending` flag to prevent `onDone` from transitioning to `CompletedState` during tool execution
- Guard continuation run against concurrent `cancelRun()` with identity check
- Add 12 unit tests covering the full tool call continuation flow

## Changes
- **`active_run_notifier.dart`**: Add `streamDone` Completer + `toolExecutionPending` bool to `RunningInternalState`; update `onDone` handler to complete Completer and skip completion when pending; update `_executeToolsAndContinue` to resume/drain/cancel stream before continuation; add `_internalState != internal` identity guard
- **`active_run_notifier_test.dart`**: New `tool call execution` test group with 12 tests covering execution trigger, status lifecycle, onDone skip, stream drain, tool results in messages, tool failure, continuation failure, timeout, empty registry, normal runs, cache update, and cancel-during-execution

## Test plan
- [x] `dart format .` — no changes
- [x] `flutter analyze --fatal-infos` — 0 issues
- [x] `flutter test` — 1233 tests pass
- [x] Coverage: 85.8% for `active_run_notifier.dart`