### PR TITLE
refactor(markdown): sanitize stray HTML br tags in markdown input

### DIFF
--- a/lib/shared/widgets/markdown/flutter_markdown_plus_renderer.dart
+++ b/lib/shared/widgets/markdown/flutter_markdown_plus_renderer.dart
@@ -26,7 +26,7 @@ class FlutterMarkdownPlusRenderer extends MarkdownRenderer {
     final monoStyle = context.monospace;
 
     return MarkdownBody(
-      data: data,
+      data: _sanitize(data),
       styleSheet: markdownTheme?.toMarkdownStyleSheet(
         codeFontStyle: monoStyle,
       ),
@@ -37,4 +37,8 @@ class FlutterMarkdownPlusRenderer extends MarkdownRenderer {
       },
     );
   }
+
+  static final _brTag = RegExp(r'<br\s*/?>');
+
+  static String _sanitize(String markdown) => markdown.replaceAll(_brTag, '\n');
 }

--- a/test/shared/widgets/markdown/flutter_markdown_plus_renderer_test.dart
+++ b/test/shared/widgets/markdown/flutter_markdown_plus_renderer_test.dart
@@ -57,6 +57,60 @@ void main() {
       expect(find.byType(MarkdownBody), findsOneWidget);
     });
 
+    testWidgets('sanitizes <br> tags to newlines', (tester) async {
+      await tester.pumpWidget(
+        createTestApp(
+          home: const FlutterMarkdownPlusRenderer(
+            data: 'line one<br>line two',
+          ),
+        ),
+      );
+
+      final body = tester.widget<MarkdownBody>(find.byType(MarkdownBody));
+      expect(body.data, 'line one\nline two');
+    });
+
+    testWidgets('sanitizes <br /> tags to newlines', (tester) async {
+      await tester.pumpWidget(
+        createTestApp(
+          home: const FlutterMarkdownPlusRenderer(
+            data: 'line one<br />line two',
+          ),
+        ),
+      );
+
+      final body = tester.widget<MarkdownBody>(find.byType(MarkdownBody));
+      expect(body.data, 'line one\nline two');
+    });
+
+    testWidgets('sanitizes <br/> tags to newlines', (tester) async {
+      await tester.pumpWidget(
+        createTestApp(
+          home: const FlutterMarkdownPlusRenderer(
+            data: 'line one<br/>line two',
+          ),
+        ),
+      );
+
+      final body = tester.widget<MarkdownBody>(find.byType(MarkdownBody));
+      expect(body.data, 'line one\nline two');
+    });
+
+    testWidgets('passes through content without HTML unchanged', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        createTestApp(
+          home: const FlutterMarkdownPlusRenderer(
+            data: 'no html here',
+          ),
+        ),
+      );
+
+      final body = tester.widget<MarkdownBody>(find.byType(MarkdownBody));
+      expect(body.data, 'no html here');
+    });
+
     testWidgets('uses styles from MarkdownThemeExtension', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary

- Add `_sanitize()` method to `FlutterMarkdownPlusRenderer`
- Replace `<br>`, `<br />`, `<br/>` variants with newlines
- Content without HTML passes through unchanged

Part of #100 (slice 3/7)

**Depends on:** #298

## Test plan

- [x] `<br>` replaced with newline
- [x] `<br />` replaced with newline
- [x] `<br/>` replaced with newline
- [x] Content without HTML passes through unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)