### PR TITLE
refactor(markdown): wire clickable links in markdown renderer

### DIFF
--- a/lib/features/chat/widgets/chat_message_widget.dart
+++ b/lib/features/chat/widgets/chat_message_widget.dart
@@ -11,6 +11,8 @@ import 'package:soliplex_frontend/design/design.dart';
 import 'package:soliplex_frontend/features/chat/widgets/citations_section.dart';
 import 'package:soliplex_frontend/shared/widgets/markdown/flutter_markdown_plus_renderer.dart';
 
+import 'package:url_launcher/url_launcher.dart';
+
 /// Widget that displays a single chat message.
 class ChatMessageWidget extends StatelessWidget {
   const ChatMessageWidget({
@@ -113,7 +115,10 @@ class ChatMessageWidget extends StatelessWidget {
                       // The markdown is rendered as separate widgets,
                       // if you set selectable: true, you'll have to select
                       // each widget separately.
-                      FlutterMarkdownPlusRenderer(data: text),
+                      FlutterMarkdownPlusRenderer(
+                        data: text,
+                        onLinkTap: _openLink,
+                      ),
                     // Only show streaming indicator when there's actual text
                     // being streamed. When text is empty, the status indicator
                     // at the bottom of the list shows what's happening.
@@ -226,6 +231,20 @@ class ChatMessageWidget extends StatelessWidget {
         ],
       ),
     );
+  }
+
+  Future<void> _openLink(String href, String? title) async {
+    final uri = Uri.tryParse(href);
+    if (uri == null) return;
+    try {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    } on Exception catch (e, stackTrace) {
+      Loggers.ui.error(
+        'Failed to open link: $href',
+        error: e,
+        stackTrace: stackTrace,
+      );
+    }
   }
 
   Future<void> _copyToClipboard(BuildContext context, String text) async {

--- a/lib/shared/widgets/markdown/flutter_markdown_plus_renderer.dart
+++ b/lib/shared/widgets/markdown/flutter_markdown_plus_renderer.dart
@@ -30,6 +30,11 @@ class FlutterMarkdownPlusRenderer extends MarkdownRenderer {
       styleSheet: markdownTheme?.toMarkdownStyleSheet(
         codeFontStyle: monoStyle,
       ),
+      onTapLink: onLinkTap == null
+          ? null
+          : (_, href, title) {
+              if (href != null) onLinkTap!(href, title);
+            },
       builders: {
         'code': CodeBlockBuilder(
           preferredStyle: monoStyle.copyWith(fontSize: 14),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1018,6 +1018,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "767344bf3063897b5cf0db830e94f904528e6dd50a6dfaf839f0abf509009611"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.28"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: b1aca26728b7cc7a3af971bb6f601554a8ae9df2e0a006de8450ba06a17ad36a
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.0"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.5"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: d0412fcf4c6b31ecfdb7762359b7206ffba3bbffd396c6d9f9c4616ece476c1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   uuid:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
     path: packages/soliplex_client_native
   soliplex_logging:
     path: packages/soliplex_logging
+  url_launcher: ^6.3.2
   uuid: ^4.5.1
   wakelock_plus: ^1.4.0
   web: ^1.1.1

--- a/test/features/chat/widgets/chat_message_widget_test.dart
+++ b/test/features/chat/widgets/chat_message_widget_test.dart
@@ -235,6 +235,26 @@ void main() {
         expect(find.text('**bold** and *italic* text'), findsOneWidget);
       });
 
+      testWidgets('provides link tap handler to markdown renderer', (
+        tester,
+      ) async {
+        final message = TestData.createMessage(
+          user: ChatUser.assistant,
+          text: 'Visit [site](https://example.com)',
+        );
+
+        await tester.pumpWidget(
+          createTestApp(
+            home: Scaffold(body: ChatMessageWidget(message: message)),
+          ),
+        );
+
+        final renderer = tester.widget<FlutterMarkdownPlusRenderer>(
+          find.byType(FlutterMarkdownPlusRenderer),
+        );
+        expect(renderer.onLinkTap, isNotNull);
+      });
+
       testWidgets('renders code blocks with syntax highlighting', (
         tester,
       ) async {

--- a/test/shared/widgets/markdown/flutter_markdown_plus_renderer_test.dart
+++ b/test/shared/widgets/markdown/flutter_markdown_plus_renderer_test.dart
@@ -111,6 +111,69 @@ void main() {
       expect(body.data, 'no html here');
     });
 
+    testWidgets('wires onLinkTap to MarkdownBody.onTapLink', (
+      tester,
+    ) async {
+      String? tappedHref;
+      String? tappedTitle;
+
+      await tester.pumpWidget(
+        createTestApp(
+          home: FlutterMarkdownPlusRenderer(
+            data: '[example](https://example.com)',
+            onLinkTap: (href, title) {
+              tappedHref = href;
+              tappedTitle = title;
+            },
+          ),
+        ),
+      );
+
+      final body = tester.widget<MarkdownBody>(find.byType(MarkdownBody));
+      expect(body.onTapLink, isNotNull);
+
+      // Simulate the package callback to verify bridging
+      body.onTapLink!('example', 'https://example.com', '');
+      expect(tappedHref, 'https://example.com');
+      expect(tappedTitle, '');
+    });
+
+    testWidgets('does not set onTapLink when onLinkTap is null', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        createTestApp(
+          home: const FlutterMarkdownPlusRenderer(
+            data: '[example](https://example.com)',
+          ),
+        ),
+      );
+
+      final body = tester.widget<MarkdownBody>(find.byType(MarkdownBody));
+      expect(body.onTapLink, isNull);
+    });
+
+    testWidgets('onLinkTap ignores links with null href', (tester) async {
+      String? tappedHref;
+
+      await tester.pumpWidget(
+        createTestApp(
+          home: FlutterMarkdownPlusRenderer(
+            data: '[example](https://example.com)',
+            onLinkTap: (href, title) {
+              tappedHref = href;
+            },
+          ),
+        ),
+      );
+
+      final body = tester.widget<MarkdownBody>(find.byType(MarkdownBody));
+
+      // Simulate the package calling with null href
+      body.onTapLink!('example', null, '');
+      expect(tappedHref, isNull);
+    });
+
     testWidgets('uses styles from MarkdownThemeExtension', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary

- Wire `onTapLink` in `FlutterMarkdownPlusRenderer` to the adapter's `onLinkTap` callback
- In `ChatMessageWidget`, provide an `onLinkTap` handler that opens URLs via `url_launcher`
- Null-safe: ignores links with null href, skips callback wiring when `onLinkTap` is null

Part of #100 (slice 4/7)

**Depends on:** #299

## Test plan

- [ ] Tapping a link calls `onLinkTap` with correct href
- [ ] Links with null href are ignored
- [ ] No `onTapLink` set when `onLinkTap` is null

🤖 Generated with [Claude Code](https://claude.com/claude-code)