### PR TITLE
refactor(markdown): add fullscreen image viewer with zoom/pan/rotate

### DIFF
--- a/lib/features/chat/widgets/chat_message_widget.dart
+++ b/lib/features/chat/widgets/chat_message_widget.dart
@@ -9,6 +9,7 @@ import 'package:soliplex_client/soliplex_client.dart'
 import 'package:soliplex_frontend/core/logging/loggers.dart';
 import 'package:soliplex_frontend/design/design.dart';
 import 'package:soliplex_frontend/features/chat/widgets/citations_section.dart';
+import 'package:soliplex_frontend/shared/widgets/fullscreen_image_viewer.dart';
 import 'package:soliplex_frontend/shared/widgets/markdown/flutter_markdown_plus_renderer.dart';
 
 import 'package:url_launcher/url_launcher.dart';
@@ -118,6 +119,11 @@ class ChatMessageWidget extends StatelessWidget {
                       FlutterMarkdownPlusRenderer(
                         data: text,
                         onLinkTap: _openLink,
+                        onImageTap: (src, alt) => _openImage(
+                          context,
+                          src,
+                          alt,
+                        ),
                       ),
                     // Only show streaming indicator when there's actual text
                     // being streamed. When text is empty, the status indicator
@@ -245,6 +251,14 @@ class ChatMessageWidget extends StatelessWidget {
         stackTrace: stackTrace,
       );
     }
+  }
+
+  void _openImage(BuildContext context, String src, String? alt) {
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => FullscreenImageViewer(imageUrl: src, altText: alt),
+      ),
+    );
   }
 
   Future<void> _copyToClipboard(BuildContext context, String text) async {

--- a/lib/shared/widgets/fullscreen_image_viewer.dart
+++ b/lib/shared/widgets/fullscreen_image_viewer.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+
+/// Fullscreen overlay for viewing images with zoom, pan, and rotation.
+class FullscreenImageViewer extends StatefulWidget {
+  const FullscreenImageViewer({
+    required this.imageUrl,
+    this.altText,
+    super.key,
+  });
+
+  final String imageUrl;
+  final String? altText;
+
+  @override
+  State<FullscreenImageViewer> createState() => _FullscreenImageViewerState();
+}
+
+class _FullscreenImageViewerState extends State<FullscreenImageViewer> {
+  int _quarterTurns = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        foregroundColor: Colors.white,
+        leading: IconButton(
+          icon: const Icon(Icons.close),
+          tooltip: 'Close',
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.rotate_right),
+            tooltip: 'Rotate',
+            onPressed: () => setState(() => _quarterTurns++),
+          ),
+        ],
+      ),
+      extendBodyBehindAppBar: true,
+      body: Column(
+        children: [
+          Expanded(
+            child: InteractiveViewer(
+              minScale: 1,
+              maxScale: 5,
+              child: Center(
+                child: RotatedBox(
+                  quarterTurns: _quarterTurns,
+                  child: Image.network(
+                    widget.imageUrl,
+                    errorBuilder: (_, __, ___) => const Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Icon(
+                          Icons.broken_image,
+                          color: Colors.white54,
+                          size: 64,
+                        ),
+                        SizedBox(height: 16),
+                        Text(
+                          'Failed to load image',
+                          style: TextStyle(color: Colors.white54),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          if (widget.altText != null && widget.altText!.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: Text(
+                widget.altText!,
+                style: const TextStyle(color: Colors.white70),
+                textAlign: TextAlign.center,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/shared/widgets/markdown/flutter_markdown_plus_renderer.dart
+++ b/lib/shared/widgets/markdown/flutter_markdown_plus_renderer.dart
@@ -35,11 +35,30 @@ class FlutterMarkdownPlusRenderer extends MarkdownRenderer {
           : (_, href, title) {
               if (href != null) onLinkTap!(href, title);
             },
+      imageBuilder: onImageTap == null ? null : _buildImage,
       builders: {
         'code': CodeBlockBuilder(
           preferredStyle: monoStyle.copyWith(fontSize: 14),
         ),
       },
+    );
+  }
+
+  Widget _buildImage(Uri uri, String? title, String? alt) {
+    return GestureDetector(
+      onTap: () => onImageTap!(uri.toString(), alt),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxHeight: 400),
+        child: Image.network(
+          uri.toString(),
+          fit: BoxFit.contain,
+          errorBuilder: (_, __, ___) => const Icon(
+            Icons.broken_image,
+            size: 48,
+            color: Colors.grey,
+          ),
+        ),
+      ),
     );
   }
 

--- a/test/features/chat/widgets/chat_message_widget_test.dart
+++ b/test/features/chat/widgets/chat_message_widget_test.dart
@@ -255,6 +255,26 @@ void main() {
         expect(renderer.onLinkTap, isNotNull);
       });
 
+      testWidgets('provides image tap handler to markdown renderer', (
+        tester,
+      ) async {
+        final message = TestData.createMessage(
+          user: ChatUser.assistant,
+          text: '![photo](https://example.com/img.png)',
+        );
+
+        await tester.pumpWidget(
+          createTestApp(
+            home: Scaffold(body: ChatMessageWidget(message: message)),
+          ),
+        );
+
+        final renderer = tester.widget<FlutterMarkdownPlusRenderer>(
+          find.byType(FlutterMarkdownPlusRenderer),
+        );
+        expect(renderer.onImageTap, isNotNull);
+      });
+
       testWidgets('renders code blocks with syntax highlighting', (
         tester,
       ) async {

--- a/test/shared/widgets/fullscreen_image_viewer_test.dart
+++ b/test/shared/widgets/fullscreen_image_viewer_test.dart
@@ -1,0 +1,173 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/shared/widgets/fullscreen_image_viewer.dart';
+
+import '../../helpers/test_helpers.dart';
+
+void main() {
+  group('FullscreenImageViewer', () {
+    testWidgets('wraps image in InteractiveViewer for zoom/pan', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        createTestApp(
+          home: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () => Navigator.of(context).push(
+                MaterialPageRoute<void>(
+                  builder: (_) => const FullscreenImageViewer(
+                    imageUrl: 'https://example.com/photo.png',
+                  ),
+                ),
+              ),
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(InteractiveViewer), findsOneWidget);
+    });
+
+    testWidgets('close button pops the route', (tester) async {
+      await tester.pumpWidget(
+        createTestApp(
+          home: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () => Navigator.of(context).push(
+                MaterialPageRoute<void>(
+                  builder: (_) => const FullscreenImageViewer(
+                    imageUrl: 'https://example.com/photo.png',
+                  ),
+                ),
+              ),
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byTooltip('Close'));
+      await tester.pumpAndSettle();
+
+      // Back on the original page
+      expect(find.text('Open'), findsOneWidget);
+      expect(find.byType(FullscreenImageViewer), findsNothing);
+    });
+
+    testWidgets('shows error state when image fails to load', (tester) async {
+      await tester.pumpWidget(
+        createTestApp(
+          home: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () => Navigator.of(context).push(
+                MaterialPageRoute<void>(
+                  builder: (_) => const FullscreenImageViewer(
+                    imageUrl: 'https://broken.example.com/missing.png',
+                  ),
+                ),
+              ),
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      // Network images fail in test environment, triggering the error state
+      expect(find.byIcon(Icons.broken_image), findsOneWidget);
+    });
+
+    testWidgets('displays alt text when provided', (tester) async {
+      await tester.pumpWidget(
+        createTestApp(
+          home: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () => Navigator.of(context).push(
+                MaterialPageRoute<void>(
+                  builder: (_) => const FullscreenImageViewer(
+                    imageUrl: 'https://example.com/photo.png',
+                    altText: 'A beautiful sunset',
+                  ),
+                ),
+              ),
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('A beautiful sunset'), findsOneWidget);
+    });
+
+    testWidgets('rotate button rotates image by 90 degrees', (tester) async {
+      await tester.pumpWidget(
+        createTestApp(
+          home: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () => Navigator.of(context).push(
+                MaterialPageRoute<void>(
+                  builder: (_) => const FullscreenImageViewer(
+                    imageUrl: 'https://example.com/photo.png',
+                  ),
+                ),
+              ),
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      // Initially no rotation
+      var rotated = tester.widget<RotatedBox>(find.byType(RotatedBox));
+      expect(rotated.quarterTurns, 0);
+
+      // Tap rotate button
+      await tester.tap(find.byTooltip('Rotate'));
+      await tester.pumpAndSettle();
+
+      // After one tap, rotated 90 degrees
+      rotated = tester.widget<RotatedBox>(find.byType(RotatedBox));
+      expect(rotated.quarterTurns, 1);
+    });
+
+    testWidgets('has dark background for image viewing', (tester) async {
+      await tester.pumpWidget(
+        createTestApp(
+          home: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () => Navigator.of(context).push(
+                MaterialPageRoute<void>(
+                  builder: (_) => const FullscreenImageViewer(
+                    imageUrl: 'https://example.com/photo.png',
+                  ),
+                ),
+              ),
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      final scaffold = tester.widget<Scaffold>(find.byType(Scaffold).last);
+      expect(scaffold.backgroundColor, Colors.black);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Create `FullscreenImageViewer` with `InteractiveViewer` for zoom/pan
- Add rotation support using `RotatedBox` for 90-degree increments
- Wire `imageBuilder` in `FlutterMarkdownPlusRenderer` for tappable images
- Constrain inline image size (max height 400px)
- Error state for broken image URLs
- Image builder only wired when `onImageTap` is provided

Part of #100 (slice 6/7)

**Depends on:** #301

## Test plan

- [x] Images render inline with constrained size
- [x] Tapping image calls `onImageTap` with correct src
- [x] `imageBuilder` set only when `onImageTap` provided
- [x] Error state shown for broken image URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)