### PR TITLE
refactor(markdown): wire custom block extensions in renderer

### DIFF
--- a/lib/shared/widgets/markdown/flutter_markdown_plus_renderer.dart
+++ b/lib/shared/widgets/markdown/flutter_markdown_plus_renderer.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
+import 'package:markdown/markdown.dart' as md;
 
 import 'package:soliplex_frontend/design/design.dart';
 import 'package:soliplex_frontend/shared/widgets/markdown/code_block_builder.dart';
+import 'package:soliplex_frontend/shared/widgets/markdown/markdown_block_extension.dart';
 import 'package:soliplex_frontend/shared/widgets/markdown/markdown_renderer.dart';
 import 'package:soliplex_frontend/shared/widgets/markdown/markdown_theme_extension.dart';
 
@@ -36,10 +38,15 @@ class FlutterMarkdownPlusRenderer extends MarkdownRenderer {
               if (href != null) onLinkTap!(href, title);
             },
       imageBuilder: onImageTap == null ? null : _buildImage,
+      blockSyntaxes: [
+        for (final ext in blockExtensions.values) _ExtensionBlockSyntax(ext),
+      ],
       builders: {
         'code': CodeBlockBuilder(
           preferredStyle: monoStyle.copyWith(fontSize: 14),
         ),
+        for (final ext in blockExtensions.values)
+          ext.tag: _ExtensionElementBuilder(ext),
       },
     );
   }
@@ -65,4 +72,61 @@ class FlutterMarkdownPlusRenderer extends MarkdownRenderer {
   static final _brTag = RegExp(r'<br\s*/?>');
 
   static String _sanitize(String markdown) => markdown.replaceAll(_brTag, '\n');
+}
+
+/// Adapts [MarkdownBlockExtension] to [md.BlockSyntax].
+class _ExtensionBlockSyntax extends md.BlockSyntax {
+  _ExtensionBlockSyntax(this._extension);
+
+  final MarkdownBlockExtension _extension;
+
+  @override
+  RegExp get pattern => _extension.pattern;
+
+  @override
+  md.Node parse(md.BlockParser parser) {
+    final endPattern = _extension.endPattern;
+    if (endPattern != null) return _parseMultiLine(parser, endPattern);
+
+    final line = parser.current.content;
+    parser.advance();
+    final match = pattern.firstMatch(line);
+    final content =
+        match != null && match.groupCount > 0 ? match.group(1)! : line;
+    return md.Element.text(_extension.tag, content);
+  }
+
+  md.Node _parseMultiLine(md.BlockParser parser, RegExp endPattern) {
+    parser.advance(); // skip opening fence
+    final lines = <String>[];
+    while (!parser.isDone) {
+      if (endPattern.hasMatch(parser.current.content)) {
+        parser.advance(); // skip closing fence
+        break;
+      }
+      lines.add(parser.current.content);
+      parser.advance();
+    }
+    return md.Element.text(_extension.tag, lines.join('\n'));
+  }
+}
+
+/// Adapts [MarkdownBlockExtension] to [MarkdownElementBuilder].
+class _ExtensionElementBuilder extends MarkdownElementBuilder {
+  _ExtensionElementBuilder(this._extension);
+
+  final MarkdownBlockExtension _extension;
+
+  @override
+  bool isBlockElement() => true;
+
+  @override
+  Widget? visitElementAfterWithContext(
+    BuildContext context,
+    md.Element element,
+    TextStyle? preferredStyle,
+    TextStyle? parentStyle,
+  ) {
+    return _extension.builder(element.textContent, element.attributes);
+  }
 }

--- a/lib/shared/widgets/markdown/markdown_block_extension.dart
+++ b/lib/shared/widgets/markdown/markdown_block_extension.dart
@@ -9,10 +9,16 @@ class MarkdownBlockExtension {
     required this.pattern,
     required this.tag,
     required this.builder,
+    this.endPattern,
   });
 
   /// Pattern to detect this block type in markdown text.
   final RegExp pattern;
+
+  /// Closing pattern for multi-line blocks. When set, the parser
+  /// consumes lines until this pattern matches, collecting them
+  /// as the block content.
+  final RegExp? endPattern;
 
   /// Tag name used to identify this block type.
   final String tag;

--- a/test/shared/widgets/markdown/markdown_block_extension_test.dart
+++ b/test/shared/widgets/markdown/markdown_block_extension_test.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/shared/widgets/markdown/flutter_markdown_plus_renderer.dart';
+import 'package:soliplex_frontend/shared/widgets/markdown/markdown_block_extension.dart';
+
+import '../../../helpers/test_helpers.dart';
+
+void main() {
+  group('MarkdownBlockExtension', () {
+    testWidgets('registered block renders custom widget', (tester) async {
+      final extension = MarkdownBlockExtension(
+        pattern: RegExp(r'^\[\[note:\s*(.+)\]\]$'),
+        tag: 'note',
+        builder: (content, attributes) => Container(
+          key: const Key('custom-note'),
+          child: Text('NOTE: $content'),
+        ),
+      );
+
+      await tester.pumpWidget(
+        createTestApp(
+          home: FlutterMarkdownPlusRenderer(
+            data: '[[note: This is important]]',
+            blockExtensions: {'note': extension},
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('custom-note')), findsOneWidget);
+      expect(find.text('NOTE: This is important'), findsOneWidget);
+    });
+
+    testWidgets('multiple extensions work simultaneously', (tester) async {
+      final noteExtension = MarkdownBlockExtension(
+        pattern: RegExp(r'^\[\[note:\s*(.+)\]\]$'),
+        tag: 'note',
+        builder: (content, attributes) => Text(
+          'NOTE: $content',
+          key: const Key('note-widget'),
+        ),
+      );
+
+      final warnExtension = MarkdownBlockExtension(
+        pattern: RegExp(r'^\[\[warn:\s*(.+)\]\]$'),
+        tag: 'warn',
+        builder: (content, attributes) => Text(
+          'WARN: $content',
+          key: const Key('warn-widget'),
+        ),
+      );
+
+      await tester.pumpWidget(
+        createTestApp(
+          home: FlutterMarkdownPlusRenderer(
+            data: '[[note: Info here]]\n\n[[warn: Be careful]]',
+            blockExtensions: {
+              'note': noteExtension,
+              'warn': warnExtension,
+            },
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('note-widget')), findsOneWidget);
+      expect(find.byKey(const Key('warn-widget')), findsOneWidget);
+    });
+
+    testWidgets('passes matched content to builder', (tester) async {
+      String? capturedContent;
+
+      final extension = MarkdownBlockExtension(
+        pattern: RegExp(r'^\[\[color:\s*(.+)\]\]$'),
+        tag: 'color',
+        builder: (content, attributes) {
+          capturedContent = content;
+          return Text('Color: $content');
+        },
+      );
+
+      await tester.pumpWidget(
+        createTestApp(
+          home: FlutterMarkdownPlusRenderer(
+            data: '[[color: red]]',
+            blockExtensions: {'color': extension},
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      expect(capturedContent, contains('red'));
+    });
+
+    testWidgets('multi-line block collects content between fences', (
+      tester,
+    ) async {
+      String? capturedContent;
+
+      final extension = MarkdownBlockExtension(
+        pattern: RegExp(r'^```special\s*$'),
+        endPattern: RegExp(r'^```\s*$'),
+        tag: 'special',
+        builder: (content, attributes) {
+          capturedContent = content;
+          return Text('SPECIAL: $content', key: const Key('special'));
+        },
+      );
+
+      await tester.pumpWidget(
+        createTestApp(
+          home: FlutterMarkdownPlusRenderer(
+            data: '```special\nline one\nline two\n```',
+            blockExtensions: {'special': extension},
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('special')), findsOneWidget);
+      expect(capturedContent, 'line one\nline two');
+    });
+
+    testWidgets('single-line and multi-line extensions coexist', (
+      tester,
+    ) async {
+      final singleLine = MarkdownBlockExtension(
+        pattern: RegExp(r'^\[\[note:\s*(.+)\]\]$'),
+        tag: 'note',
+        builder: (content, attributes) => Text(
+          'NOTE: $content',
+          key: const Key('note-widget'),
+        ),
+      );
+
+      final multiLine = MarkdownBlockExtension(
+        pattern: RegExp(r'^```special\s*$'),
+        endPattern: RegExp(r'^```\s*$'),
+        tag: 'special',
+        builder: (content, attributes) => Text(
+          'SPECIAL: $content',
+          key: const Key('special-widget'),
+        ),
+      );
+
+      await tester.pumpWidget(
+        createTestApp(
+          home: FlutterMarkdownPlusRenderer(
+            data: '[[note: Hello]]\n\n```special\nfoo\nbar\n```',
+            blockExtensions: {
+              'note': singleLine,
+              'special': multiLine,
+            },
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('note-widget')), findsOneWidget);
+      expect(find.byKey(const Key('special-widget')), findsOneWidget);
+    });
+
+    testWidgets('does not interfere with standard markdown', (tester) async {
+      final extension = MarkdownBlockExtension(
+        pattern: RegExp(r'^\[\[note:\s*(.+)\]\]$'),
+        tag: 'note',
+        builder: (content, attributes) => Text(
+          'NOTE: $content',
+          key: const Key('note-widget'),
+        ),
+      );
+
+      await tester.pumpWidget(
+        createTestApp(
+          home: FlutterMarkdownPlusRenderer(
+            data: '# Heading\n\n[[note: Important]]\n\nRegular text',
+            blockExtensions: {'note': extension},
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('note-widget')), findsOneWidget);
+      expect(find.text('Heading'), findsOneWidget);
+      expect(find.text('Regular text'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Implement `MarkdownBlockExtension` translation in the concrete adapter
- For each registered extension, create a `BlockSyntax` subclass from the pattern and a `MarkdownElementBuilder` from the builder function
- Support both single-line (pattern only) and multi-line (pattern + endPattern) blocks
- Single-line blocks extract the first capture group; multi-line blocks collect inner lines

Part of #100 (slice 7/7)

**Depends on:** #302

## Test plan

- [ ] Extension pattern matches expected syntax
- [ ] Registered block renders custom widget
- [ ] Unregistered blocks render as plain text
- [ ] Multiple extensions can be registered simultaneously
- [ ] Multi-line block extensions work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)