### PR TITLE
feat(run): support concurrent runs via handle-scoped event processing

### DIFF
--- a/lib/core/models/run_handle.dart
+++ b/lib/core/models/run_handle.dart
@@ -3,6 +3,9 @@ import 'dart:async';
 import 'package:soliplex_client/soliplex_client.dart';
 import 'package:soliplex_frontend/core/models/active_run_state.dart';
 
+/// Composite identifier for a run: (roomId, threadId).
+typedef RunKey = ({String roomId, String threadId});
+
 /// Encapsulates all resources for a single AG-UI run.
 ///
 /// RunHandle bundles together the cancellation token, stream subscription,
@@ -14,13 +17,12 @@ import 'package:soliplex_frontend/core/models/active_run_state.dart';
 /// The [key] property provides a composite identifier for use in registries:
 /// ```dart
 /// final handle = RunHandle(...);
-/// registry[handle.key] = handle; // Key: "room-1:thread-1"
+/// registry[handle.key] = handle;
 /// ```
 class RunHandle {
   /// Creates a run handle with the given resources.
   RunHandle({
-    required this.roomId,
-    required this.threadId,
+    required this.key,
     required this.runId,
     required this.cancelToken,
     required this.subscription,
@@ -31,11 +33,14 @@ class RunHandle {
 
   bool _disposed = false;
 
+  /// Composite key identifying which room/thread this run belongs to.
+  final RunKey key;
+
   /// The room this run belongs to.
-  final String roomId;
+  String get roomId => key.roomId;
 
   /// The thread this run belongs to.
-  final String threadId;
+  String get threadId => key.threadId;
 
   /// The backend-generated run ID.
   final String runId;
@@ -54,9 +59,6 @@ class RunHandle {
 
   /// Current state of the run.
   ActiveRunState state;
-
-  /// Composite key for registry lookups: "roomId:threadId".
-  String get key => '$roomId:$threadId';
 
   /// Whether the run is currently active (not idle or completed).
   bool get isActive => state.isRunning;

--- a/lib/core/models/run_lifecycle_event.dart
+++ b/lib/core/models/run_lifecycle_event.dart
@@ -1,0 +1,36 @@
+import 'package:meta/meta.dart';
+import 'package:soliplex_frontend/core/models/active_run_state.dart';
+import 'package:soliplex_frontend/core/models/run_handle.dart';
+
+/// Events broadcast when runs start or complete.
+@immutable
+sealed class RunLifecycleEvent {
+  const RunLifecycleEvent({required this.key});
+
+  /// Composite key identifying which room/thread this event is for.
+  final RunKey key;
+
+  /// The room this event belongs to.
+  String get roomId => key.roomId;
+
+  /// The thread this event belongs to.
+  String get threadId => key.threadId;
+}
+
+/// Emitted when a run is registered in the registry.
+@immutable
+class RunStarted extends RunLifecycleEvent {
+  const RunStarted({required super.key});
+}
+
+/// Emitted when a run reaches a terminal state (success, failure, or cancel).
+@immutable
+class RunCompleted extends RunLifecycleEvent {
+  const RunCompleted({
+    required super.key,
+    required this.result,
+  });
+
+  /// The completion result — [Success], [FailedResult], or [CancelledResult].
+  final CompletionResult result;
+}

--- a/lib/core/providers/active_run_provider.dart
+++ b/lib/core/providers/active_run_provider.dart
@@ -109,7 +109,10 @@ final allMessagesProvider = FutureProvider<List<ChatMessage>>((ref) async {
           .getHistory(room.id, thread.id);
 
   final runState = ref.watch(activeRunNotifierProvider);
-  return _mergeMessages(history.messages, runState.messages);
+  final runMessages = runState.conversation.threadId == thread.id
+      ? runState.messages
+      : <ChatMessage>[];
+  return _mergeMessages(history.messages, runMessages);
 });
 
 /// Merges cached and running messages, deduplicating by ID.

--- a/lib/core/services/run_registry.dart
+++ b/lib/core/services/run_registry.dart
@@ -1,12 +1,16 @@
+import 'dart:async';
+
 import 'package:soliplex_frontend/core/models/active_run_state.dart';
 import 'package:soliplex_frontend/core/models/run_handle.dart';
+import 'package:soliplex_frontend/core/models/run_lifecycle_event.dart';
 
 /// Registry for tracking multiple concurrent AG-UI runs.
 ///
 /// RunRegistry manages a collection of [RunHandle] instances, keyed by
-/// their composite `roomId:threadId` identifier. It provides:
-/// - Registration and lookup of active runs
-/// - Cancellation of individual or all runs
+/// their [RunKey]. It provides:
+/// - Registration and lookup of runs
+/// - Lifecycle event broadcasting via [completeRun]
+/// - Removal and disposal of individual or all runs
 /// - Query methods for UI state
 ///
 /// Usage:
@@ -16,64 +20,80 @@ import 'package:soliplex_frontend/core/models/run_handle.dart';
 /// // Register a new run
 /// registry.registerRun(handle);
 ///
-/// // Check if a run is active
-/// if (registry.hasActiveRun('room-1', 'thread-1')) {
-///   final state = registry.getRunState('room-1', 'thread-1');
+/// // Check if a run exists or is active
+/// final key = (roomId: 'room-1', threadId: 'thread-1');
+/// if (registry.hasRun(key)) {
+///   final state = registry.getRunState(key);
 /// }
 ///
-/// // Cancel when done
-/// await registry.cancelRun('room-1', 'thread-1');
+/// // Remove when done
+/// await registry.removeRun(key);
 /// ```
 class RunRegistry {
-  final Map<String, RunHandle> _runs = {};
+  final Map<RunKey, RunHandle> _runs = {};
+  final _controller = StreamController<RunLifecycleEvent>.broadcast();
+
+  /// Stream of lifecycle events for run start and completion.
+  Stream<RunLifecycleEvent> get lifecycleEvents => _controller.stream;
 
   /// Registers a run handle in the registry.
   ///
   /// If a run already exists for the same room/thread, the existing run
   /// is cancelled and replaced with the new one.
   Future<void> registerRun(RunHandle handle) async {
+    _checkNotDisposed();
     final existingHandle = _runs[handle.key];
     if (existingHandle != null) {
       await existingHandle.dispose();
     }
     _runs[handle.key] = handle;
+    _controller.add(RunStarted(key: handle.key));
+  }
+
+  /// Transitions a run to completed state and emits a lifecycle event.
+  ///
+  /// Sets the handle's state and broadcasts [RunCompleted] for all results
+  /// including cancellations. Consumers decide which events to act on.
+  ///
+  /// Silently returns if the registry is disposed or the handle is not
+  /// the currently registered one for its key (e.g., it was replaced by
+  /// a newer run).
+  void completeRun(RunHandle handle, CompletedState completed) {
+    if (_controller.isClosed || _runs[handle.key] != handle) return;
+    handle.state = completed;
+    _controller.add(RunCompleted(key: handle.key, result: completed.result));
   }
 
   /// Gets the current state for a thread's run.
   ///
   /// Returns null if no run exists for the given room/thread.
-  ActiveRunState? getRunState(String roomId, String threadId) {
-    final key = _makeKey(roomId, threadId);
-    return _runs[key]?.state;
-  }
+  ActiveRunState? getRunState(RunKey key) => _runs[key]?.state;
 
   /// Gets the run handle for a thread.
   ///
   /// Returns null if no run exists for the given room/thread.
-  RunHandle? getHandle(String roomId, String threadId) {
-    final key = _makeKey(roomId, threadId);
-    return _runs[key];
-  }
+  RunHandle? getHandle(RunKey key) => _runs[key];
 
-  /// Checks if a run is registered for the given room/thread.
-  ///
-  /// Returns true if a handle exists, regardless of its state.
-  bool hasActiveRun(String roomId, String threadId) {
-    final key = _makeKey(roomId, threadId);
-    return _runs.containsKey(key);
-  }
+  /// Checks if any run (active or completed) is registered for the given key.
+  bool hasRun(RunKey key) => _runs.containsKey(key);
 
-  /// Cancels and removes a specific run.
+  /// Checks if an actively running (not yet completed) run exists for the key.
+  bool hasActiveRun(RunKey key) => _runs[key]?.isActive ?? false;
+
+  /// Removes a run and disposes its resources.
   ///
-  /// Does nothing if no run exists for the given room/thread.
-  Future<void> cancelRun(String roomId, String threadId) async {
-    final key = _makeKey(roomId, threadId);
+  /// Callers must call [completeRun] first if a lifecycle event is needed.
+  /// Does nothing if no run exists for the given key.
+  Future<void> removeRun(RunKey key) async {
     final handle = _runs.remove(key);
     await handle?.dispose();
   }
 
-  /// Cancels and removes all runs.
-  Future<void> cancelAll() async {
+  /// Disposes all runs without emitting lifecycle events.
+  ///
+  /// For individual run lifecycle management, use [completeRun] followed
+  /// by [removeRun].
+  Future<void> removeAll() async {
     final handles = _runs.values.toList();
     _runs.clear();
     for (final handle in handles) {
@@ -81,8 +101,11 @@ class RunRegistry {
     }
   }
 
-  /// Number of registered runs.
-  int get activeRunCount => _runs.length;
+  /// Number of registered runs (including completed ones).
+  int get runCount => _runs.length;
+
+  /// Number of actively running (not yet completed) runs.
+  int get activeRunCount => _runs.values.where((h) => h.isActive).length;
 
   /// All currently registered run handles.
   Iterable<RunHandle> get handles => _runs.values;
@@ -91,9 +114,13 @@ class RunRegistry {
   ///
   /// After calling dispose, the registry should not be used.
   Future<void> dispose() async {
-    await cancelAll();
+    await removeAll();
+    await _controller.close();
   }
 
-  /// Creates a composite key from room and thread IDs.
-  String _makeKey(String roomId, String threadId) => '$roomId:$threadId';
+  void _checkNotDisposed() {
+    if (_controller.isClosed) {
+      throw StateError('RunRegistry has been disposed');
+    }
+  }
 }

--- a/test/core/providers/active_run_notifier_test.dart
+++ b/test/core/providers/active_run_notifier_test.dart
@@ -7,8 +7,10 @@ import 'package:soliplex_client/soliplex_client.dart';
 import 'package:soliplex_client/soliplex_client.dart' as domain
     show Cancelled, Completed, Conversation, Failed, Running;
 import 'package:soliplex_frontend/core/models/active_run_state.dart';
+import 'package:soliplex_frontend/core/models/run_lifecycle_event.dart';
 import 'package:soliplex_frontend/core/providers/active_run_provider.dart';
 import 'package:soliplex_frontend/core/providers/api_provider.dart';
+import 'package:soliplex_frontend/core/providers/rooms_provider.dart';
 import 'package:soliplex_frontend/core/providers/thread_history_cache.dart';
 import 'package:soliplex_frontend/core/providers/threads_provider.dart';
 
@@ -517,9 +519,15 @@ void main() {
       // Both runs should be registered
       final registry =
           container.read(activeRunNotifierProvider.notifier).registry;
-      expect(registry.hasActiveRun('room-1', 'thread-1'), isTrue);
-      expect(registry.hasActiveRun('room-1', 'thread-2'), isTrue);
-      expect(registry.activeRunCount, 2);
+      expect(
+        registry.hasRun((roomId: 'room-1', threadId: 'thread-1')),
+        isTrue,
+      );
+      expect(
+        registry.hasRun((roomId: 'room-1', threadId: 'thread-2')),
+        isTrue,
+      );
+      expect(registry.runCount, 2);
     });
   });
 
@@ -582,6 +590,15 @@ void main() {
       expect(completedState.result, isA<CancelledResult>());
     });
 
+    test('is a no-op when no run is active', () async {
+      final state = container.read(activeRunNotifierProvider);
+      expect(state, isA<IdleState>());
+
+      await container.read(activeRunNotifierProvider.notifier).cancelRun();
+
+      expect(container.read(activeRunNotifierProvider), isA<IdleState>());
+    });
+
     test('preserves messages after cancellation', () async {
       // Start a run
       await container.read(activeRunNotifierProvider.notifier).startRun(
@@ -636,7 +653,7 @@ void main() {
       eventStreamController.close();
     });
 
-    test('run continues when switching threads', () async {
+    test('run continues in background when switching threads', () async {
       final container = ProviderContainer(
         overrides: [
           apiProvider.overrideWithValue(mockApi),
@@ -671,9 +688,19 @@ void main() {
       // Allow listener to fire
       await Future<void>.delayed(Duration.zero);
 
-      // Run state should NOT be reset - run continues in background
-      expect(container.read(activeRunNotifierProvider), isA<RunningState>());
-      expect(container.read(activeRunNotifierProvider).messages, isNotEmpty);
+      // Notifier state should be idle (viewing thread-b, which has no run)
+      expect(container.read(activeRunNotifierProvider), isA<IdleState>());
+
+      // But the run continues in the background via registry
+      final registry =
+          container.read(activeRunNotifierProvider.notifier).registry;
+      expect(
+        registry.hasRun((roomId: 'room-1', threadId: 'thread-a')),
+        isTrue,
+      );
+      final handle =
+          registry.getHandle((roomId: 'room-1', threadId: 'thread-a'))!;
+      expect(handle.state, isA<RunningState>());
     });
 
     test('run state preserved when returning to thread', () async {
@@ -1748,9 +1775,13 @@ void main() {
 
       final registry =
           container.read(activeRunNotifierProvider.notifier).registry;
-      expect(registry.hasActiveRun('room-1', 'thread-1'), isTrue);
+      expect(
+        registry.hasRun((roomId: 'room-1', threadId: 'thread-1')),
+        isTrue,
+      );
 
-      final handle = registry.getHandle('room-1', 'thread-1');
+      final handle =
+          registry.getHandle((roomId: 'room-1', threadId: 'thread-1'));
       expect(handle, isNotNull);
       expect(handle!.state, isA<RunningState>());
     });
@@ -1773,7 +1804,8 @@ void main() {
 
       final registry =
           container.read(activeRunNotifierProvider.notifier).registry;
-      final handle = registry.getHandle('room-1', 'thread-1')!;
+      final handle =
+          registry.getHandle((roomId: 'room-1', threadId: 'thread-1'))!;
 
       eventStreamController.add(
         const RunFinishedEvent(threadId: 'thread-1', runId: 'run-1'),
@@ -1801,7 +1833,8 @@ void main() {
 
       final registry =
           container.read(activeRunNotifierProvider.notifier).registry;
-      final handle = registry.getHandle('room-1', 'thread-1')!;
+      final handle =
+          registry.getHandle((roomId: 'room-1', threadId: 'thread-1'))!;
 
       await container.read(activeRunNotifierProvider.notifier).cancelRun();
 
@@ -1828,7 +1861,8 @@ void main() {
 
       final registry =
           container.read(activeRunNotifierProvider.notifier).registry;
-      final handle = registry.getHandle('room-1', 'thread-1')!;
+      final handle =
+          registry.getHandle((roomId: 'room-1', threadId: 'thread-1'))!;
 
       eventStreamController
         ..add(const TextMessageStartEvent(messageId: 'msg-1'))
@@ -1864,7 +1898,8 @@ void main() {
 
       final registry =
           container.read(activeRunNotifierProvider.notifier).registry;
-      final handle = registry.getHandle('room-1', 'thread-1')!;
+      final handle =
+          registry.getHandle((roomId: 'room-1', threadId: 'thread-1'))!;
 
       eventStreamController.addError(Exception('Network error'));
       await Future<void>.delayed(Duration.zero);
@@ -1931,7 +1966,8 @@ void main() {
 
       final registry =
           container.read(activeRunNotifierProvider.notifier).registry;
-      final handle = registry.getHandle('room-1', 'thread-1')!;
+      final handle =
+          registry.getHandle((roomId: 'room-1', threadId: 'thread-1'))!;
 
       // Complete the run
       eventStreamController.add(
@@ -1971,7 +2007,8 @@ void main() {
 
       final registry =
           container.read(activeRunNotifierProvider.notifier).registry;
-      final handle = registry.getHandle('room-1', 'thread-1')!;
+      final handle =
+          registry.getHandle((roomId: 'room-1', threadId: 'thread-1'))!;
 
       // Close stream without sending RUN_FINISHED
       await eventStreamController.close();
@@ -2008,7 +2045,7 @@ void main() {
 
       final registry =
           container.read(activeRunNotifierProvider.notifier).registry;
-      expect(registry.activeRunCount, 1);
+      expect(registry.runCount, 1);
 
       // Dispose container — should not throw
       container.dispose();
@@ -2105,7 +2142,8 @@ void main() {
       await Future<void>.delayed(Duration.zero);
 
       // Handle A should have the new message
-      final handleA = notifier.registry.getHandle('room-1', 'thread-a')!;
+      final handleA = notifier.registry
+          .getHandle((roomId: 'room-1', threadId: 'thread-a'))!;
       expect(handleA.state, isA<RunningState>());
       expect(handleA.state.messages, hasLength(2));
 
@@ -2144,10 +2182,14 @@ void main() {
       await notifier.cancelRun();
 
       // Thread A should still be active in registry
-      expect(notifier.registry.hasActiveRun('room-1', 'thread-a'), isTrue);
+      expect(
+        notifier.registry.hasRun((roomId: 'room-1', threadId: 'thread-a')),
+        isTrue,
+      );
 
       // Thread A's handle should still be running
-      final handleA = notifier.registry.getHandle('room-1', 'thread-a')!;
+      final handleA = notifier.registry
+          .getHandle((roomId: 'room-1', threadId: 'thread-a'))!;
       expect(handleA.state, isA<RunningState>());
     });
 
@@ -2190,6 +2232,431 @@ void main() {
       final notifierState = container.read(activeRunNotifierProvider);
       expect(notifierState, isA<RunningState>());
       expect((notifierState as RunningState).threadId, 'thread-b');
+    });
+  });
+
+  group('room/thread navigation sync', () {
+    late MockAgUiClient mockAgUiClient;
+    late MockSoliplexApi mockApi;
+    late StreamController<BaseEvent> streamA;
+
+    setUp(() {
+      mockAgUiClient = MockAgUiClient();
+      mockApi = MockSoliplexApi();
+      streamA = StreamController<BaseEvent>();
+
+      when(
+        () => mockApi.createRun(
+          any(),
+          any(),
+          cancelToken: any(named: 'cancelToken'),
+        ),
+      ).thenAnswer(
+        (_) async => RunInfo(
+          id: 'run-1',
+          threadId: 'thread-1',
+          createdAt: DateTime.now(),
+        ),
+      );
+
+      when(
+        () => mockAgUiClient.runAgent(
+          any(),
+          any(),
+          cancelToken: any(named: 'cancelToken'),
+        ),
+      ).thenAnswer((_) => streamA.stream);
+    });
+
+    tearDown(() {
+      streamA.close();
+    });
+
+    test('switching thread resets state to idle when target has no run',
+        () async {
+      final container = ProviderContainer(
+        overrides: [
+          apiProvider.overrideWithValue(mockApi),
+          agUiClientProvider.overrideWithValue(mockAgUiClient),
+          currentRoomIdProviderOverride('room-1'),
+          threadSelectionProviderOverride(
+            const ThreadSelected('thread-a'),
+          ),
+        ],
+      );
+
+      addTearDown(container.dispose);
+
+      // Start a run in thread-a
+      await container.read(activeRunNotifierProvider.notifier).startRun(
+            roomId: 'room-1',
+            threadId: 'thread-a',
+            userMessage: 'Hello',
+          );
+
+      expect(
+        container.read(activeRunNotifierProvider),
+        isA<RunningState>(),
+      );
+
+      // User navigates to thread-b (no active run there)
+      container
+          .read(threadSelectionProvider.notifier)
+          .set(const ThreadSelected('thread-b'));
+
+      // Allow listener to fire
+      await Future<void>.delayed(Duration.zero);
+
+      // Notifier should show idle for thread-b
+      final state = container.read(activeRunNotifierProvider);
+      expect(state, isA<IdleState>());
+    });
+
+    test('switching back to thread with active run restores its state',
+        () async {
+      final container = ProviderContainer(
+        overrides: [
+          apiProvider.overrideWithValue(mockApi),
+          agUiClientProvider.overrideWithValue(mockAgUiClient),
+          currentRoomIdProviderOverride('room-1'),
+          threadSelectionProviderOverride(
+            const ThreadSelected('thread-a'),
+          ),
+        ],
+      );
+
+      addTearDown(container.dispose);
+
+      // Start a run in thread-a
+      await container.read(activeRunNotifierProvider.notifier).startRun(
+            roomId: 'room-1',
+            threadId: 'thread-a',
+            userMessage: 'Hello',
+          );
+
+      expect(
+        container.read(activeRunNotifierProvider),
+        isA<RunningState>(),
+      );
+
+      // Navigate away to thread-b
+      container
+          .read(threadSelectionProvider.notifier)
+          .set(const ThreadSelected('thread-b'));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        container.read(activeRunNotifierProvider),
+        isA<IdleState>(),
+      );
+
+      // Navigate back to thread-a
+      container
+          .read(threadSelectionProvider.notifier)
+          .set(const ThreadSelected('thread-a'));
+      await Future<void>.delayed(Duration.zero);
+
+      // Should restore thread-a's running state from registry
+      final restored = container.read(activeRunNotifierProvider);
+      expect(restored, isA<RunningState>());
+      expect((restored as RunningState).threadId, 'thread-a');
+    });
+
+    test('switching room resets state to idle', () async {
+      final container = ProviderContainer(
+        overrides: [
+          apiProvider.overrideWithValue(mockApi),
+          agUiClientProvider.overrideWithValue(mockAgUiClient),
+          currentRoomIdProviderOverride('room-1'),
+          threadSelectionProviderOverride(
+            const ThreadSelected('thread-a'),
+          ),
+        ],
+      );
+
+      addTearDown(container.dispose);
+
+      // Start a run in room-1/thread-a
+      await container.read(activeRunNotifierProvider.notifier).startRun(
+            roomId: 'room-1',
+            threadId: 'thread-a',
+            userMessage: 'Hello',
+          );
+
+      expect(
+        container.read(activeRunNotifierProvider),
+        isA<RunningState>(),
+      );
+
+      // User navigates to room-2
+      container.read(currentRoomIdProvider.notifier).set('room-2');
+      container
+          .read(threadSelectionProvider.notifier)
+          .set(const ThreadSelected('thread-x'));
+      await Future<void>.delayed(Duration.zero);
+
+      // Notifier should show idle (no run in room-2/thread-x)
+      final state = container.read(activeRunNotifierProvider);
+      expect(state, isA<IdleState>());
+    });
+
+    test(
+        'background run events do not update state '
+        'after switching away', () async {
+      final container = ProviderContainer(
+        overrides: [
+          apiProvider.overrideWithValue(mockApi),
+          agUiClientProvider.overrideWithValue(mockAgUiClient),
+          currentRoomIdProviderOverride('room-1'),
+          threadSelectionProviderOverride(
+            const ThreadSelected('thread-a'),
+          ),
+        ],
+      );
+
+      addTearDown(container.dispose);
+
+      // Start a run in thread-a
+      await container.read(activeRunNotifierProvider.notifier).startRun(
+            roomId: 'room-1',
+            threadId: 'thread-a',
+            userMessage: 'Hello',
+          );
+
+      // Switch to thread-b
+      container
+          .read(threadSelectionProvider.notifier)
+          .set(const ThreadSelected('thread-b'));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        container.read(activeRunNotifierProvider),
+        isA<IdleState>(),
+      );
+
+      // Background events arrive for thread-a (full message lifecycle)
+      streamA
+        ..add(const TextMessageStartEvent(messageId: 'msg-1'))
+        ..add(
+          const TextMessageContentEvent(
+            messageId: 'msg-1',
+            delta: 'Hello from background',
+          ),
+        )
+        ..add(const TextMessageEndEvent(messageId: 'msg-1'));
+      await Future<void>.delayed(Duration.zero);
+
+      // State should remain idle (not leak thread-a's messages)
+      expect(
+        container.read(activeRunNotifierProvider),
+        isA<IdleState>(),
+      );
+
+      // But the handle in the registry should have the messages
+      final handle = container
+          .read(activeRunNotifierProvider.notifier)
+          .registry
+          .getHandle((roomId: 'room-1', threadId: 'thread-a'))!;
+      expect(handle.state, isA<RunningState>());
+      expect(handle.state.messages, hasLength(2));
+    });
+
+    test('deselecting thread resets state to idle', () async {
+      final container = ProviderContainer(
+        overrides: [
+          apiProvider.overrideWithValue(mockApi),
+          agUiClientProvider.overrideWithValue(mockAgUiClient),
+          currentRoomIdProviderOverride('room-1'),
+          threadSelectionProviderOverride(
+            const ThreadSelected('thread-a'),
+          ),
+        ],
+      );
+
+      addTearDown(container.dispose);
+
+      // Start a run on thread-a
+      await container.read(activeRunNotifierProvider.notifier).startRun(
+            roomId: 'room-1',
+            threadId: 'thread-a',
+            userMessage: 'Hello',
+          );
+
+      expect(container.read(activeRunNotifierProvider), isA<RunningState>());
+
+      // Deselect thread (e.g., navigating away from room)
+      container
+          .read(threadSelectionProvider.notifier)
+          .set(const NoThreadSelected());
+      await Future<void>.delayed(Duration.zero);
+
+      expect(container.read(activeRunNotifierProvider), isA<IdleState>());
+    });
+  });
+
+  group('lifecycle events', () {
+    late MockAgUiClient mockAgUiClient;
+    late MockSoliplexApi mockApi;
+    late StreamController<BaseEvent> eventStreamController;
+
+    setUp(() {
+      mockAgUiClient = MockAgUiClient();
+      mockApi = MockSoliplexApi();
+      eventStreamController = StreamController<BaseEvent>();
+
+      when(
+        () => mockApi.createRun(
+          any(),
+          any(),
+          cancelToken: any(named: 'cancelToken'),
+        ),
+      ).thenAnswer(
+        (_) async => RunInfo(
+          id: 'run-1',
+          threadId: 'thread-1',
+          createdAt: DateTime.now(),
+        ),
+      );
+
+      when(
+        () => mockAgUiClient.runAgent(
+          any(),
+          any(),
+          cancelToken: any(named: 'cancelToken'),
+        ),
+      ).thenAnswer((_) => eventStreamController.stream);
+    });
+
+    tearDown(() {
+      eventStreamController.close();
+    });
+
+    test('stream completion emits RunCompleted via registry', () async {
+      final container = ProviderContainer(
+        overrides: [
+          apiProvider.overrideWithValue(mockApi),
+          agUiClientProvider.overrideWithValue(mockAgUiClient),
+        ],
+      );
+
+      addTearDown(container.dispose);
+
+      final notifier = container.read(activeRunNotifierProvider.notifier);
+      final events = <RunLifecycleEvent>[];
+      notifier.registry.lifecycleEvents.listen(events.add);
+
+      await notifier.startRun(
+        roomId: 'room-1',
+        threadId: 'thread-1',
+        userMessage: 'Hello',
+      );
+
+      // RunStarted should have been emitted
+      expect(events, hasLength(1));
+      expect(events.first, isA<RunStarted>());
+
+      // Close stream → triggers _handleDoneForRun
+      await eventStreamController.close();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(events, hasLength(2));
+      expect(events.last, isA<RunCompleted>());
+      final completed = events.last as RunCompleted;
+      expect(completed.result, isA<Success>());
+    });
+
+    test('stream error emits RunCompleted with FailedResult', () async {
+      final container = ProviderContainer(
+        overrides: [
+          apiProvider.overrideWithValue(mockApi),
+          agUiClientProvider.overrideWithValue(mockAgUiClient),
+        ],
+      );
+
+      addTearDown(container.dispose);
+
+      final notifier = container.read(activeRunNotifierProvider.notifier);
+      final events = <RunLifecycleEvent>[];
+      notifier.registry.lifecycleEvents.listen(events.add);
+
+      await notifier.startRun(
+        roomId: 'room-1',
+        threadId: 'thread-1',
+        userMessage: 'Hello',
+      );
+
+      // Emit stream error → triggers _handleFailureForRun
+      eventStreamController.addError(Exception('Network error'));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(events, hasLength(2));
+      expect(events.last, isA<RunCompleted>());
+      final completed = events.last as RunCompleted;
+      expect(completed.result, isA<FailedResult>());
+    });
+
+    test('cancelRun emits RunCompleted with CancelledResult', () async {
+      final container = ProviderContainer(
+        overrides: [
+          apiProvider.overrideWithValue(mockApi),
+          agUiClientProvider.overrideWithValue(mockAgUiClient),
+        ],
+      );
+
+      addTearDown(container.dispose);
+
+      final notifier = container.read(activeRunNotifierProvider.notifier);
+      final events = <RunLifecycleEvent>[];
+      notifier.registry.lifecycleEvents.listen(events.add);
+
+      await notifier.startRun(
+        roomId: 'room-1',
+        threadId: 'thread-1',
+        userMessage: 'Hello',
+      );
+
+      // RunStarted emitted
+      expect(events, hasLength(1));
+
+      await notifier.cancelRun();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(events, hasLength(2));
+      expect(events.last, isA<RunCompleted>());
+      final completed = events.last as RunCompleted;
+      expect(completed.result, isA<CancelledResult>());
+    });
+
+    test('RUN_FINISHED event emits RunCompleted via _processEventForRun',
+        () async {
+      final container = ProviderContainer(
+        overrides: [
+          apiProvider.overrideWithValue(mockApi),
+          agUiClientProvider.overrideWithValue(mockAgUiClient),
+        ],
+      );
+
+      addTearDown(container.dispose);
+
+      final notifier = container.read(activeRunNotifierProvider.notifier);
+      final events = <RunLifecycleEvent>[];
+      notifier.registry.lifecycleEvents.listen(events.add);
+
+      await notifier.startRun(
+        roomId: 'room-1',
+        threadId: 'thread-1',
+        userMessage: 'Hello',
+      );
+
+      eventStreamController.add(
+        const RunFinishedEvent(threadId: 'thread-1', runId: 'run-1'),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(events, hasLength(2));
+      expect(events.last, isA<RunCompleted>());
+      final completed = events.last as RunCompleted;
+      expect(completed.result, isA<Success>());
     });
   });
 }


### PR DESCRIPTION
## Summary
- Refactors `ActiveRunNotifier` to use `RunHandle` + `RunRegistry` for tracking concurrent runs across rooms/threads
- Each run's event stream callbacks are scoped to its own handle, so background runs process independently
- The notifier's global `state` only updates for the "current" handle (via identity check)

## Test plan
- [ ] Verify concurrent runs: start run in thread A, start run in thread B, confirm thread A continues in background
- [ ] Verify handle isolation: background run events update handle state but not notifier state
- [ ] Verify cancellation isolation: cancelling current run doesn't affect background runs
- [ ] Verify cache updates: background run completion updates thread history cache
- [ ] Run full test suite (`flutter test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)