### PR TITLE
docs: restore PLANS/0001-narrow_rag directory

### DIFF
--- a/PLANS/0001-narrow_rag/ADR.md
+++ b/PLANS/0001-narrow_rag/ADR.md
@@ -1,0 +1,219 @@
+# ADR: Narrowed RAG Search Implementation
+
+## Status
+
+Proposed
+
+## Context
+
+Users need to narrow RAG searches to specific documents within a room. This
+requires:
+
+1. A UI mechanism to select documents from a picker.
+2. Display of selected documents as chips above the text input.
+3. Frontend logic to fetch and cache available documents.
+4. Integration with the backend API to scope RAG queries via AG-UI state.
+5. Persistence of document selection across runs within a thread.
+
+See [SPEC.md](./SPEC.md) for requirements and use cases.
+
+## Decision
+
+### UI Approach: Chips Above Input
+
+We use a **chips-above-input** pattern rather than inline mentions:
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│ [manual.pdf ×] [troubleshooting.pdf ×]                      │  ← Chip row
+├─────────────────────────────────────────────────────────────┤
+│ 📎 Type your message...                              [Send] │  ← Input row
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Rationale:**
+
+- Flutter's `TextField` cannot embed widgets (chips) inline with editable text.
+- Mention packages like `flutter_mentions` are abandoned (4+ years without
+  updates) and have critical bugs (broken hit testing, no keyboard navigation).
+- Chips above input is a well-established pattern (Gmail compose, Slack).
+- Cleaner separation: text editing is standard; document selection is separate.
+
+### UI Components
+
+**Document Picker Button (📎):**
+
+- Positioned at the start of the input row.
+- Opens a popup/dialog with the document picker.
+- Tooltip: "Select documents"
+
+**Document Picker Popup:**
+
+- Modal popup positioned above or below the input.
+- Contains a search field for filtering.
+- Multi-select list with checkboxes showing all room documents.
+- Each item shows a file type icon based on extension (PDF icon for `.pdf`,
+  Word icon for `.docx`, etc.); unknown/missing extensions use a generic icon.
+- Document paths shortened to filename + up to 2 parent folders.
+- Selected documents are pre-checked when reopening.
+- Scrollable when list exceeds max height.
+- Keyboard navigable: Tab to search, arrows to navigate, Space to toggle,
+  Escape to close.
+- Closes on click outside or Escape.
+
+**Implementation:** Use Flutter's `RawAutocomplete` or a simple
+`PopupMenuButton`/`Dialog` with `ListView` and `CheckboxListTile`. No external
+packages required. Use a helper function to map file extensions to icon widgets.
+
+**Document Chips:**
+
+- Displayed in a `Wrap` widget above the text input.
+- Each chip shows file type icon + shortened document path + × button.
+- Use Material `InputChip` or `RawChip` with `onDeleted` callback.
+- Chip row hidden when no documents selected.
+
+### Document Fetching
+
+**Endpoint:** `GET /api/v1/rooms/{room_id}/documents`
+
+**Caching:** Use a Riverpod `FutureProvider.family` keyed by room ID. Documents
+are cached per room and can be refreshed on demand.
+
+**Error Handling:**
+
+- Retry up to 3 times on retryable errors (5xx, 408, 429) with exponential
+  backoff (1s, 2s, 4s).
+- Non-retryable errors (4xx except 408/429) fail immediately.
+- On exhausted retries, show "Could not load documents. Tap to retry." in the
+  picker.
+- Document selection is optional—users can always submit without it.
+
+### State Management
+
+**Local Selection State:**
+
+Selected documents are stored in a `Set<RAGDocument>` managed by the input
+widget's state. This set:
+
+- Populates the chip row.
+- Filters the picker (already-selected documents are checked, not hidden).
+- Provides document IDs for AG-UI state on submit.
+
+**Persistence Across Runs:**
+
+Document selection persists within a thread until the user explicitly removes
+documents. The selection is stored per-thread, either:
+
+- In widget state (if thread context is preserved), or
+- In a Riverpod provider keyed by thread ID.
+
+Switching threads clears/restores the selection for that thread.
+
+**AG-UI State for Document Filtering:**
+
+Selected documents are communicated to the backend via AG-UI state. On submit,
+the frontend includes a `filter_documents` object in `RunAgentInput.state`:
+
+```json
+{
+  "filter_documents": {
+    "document_ids": ["uuid-1", "uuid-2"]
+  }
+}
+```
+
+- `document_ids`: List of document UUIDs, or `null`/absent if no filtering.
+- The backend `ask_with_rich_citations` tool reads this and applies a LanceDB
+  filter.
+
+**FilterDocuments Model:**
+
+- **Python**: Defined in `soliplex/src/soliplex/agui/features.py`
+- **Dart**: Generated via JSON Schema + quicktype
+
+### Prompt Format
+
+The prompt text sent to the LLM is **plain text** without any document markup.
+Document filtering is handled entirely via AG-UI state, not by parsing the
+prompt.
+
+Example:
+
+- **Prompt text:** `Which symbol indicates an issue with oil level?`
+- **AG-UI state:** `{"filter_documents": {"document_ids": ["uuid-1", "uuid-2"]}}`
+
+The LLM sees the question; the backend filters RAG to the specified documents.
+
+## Consequences
+
+### Positive
+
+- Uses standard Flutter widgets—no abandoned third-party packages.
+- Clear separation between text input and document selection.
+- Multi-select picker is more efficient than one-at-a-time inline mentions.
+- Selection persistence reduces repetitive selection across runs.
+- Simpler implementation—no cursor management, overlay positioning hacks, or
+  atomic deletion logic.
+
+### Negative
+
+- Document references are not visible in the prompt text itself. Users see chips
+  but the LLM doesn't see document names in the prompt.
+- Requires managing selection state persistence per thread.
+
+### Risks
+
+- Performance if room has many documents (hundreds). May need virtualized list
+  or pagination in picker.
+- Thread-keyed state adds complexity if thread switching is frequent.
+
+## Alternatives Considered
+
+### Inline Mentions with flutter_mentions
+
+**Evaluated and rejected.** The `flutter_mentions` package:
+
+- Has not been updated in 4+ years.
+- Has broken hit testing (taps on suggestions don't register).
+- Lacks keyboard navigation for the suggestion popup.
+- Uses `flutter_portal` which adds complexity.
+- Would require custom implementations for atomic deletion and keyboard nav.
+
+### Inline Mentions with Custom Implementation
+
+Building inline mentions from scratch using `TextField` + `Overlay` would
+require solving:
+
+- Cursor positioning within styled mention spans.
+- Atomic deletion when backspacing into a mention.
+- Overlay positioning relative to cursor.
+- Mobile keyboard compatibility.
+
+This is significant complexity for limited UX benefit over the chips approach.
+
+### Other Mention Packages
+
+| Package                  | Status                                     |
+| ------------------------ | ------------------------------------------ |
+| `super_editor`           | Active, but high intrusion (rich text)     |
+| `extended_text_field`    | Moderate maintenance, medium completeness  |
+| `mentionable_text_field` | Stale, low adoption                        |
+
+None offer a maintained, low-intrusion inline mention solution.
+
+## Known Gaps
+
+1. **Document ID Validation**: The backend does not validate that submitted
+   `document_ids` exist. Invalid IDs are silently ignored.
+
+2. **Stale Document References**: If a document is deleted after selection but
+   before submit, the reference becomes stale. No client-side validation.
+
+3. **Large Document Lists**: No pagination or virtualization in the initial
+   implementation. May need optimization for rooms with 100+ documents.
+
+## References
+
+- [Material Design Input Chips](https://m3.material.io/components/chips/overview)
+- [Flutter RawAutocomplete](https://api.flutter.dev/flutter/widgets/RawAutocomplete-class.html)
+- [Riverpod FutureProvider.family](https://riverpod.dev/docs/providers/future_provider)

--- a/PLANS/0001-narrow_rag/IMPLEMENTATION.md
+++ b/PLANS/0001-narrow_rag/IMPLEMENTATION.md
@@ -1,0 +1,455 @@
+# Implementation Plan: Narrowed RAG Search
+
+## Overview
+
+This plan uses vertical slicing with a "walking skeleton" approach. Slice 1
+delivers the bare minimum end-to-end feature. Subsequent slices add refinements
+and can be implemented in parallel after slice 1.
+
+## Slice Summary
+
+| # | Slice | ~Lines | Customer Value |
+|---|-------|--------|----------------|
+| 1 | Walking skeleton | ~280 | User can select ONE doc, AI uses it |
+| 2 | Chip styling | ~80 | Selected docs shown as proper chips |
+| 3 | Multi-select | ~100 | User can select multiple documents |
+| 4 | Search in picker | ~120 | User can find documents quickly |
+| 5 | Selection persistence | ~150 | Selection survives across runs |
+| 6 | Loading indicator | ~60 | Spinner while fetching documents |
+| 7 | Empty room handling | ~40 | Picker button disabled when no docs |
+| 8 | Error + retry | ~180 | Error feedback, retry button, backoff |
+| 9 | Keyboard navigation | ~120 | Arrows, space, escape in picker |
+| 10 | File type icons | ~80 | Visual cues for document types |
+
+## Dependency Structure
+
+```text
+            [1] Walking skeleton
+                     │
+      ┌──────────────┼──────────────┐
+      │              │              │
+      ▼              ▼              ▼
+     [2]            [5]            [7]
+    chips         persist        empty
+      │
+      ▼
+    [10] file-icons
+
+                     │
+                     ▼
+                    [3] multi-select
+                     │
+                     ▼
+                    [4] search
+                     │
+                     ▼
+                    [6] loading
+                     │
+                     ▼
+                    [8] error + retry
+                     │
+                     ▼
+                    [9] keyboard
+```
+
+**Parallel from slice 1:** Slices 2, 5, 7 don't touch picker internals.
+
+**Parallel from slice 2:** Slice 10 (file-icons) adds icons to chips and picker.
+
+**Stacked (picker chain):** Slices 3→4→6→8→9 all modify the picker dialog
+and must be stacked to avoid git conflicts.
+
+## Implementation Order
+
+1. **Slice 1** - Walking skeleton (required first)
+2. **Slice 3** - Multi-select (start picker chain)
+3. **Slice 5** - Persistence (parallel with picker chain)
+4. **Slice 2** - Chips (parallel with picker chain)
+5. **Slice 10** - File type icons (after chips)
+6. **Slice 4** - Search (continues picker chain)
+7. **Slice 8** - Error + retry
+8. **Slice 7** - Empty room (parallel, low priority)
+9. **Slice 6** - Loading
+10. **Slice 9** - Keyboard nav
+
+---
+
+## Slice 1: Walking Skeleton
+
+**Branch:** `feat/narrow-rag/01-skeleton`
+
+**Target:** ~280 lines
+
+**Customer value:** User can select ONE document, AI searches only that document.
+
+### What's included (minimal)
+
+- `RAGDocument` and `RoomDocuments` models
+- `getDocuments()` API method
+- Basic `documentsProvider` (no retry logic)
+- 📎 button in chat input
+- Single-select picker dialog (no search, no filtering)
+- Plain text display of selected document above input
+- `filter_documents` in AG-UI state on submit
+
+### What's intentionally excluded
+
+- Chip styling (slice 2)
+- Multi-select (slice 3)
+- Search (slice 4)
+- Persistence (slice 5)
+- Loading indicator (slice 6)
+- Empty room handling (slice 7)
+- Error handling/retry (slice 8)
+- Keyboard navigation (slice 9)
+- File type icons (slice 10)
+
+### Tasks
+
+1. Create `RAGDocument`, `RoomDocuments` models in soliplex_client
+2. Add JSON mappers for `document_set` response format
+3. Add `getDocuments()` to `SoliplexApi`
+4. Create basic `documentsProvider` (FutureProvider.family)
+5. Add 📎 IconButton to `ChatInput`
+6. Create `DocumentPickerDialog` with simple list
+7. Display selected document as plain Text above input
+8. Build `filter_documents` state and pass to `startRun()`
+
+### Tests
+
+- Unit: Models parse correctly
+- Unit: API returns documents
+- Widget: Button opens picker
+- Widget: Selecting document shows text above input
+- Integration: Submit includes filter_documents in state
+
+### Acceptance Criteria
+
+- [ ] User can tap 📎 and see document list
+- [ ] User can select one document
+- [ ] Selected document name shown above input
+- [ ] Submitting sends filter_documents to backend
+- [ ] All tests pass
+
+---
+
+## Slice 2: Chip Styling
+
+**Branch:** `feat/narrow-rag/02-chips`
+
+**Target:** ~80 lines
+
+**Customer value:** Selected documents displayed as proper chips with × button.
+
+### Tasks
+
+1. Replace plain Text with `RawChip` or `InputChip`
+2. Add × button via `onDeleted` callback
+3. Use `Wrap` widget for multiple chips (prep for slice 3)
+
+### Tests
+
+- Widget: Selected doc renders as chip
+- Widget: × button removes chip
+- Widget: Chip shows document title
+
+### Acceptance Criteria
+
+- [ ] Selected document shown as chip
+- [ ] × button removes selection
+- [ ] All tests pass
+
+---
+
+## Slice 3: Multi-select
+
+**Branch:** `feat/narrow-rag/03-multi-select`
+
+**Target:** ~100 lines
+
+**Customer value:** User can select multiple documents at once.
+
+### Tasks
+
+1. Change picker from single-select to multi-select
+2. Add checkboxes to list items
+3. Track `Set<RAGDocument>` instead of single selection
+4. Update `filter_documents` to include multiple IDs
+
+### Tests
+
+- Widget: Can select multiple documents
+- Widget: Checkboxes toggle correctly
+- Widget: Multiple chips displayed
+- Integration: Multiple IDs in filter_documents
+
+### Acceptance Criteria
+
+- [ ] User can select multiple documents
+- [ ] All selected documents shown as chips
+- [ ] All IDs sent in filter_documents
+- [ ] All tests pass
+
+---
+
+## Slice 4: Search in Picker
+
+**Branch:** `feat/narrow-rag/04-search`
+
+**Target:** ~120 lines
+
+**Customer value:** User can quickly find documents by typing.
+
+### Tasks
+
+1. Add search TextField at top of picker
+2. Filter list as user types (case-insensitive)
+3. Show "No matches" when filter yields empty
+4. Auto-focus search field on open
+
+### Tests
+
+- Widget: Search field visible
+- Widget: Typing filters list
+- Widget: Case-insensitive matching
+- Widget: "No matches" shown when appropriate
+
+### Acceptance Criteria
+
+- [ ] Search field filters document list
+- [ ] Filtering is instant
+- [ ] Empty state when no matches
+- [ ] All tests pass
+
+---
+
+## Slice 5: Selection Persistence
+
+**Branch:** `feat/narrow-rag/05-persistence`
+
+**Target:** ~150 lines
+
+**Customer value:** Document selection persists across runs in same thread.
+
+### Tasks
+
+1. Create `ThreadDocumentSelectionNotifier` provider
+2. Key selection state by thread ID
+3. Restore selection when returning to thread
+4. Clear when switching to different thread
+
+### Tests
+
+- Unit: Selection stored per thread
+- Widget: Selection persists after submit
+- Widget: Switching threads restores correct selection
+- Widget: New thread has empty selection
+
+### Acceptance Criteria
+
+- [ ] Selection persists across runs
+- [ ] Different threads have independent selections
+- [ ] All tests pass
+
+---
+
+## Slice 6: Loading Indicator
+
+**Branch:** `feat/narrow-rag/06-loading`
+
+**Target:** ~60 lines
+
+**Customer value:** User sees feedback while documents are loading.
+
+### Tasks
+
+1. Show `CircularProgressIndicator` in picker while loading
+2. Disable interaction during load
+
+### Tests
+
+- Widget: Spinner shown while loading
+- Widget: List appears after load completes
+
+### Acceptance Criteria
+
+- [ ] Loading indicator displayed
+- [ ] Smooth transition to list
+- [ ] All tests pass
+
+---
+
+## Slice 7: Empty Room Handling
+
+**Branch:** `feat/narrow-rag/07-empty-room`
+
+**Target:** ~40 lines
+
+**Customer value:** Picker button disabled when room has no documents.
+
+### Tasks
+
+1. Check document count from provider
+2. Disable/grey out 📎 button when count is 0
+3. Update tooltip to explain why disabled
+
+### Tests
+
+- Widget: Button disabled when no documents
+- Widget: Button enabled when documents exist
+- Widget: Tooltip explains disabled state
+
+### Acceptance Criteria
+
+- [ ] Button disabled for empty rooms
+- [ ] Clear indication of why
+- [ ] All tests pass
+
+---
+
+## Slice 8: Error Handling + Retry
+
+**Branch:** `feat/narrow-rag/08-error-retry`
+
+**Target:** ~180 lines
+
+**Customer value:** Graceful error handling with retry capability.
+
+### Tasks
+
+1. Add retry logic to `documentsProvider` (3 attempts, 1s/2s/4s backoff)
+2. Retry on 5xx, 408, 429, NetworkException
+3. Show error message in picker on failure
+4. Add "Retry" button that refreshes provider
+
+### Tests
+
+- Unit: Provider retries on 503
+- Unit: Provider gives up after 3 attempts
+- Unit: No retry on 404
+- Widget: Error message displayed
+- Widget: Retry button triggers refresh
+
+### Acceptance Criteria
+
+- [ ] Transient errors retried automatically
+- [ ] Error state shown after retries exhausted
+- [ ] Retry button works
+- [ ] All tests pass
+
+---
+
+## Slice 9: Keyboard Navigation
+
+**Branch:** `feat/narrow-rag/09-keyboard`
+
+**Target:** ~120 lines
+
+**Customer value:** Picker fully usable via keyboard (accessibility).
+
+### Tasks
+
+1. Arrow keys navigate list items
+2. Space toggles checkbox (if multi-select)
+3. Enter confirms selection and closes
+4. Escape closes without changes
+5. Manage focus correctly
+
+### Tests
+
+- Widget: Arrow keys move focus
+- Widget: Space toggles selection
+- Widget: Enter closes picker
+- Widget: Escape cancels
+
+### Acceptance Criteria
+
+- [ ] Full keyboard navigation
+- [ ] Focus management correct
+- [ ] All tests pass
+
+---
+
+## Slice 10: File Type Icons
+
+**Branch:** `feat/narrow-rag/10-file-icons`
+
+**Target:** ~80 lines
+
+**Customer value:** Visual cues help users identify document types at a glance.
+
+### Tasks
+
+1. Create `getFileTypeIcon(String path)` helper that maps extensions to icons
+2. Support common types: PDF, Word (.doc/.docx), Excel, PowerPoint, images, text
+3. Use generic file icon for unknown/missing extensions
+4. Apply icons in picker list items
+5. Apply icons in selected document chips
+
+### Icon Mapping
+
+| Extension | Icon |
+|-----------|------|
+| `.pdf` | `Icons.picture_as_pdf` |
+| `.doc`, `.docx` | `Icons.description` (or custom Word icon) |
+| `.xls`, `.xlsx` | `Icons.table_chart` |
+| `.ppt`, `.pptx` | `Icons.slideshow` |
+| `.png`, `.jpg`, `.jpeg`, `.gif` | `Icons.image` |
+| `.txt`, `.md` | `Icons.article` |
+| (unknown) | `Icons.insert_drive_file` |
+
+### Tests
+
+- Unit: Extension mapping returns correct icons
+- Unit: Case-insensitive extension matching
+- Unit: Unknown extension returns generic icon
+- Widget: Picker shows correct icons for each document type
+- Widget: Chips show correct icons
+
+### Acceptance Criteria
+
+- [ ] PDF files show PDF icon
+- [ ] Office documents show appropriate icons
+- [ ] Unknown extensions show generic file icon
+- [ ] Icons appear in both picker and chips
+- [ ] All tests pass
+
+---
+
+## Branch Naming Convention
+
+| Slice | Branch |
+|-------|--------|
+| 1 | `feat/narrow-rag/01-skeleton` |
+| 2 | `feat/narrow-rag/02-chips` |
+| 3 | `feat/narrow-rag/03-multi-select` |
+| 4 | `feat/narrow-rag/04-search` |
+| 5 | `feat/narrow-rag/05-persistence` |
+| 6 | `feat/narrow-rag/06-loading` |
+| 7 | `feat/narrow-rag/07-empty-room` |
+| 8 | `feat/narrow-rag/08-error-retry` |
+| 9 | `feat/narrow-rag/09-keyboard` |
+| 10 | `feat/narrow-rag/10-file-icons` |
+
+## Parallel Development with Git Worktrees
+
+After slice 1 merges, use worktrees for the parallel slices:
+
+```bash
+# Parallel slices (branch from slice 1)
+git worktree add ../narrow-rag-chips feat/narrow-rag/02-chips
+git worktree add ../narrow-rag-persist feat/narrow-rag/05-persistence
+git worktree add ../narrow-rag-empty feat/narrow-rag/07-empty-room
+```
+
+The picker chain (slices 3→4→6→8→9) must be developed sequentially in the
+main worktree to avoid conflicts.
+
+## Definition of Done (per slice)
+
+- [ ] All tasks completed
+- [ ] All tests written and passing
+- [ ] Code formatted (`dart format .`)
+- [ ] No analyzer issues (`dart analyze`)
+- [ ] PR reviewed and approved
+- [ ] Merged to `main`

--- a/PLANS/0001-narrow_rag/SPEC.md
+++ b/PLANS/0001-narrow_rag/SPEC.md
@@ -1,0 +1,182 @@
+# Feature Specification: Narrowed RAG Search
+
+## Overview
+
+Allow users to narrow the scope of RAG searches to a specific subset of documents
+(already ingested by the backend) by selecting them before submitting a prompt.
+
+## Problem Statement
+
+Currently, when a user submits a prompt, the backend performs RAG across the
+entire document database for the room. Users often know which specific documents
+contain relevant information and want to limit the search scope to improve
+result relevance and reduce noise.
+
+## Requirements
+
+### Functional Requirements
+
+1. Users can open a document picker by clicking a document button in the input
+   area.
+2. The picker displays a searchable, multi-select list of available documents in
+   the current room.
+3. Users can filter the list by typing a search query.
+4. Users can toggle document selection using keyboard (arrows + space/enter) or
+   mouse/touch.
+5. Users can select multiple documents before closing the picker.
+6. Selected documents appear as chips above the text input field.
+7. Users can remove a selected document by clicking the × button on its chip.
+8. The prompt submission includes the selected document references, instructing
+   the backend to limit RAG scope.
+9. Selected documents persist across runs in the same thread until the user
+   removes them.
+10. Changes to document selection are sent with the next run via AGUI state.
+
+### Non-Functional Requirements
+
+- Picker response should feel instantaneous (document list is cached client-side
+  after first fetch).
+- Works on both desktop (keyboard navigation) and mobile (touch selection).
+- Accessible via keyboard-only interaction.
+
+## Use Cases
+
+### Use Case 1: New Thread with Document Selection
+
+1. John starts a thread T in room R.
+2. Frontend sends request to `/api/v1/rooms/{room_id}/agui`.
+3. Backend responds with a new thread and the first (empty) Run.
+4. John clicks the 📎 button to open the document picker.
+5. Frontend requests documents via `/api/v1/rooms/{room_id}/documents`.
+6. Backend responds with the document list.
+7. Frontend displays the picker popup with a search field and multi-select list.
+8. John selects document_A (checkbox toggles on).
+9. John selects document_B (checkbox toggles on).
+10. John closes the picker (clicks outside or presses Escape).
+11. Both documents appear as chips above the text input.
+12. John types their prompt in the text field.
+13. John submits the prompt.
+14. Frontend populates RunAgentInput with prompt + State containing selected
+    document references.
+15. Frontend starts the Run.
+
+### Use Case 2: Follow-up Run with Persisted Selection
+
+1. John's previous run used document_A and document_B.
+2. The chips for document_A and document_B remain visible above the input.
+3. John types a follow-up question without changing the document selection.
+4. John submits the prompt.
+5. Frontend sends RunAgentInput with the same document references in State.
+6. The backend uses the same narrowed document scope.
+
+### Use Case 3: Modifying Selection for a Follow-up Run
+
+1. John's previous run used document_A and document_B.
+2. John clicks × on the document_A chip to remove it.
+3. John opens the picker and adds document_C.
+4. John types a follow-up question.
+5. John submits the prompt.
+6. Frontend sends RunAgentInput with document_B and document_C in State.
+7. The backend uses the updated document scope.
+
+### Use Case 4: Clearing All Selected Documents
+
+1. John has document_A and document_B selected.
+2. John removes both chips by clicking × on each.
+3. John types a question.
+4. John submits the prompt.
+5. Frontend sends RunAgentInput with no document references in State.
+6. The backend performs RAG across all documents in the room.
+
+## Design
+
+### User Experience
+
+**Layout:**
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│ [manual.pdf ×] [troubleshooting.pdf ×]                      │  ← Chip row
+├─────────────────────────────────────────────────────────────┤
+│ 📎 Type your message...                              [Send] │  ← Input row
+└─────────────────────────────────────────────────────────────┘
+```
+
+- The chip row only appears when at least one document is selected.
+- The 📎 button opens the document picker popup.
+
+**Trigger:**
+
+- Clicking the 📎 button opens the picker popup.
+
+**Picker popup:**
+
+- Positioned above or below the input area.
+- Contains a search field at the top for filtering.
+- Lists all documents with checkboxes; selected documents are checked.
+- Each document displays a file type icon matching its extension (e.g., PDF icon
+  for `.pdf`, Word icon for `.docx`); unknown or missing extensions show a
+  generic file icon.
+- Document paths are shortened to show filename plus up to 2 parent folders
+  (e.g., `my/folder/document.pdf`).
+- Multi-select: user can toggle multiple documents before closing.
+- Keyboard navigable: Tab to search, arrows to navigate list, Space to toggle,
+  Escape to dismiss.
+- Touch/click to toggle selection on mobile.
+- Scrollable if the list exceeds the popup height.
+- Closes when user clicks outside or presses Escape.
+
+**Selected document chips:**
+
+- Displayed in a row above the text input.
+- Each chip shows a file type icon (matching the document's extension), the
+  shortened document path, and an × button.
+- Clicking × removes the document from selection.
+- Row wraps if many documents are selected.
+- Chips persist across runs until explicitly removed.
+
+**Selection persistence:**
+
+- Document selection is maintained across runs within the same thread.
+- When the user submits a prompt, the current selection is sent via AGUI state.
+- Users can modify the selection at any time; changes apply to the next run.
+- Switching threads clears the selection (each thread has independent state).
+
+**Loading state:**
+
+- While documents are being fetched, the picker shows a loading indicator.
+- The user can dismiss the picker and continue typing.
+
+**Empty state:**
+
+- If the room has no documents, the picker shows: "No documents in this room."
+- The user can dismiss the picker and continue typing.
+
+**Error state:**
+
+- If document fetching fails after retries, the picker shows: "Could not load
+  documents. Tap to retry."
+- The user can dismiss the picker and continue typing without document
+  selection.
+
+## Acceptance Criteria
+
+- [ ] Clicking 📎 button opens document picker popup.
+- [ ] Picker shows all documents available in the current room.
+- [ ] Picker has a search field that filters the document list.
+- [ ] Picker supports multi-select (checkboxes, user can select many before
+      closing).
+- [ ] User can toggle selection via keyboard (arrows + space).
+- [ ] User can toggle selection via mouse click or touch.
+- [ ] Selected documents appear as chips above the text input.
+- [ ] User can remove a chip by clicking its × button.
+- [ ] Picker popup is scrollable when document list is long.
+- [ ] Picker closes on click outside or Escape key.
+- [ ] Document selection persists across runs in the same thread.
+- [ ] Submitted prompt includes selected document references in AGUI state.
+- [ ] Switching threads clears the document selection.
+- [ ] Works on desktop, web, iOS, and Android.
+
+## Open Questions
+
+*None at this time.*


### PR DESCRIPTION
## Summary
- Restores the narrow RAG plan docs (ADR, IMPLEMENTATION, SPEC) that were accidentally removed in 611562ff30b ("Doc updates #261")

## Test plan
- [x] Verify all 3 files restored match their pre-deletion content

🤖 Generated with [Claude Code](https://claude.com/claude-code)