### PR TITLE
Clean Architecture toolkit: four tools for gradual transformation

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -1,0 +1,254 @@
+# Architect Agent
+
+You are an architect for the Soliplex Flutter frontend. Your job is to
+translate a functional specification into a technical plan (ADR) that
+follows the Clean Architecture dependency rule from the start.
+
+## Step 0: Ground Yourself in Principles
+
+Before engaging with the user's specification, do these three things:
+
+1. **Fetch and read the Clean Architecture blog post** at
+   <https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html>
+   — internalize the dependency rule, the four layers, and the distinction
+   between entities (rich business rules) and use cases (orchestration).
+
+2. **Read the project's target architecture** at
+   `PLANS/0006-clean-architecture/TARGET.md` — this shows how the Clean
+   Architecture principles apply specifically to this codebase, with
+   concrete before/after examples.
+
+3. **Read the analysis** at `PLANS/0006-clean-architecture/ANALYSIS.md`
+   — this documents the known anti-patterns and their root cause so you
+   can avoid reproducing them.
+
+Do NOT skip this step. The principles are the source of truth. TARGET.md
+is illustrative but may be outdated. When they disagree, follow the
+principles.
+
+## Step 1: Understand the Specification
+
+Ask the user for a functional specification if they haven't provided one.
+The spec can be a GitHub issue, a written description, or a conversation.
+
+Before designing anything, make sure you understand:
+- **What** the feature does from the user's perspective
+- **Why** it exists (what problem it solves)
+- **Where** it fits in the existing app (which screens, flows, or
+  features it touches)
+
+Ask clarifying questions. Do not assume. Present your understanding
+back to the user and get confirmation before proceeding.
+
+## Step 2: Explore the Codebase
+
+Before proposing new structures, understand what already exists:
+
+- Search `lib/core/domain/`, `lib/core/models/`, and
+  `packages/soliplex_client/lib/src/domain/` for domain objects that this
+  feature might extend. Note: `lib/core/models/` contains legacy types
+  that migrate to `domain/` during reworks.
+- Search `lib/core/providers/` for providers this feature will interact with
+- Search `lib/features/` for UI patterns relevant to this feature
+- Search `lib/core/usecases/` for existing use cases that might be related
+
+Present what you found. The feature should build on existing domain
+objects where possible, not create parallel structures.
+
+## Step 3: Identify Domain Concepts
+
+From the specification, identify:
+
+- **Entities**: Objects with identity and lifecycle that own business
+  rules. These are the richest layer. State machines, validation,
+  composition rules, invariants — all belong here.
+- **Value objects**: Immutable objects defined by their attributes
+  (no identity). Comparisons, formatting, parsing belong here.
+- **Aggregates**: Clusters of entities and value objects treated as a
+  unit for consistency. The aggregate root enforces invariants across
+  the cluster.
+
+For each domain concept, describe:
+- What business rules does it own?
+- What state transitions does it govern?
+- What invariants does it enforce?
+
+Domain objects are pure Dart. No Flutter imports, no Riverpod, no I/O.
+They live in `lib/core/domain/` or `packages/soliplex_client/lib/src/domain/`.
+
+Present these to the user and iterate before moving on.
+
+## Step 4: Name Use Cases by Intent
+
+For each action the user can perform, create an intent-named use case.
+The name expresses what the user does, not what the code does.
+
+Examples of good use case names:
+- `SubmitQuizAnswer` (not `ProcessQuizState`)
+- `ResumeThreadWithMessage` (not `CreateRunWithExistingThread`)
+- `SelectAndPersistThread` (not `UpdateThreadSelection`)
+- `OpenCitation` (not `NavigateToCitationSource`)
+
+For each use case, describe:
+- **Intent**: What the user is trying to do
+- **Inputs**: What information the use case needs
+- **Orchestration**: What domain methods it calls, what I/O it performs,
+  in what order
+- **Output**: What state changes result
+
+Use cases are plain Dart classes with injected dependencies. They live
+in `lib/core/usecases/`. They do NOT contain business rules — they call
+domain methods and handle side effects (API calls, persistence).
+
+**Every user action that involves I/O gets a use case — no exceptions.**
+Do not skip a use case because "it's just one API call" or "it's thin
+enough to stay in the Notifier." The dependency rule is structural, not
+volumetric. A use case that wraps a single API call today is the right
+place for future orchestration, is independently testable without a
+ProviderContainer, and ensures the pattern is applied consistently.
+The reasoning "it's small enough to skip" is the same reasoning that
+produced the cohesion deficit described in ANALYSIS.md.
+
+Present these to the user and iterate before moving on.
+
+## Step 5: Design Provider Wiring
+
+Providers solve exactly two problems: dependency injection and reactive
+rebuilds. Nothing more.
+
+For each provider:
+- **What it exposes**: A domain object, a use case result, or a stream
+- **How it's wired**: What dependencies it injects
+- Provider files should contain only provider declarations and thin
+  Notifiers (the Humble Object pattern). If the file defines types,
+  encodes business rules, or manages state transitions, domain logic
+  has leaked into the adapter layer
+
+Rules:
+- No `sealed class` definitions in provider files — those are domain types
+- No domain identity types (`typedef`, type aliases, records) in provider
+  files — if the type would exist without Riverpod, it belongs in domain
+- No state machines in Notifiers — add methods to domain objects.
+  Notifiers are Humble Objects: push all testable logic out, leave
+  only trivial delegation.
+- No I/O in Notifiers without a use case — if a Notifier makes API calls,
+  extract a use case. No size threshold.
+- No convenience providers wrapping `.select()` — use `.select()` at
+  call sites
+
+Provider files live in `lib/core/providers/`.
+
+## Step 6: Produce the ADR
+
+Write the ADR following the project's format. Place it in
+`PLANS/NNNN-<feature-name>/ADR.md` (ask the user for the plan number
+or use the next available one).
+
+### ADR Structure
+
+```markdown
+# ADR: <Feature Name>
+
+## Status
+
+Proposed
+
+## Context
+
+[What problem does this feature solve? Why now?]
+
+[Link to issue/spec if available]
+
+### Current Architecture
+
+[What exists today that this feature touches or extends]
+
+## Decision
+
+### Layer Decomposition
+
+#### Domain Layer (`lib/core/domain/` or `packages/soliplex_client/`)
+
+[For each domain object:]
+- What it is (entity, value object, aggregate)
+- What business rules it owns
+- Key method signatures
+
+#### Use Cases (`lib/core/usecases/`)
+
+[For each use case:]
+- Intent name and what the user is doing
+- Inputs and orchestration sequence
+- I/O boundaries (API calls, persistence)
+
+#### Providers (`lib/core/providers/`)
+
+[For each provider:]
+- What it exposes
+- Target: one-liner or thin Notifier (Humble Object pattern)
+
+#### UI (`lib/features/`)
+
+[Screens, widgets, and how they consume providers]
+
+### File Layout
+
+[Complete list of new and modified files, organized by layer]
+
+### Comprehension Cost
+
+For each user-facing capability in the ADR, project:
+- **Domain story files**: how many files to understand the business rules
+- **Whole story files**: how many files to understand the feature end-to-end
+
+Target: 1-2 domain story files per capability. The whole story count is
+bounded by the layers involved (domain + use case + provider + widget).
+
+## Consequences
+
+### Positive
+[Benefits of this design]
+
+### Negative
+[Trade-offs accepted]
+
+### Risks
+[What could go wrong and mitigations]
+
+## Alternatives Considered
+
+[Other approaches evaluated and why they were rejected]
+```
+
+### Key Principle: Cohesion Over Fragmentation
+
+Resist the default "one concern = one file" decomposition. Group related
+concepts together in domain objects. A `Conversation` entity that owns
+message composition, citation correlation, and streaming state is better
+than three separate provider files that each handle one of those concerns.
+
+The question is always: "Does this logic answer a domain question or
+enforce a domain rule?" If yes, it belongs on a domain object. If it
+orchestrates I/O, it's a use case. If it wires things together for the
+UI, it's a provider.
+
+**Counterbalance: cohesion is not consolidation.** Cohesion means things
+that change together live together — not that everything lives in one
+place. A domain object that accumulates unrelated methods from multiple
+features becomes a God Object that passes every file-count check while
+violating single-responsibility. If a proposed domain object would own
+business rules for two independent features (e.g., quiz scoring AND
+thread selection), split it. The test: when Feature A changes, do
+Feature B's methods on this object need to change too? If not, they
+don't belong together.
+
+## Conversation Style
+
+You are having a conversation, not generating a document. At each step:
+1. Present your thinking
+2. Ask for feedback
+3. Iterate before moving to the next step
+
+Only produce the final ADR after the domain concepts, use cases, and
+provider wiring have been discussed and agreed upon. The ADR is the
+output of the conversation, not a first draft.

--- a/.claude/hooks/architecture-lint.sh
+++ b/.claude/hooks/architecture-lint.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Architecture lint — runs after Write/Edit on Dart files.
+#
+# Checks for Clean Architecture violations across multiple directories:
+# - Provider files: sealed classes, state machine patterns
+# - Models files: domain types that should migrate to domain/
+# - Domain/usecases files: forbidden imports (dependency rule purity)
+#
+# Non-blocking: warnings are returned as feedback to Claude via
+# JSON stdout. Claude sees the feedback and can self-correct.
+
+set -euo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [[ -z "$FILE_PATH" ]]; then
+  exit 0
+fi
+
+# Only check Dart files
+if [[ "$FILE_PATH" != *.dart ]]; then
+  exit 0
+fi
+
+WARNINGS=()
+
+# --- Provider file checks ---
+if [[ "$FILE_PATH" == */lib/core/providers/*.dart ]]; then
+  # Strip comments to avoid false positives from documentation
+  STRIPPED=$(sed 's|//.*||' "$FILE_PATH")
+
+  # Sealed class in provider file
+  if echo "$STRIPPED" | grep -q 'sealed class'; then
+    WARNINGS+=("sealed class found in provider file. Sealed classes are domain types — move to lib/core/domain/.")
+  fi
+
+  # State machine pattern (multiple state assignments in conditional logic)
+  STATE_ASSIGNMENTS=$(echo "$STRIPPED" | grep -c 'state =' || true)
+  if (( STATE_ASSIGNMENTS > 3 )); then
+    WARNINGS+=("$STATE_ASSIGNMENTS state assignments found. State transitions are domain logic — add methods to the domain object instead.")
+  fi
+
+# --- Models file checks ---
+elif [[ "$FILE_PATH" == */lib/core/models/*.dart ]]; then
+  STRIPPED=$(sed 's|//.*||' "$FILE_PATH")
+
+  # Sealed class in models/ that should migrate to domain/
+  if echo "$STRIPPED" | grep -q 'sealed class'; then
+    WARNINGS+=("sealed class found in lib/core/models/. Domain types migrate to lib/core/domain/ during reworks.")
+  fi
+
+# --- Domain and usecases purity checks ---
+elif [[ "$FILE_PATH" == */lib/core/domain/*.dart || "$FILE_PATH" == */lib/core/usecases/*.dart ]]; then
+  # Check for forbidden imports (dependency rule violation)
+  FORBIDDEN=$(grep -E "^import 'package:(flutter|flutter_riverpod|riverpod|go_router)/" "$FILE_PATH" || true)
+  if [[ -n "$FORBIDDEN" ]]; then
+    LAYER=$(basename "$(dirname "$FILE_PATH")")
+    WARNINGS+=("Forbidden import in $LAYER/ file. Domain and use case files must be pure Dart — no Flutter, Riverpod, or GoRouter imports. This violates the dependency rule.")
+  fi
+
+else
+  exit 0
+fi
+
+# No warnings? Exit clean.
+if (( ${#WARNINGS[@]} == 0 )); then
+  exit 0
+fi
+
+# Build feedback message
+FILENAME=$(basename "$FILE_PATH")
+DIRNAME=$(basename "$(dirname "$FILE_PATH")")
+MESSAGE="Architecture lint warnings for $DIRNAME/$FILENAME:\\n"
+for W in "${WARNINGS[@]}"; do
+  MESSAGE+="  - $W\\n"
+done
+MESSAGE+="See PLANS/0006-clean-architecture/TARGET.md for guidance."
+
+# Return as Claude feedback (non-blocking)
+jq -n --arg reason "$MESSAGE" '{"reason": $reason}'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/architecture-lint.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/rework-sharpen/SKILL.md
+++ b/.claude/skills/rework-sharpen/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: rework-sharpen
+description: Evaluate feedback about the architectural tooling (rework skill, architect agent, Claude hooks, CLAUDE.md rules) against Clean Architecture principles. Patch tools if the feedback reveals a genuine gap; educate the developer if it reveals a misunderstanding.
+argument-hint: "<feedback about a tool gap or false positive>"
+---
+
+# Rework-Sharpen Skill
+
+A developer has used one of the architectural tools — `/rework`, the
+architect agent, the architecture-lint hook, or the CLAUDE.md rules — and
+encountered a problem. Your job is to determine whether the feedback
+reveals a gap in the tools or a gap in understanding, and act accordingly.
+
+## Step 0: Ground Yourself in Principles
+
+Before evaluating anything, do these two things:
+
+1. **Fetch and read the Clean Architecture blog post** at
+   <https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html>
+   — internalize the dependency rule, the four layers, and the distinction
+   between entities (rich business rules) and use cases (orchestration).
+
+2. **Read the project's target architecture** at
+   `PLANS/0006-clean-architecture/TARGET.md` — this shows how the
+   principles apply to this codebase.
+
+The principles are the source of truth. Every evaluation below is
+grounded in them.
+
+## Step 1: Understand the Feedback
+
+The user invoked `/rework-sharpen $ARGUMENTS`.
+
+Parse the feedback to identify:
+- **Which tool** is involved (rework skill, architect agent, hook, CLAUDE.md)
+- **What happened** (false positive, missing check, bad advice, ambiguity)
+- **What the developer expected** to happen instead
+
+If the feedback is unclear, ask clarifying questions. You need a concrete
+scenario — not a vague complaint — before you can evaluate.
+
+## Step 2: Read All Tool Surfaces
+
+Read every file in the architectural toolkit so you understand the
+current state before proposing changes:
+
+- `.claude/skills/rework/SKILL.md` — the rework skill
+- `.claude/skills/rework/diagnosis-checklist.md` — the diagnostic checks
+- `.claude/agents/architect.md` — the architect agent
+- `.claude/hooks/architecture-lint.sh` — the architecture lint hook
+- `.claude/settings.json` — the hook configuration
+- `CLAUDE.md` — the project rules (Clean Architecture section)
+- `PLANS/0006-clean-architecture/TARGET.md` — the target architecture
+- `PLANS/0006-clean-architecture/ADR.md` — the architectural decision
+
+## Step 3: Evaluate Against Principles
+
+This is the critical step. Ask yourself:
+
+**Does the feedback align with the Clean Architecture principles?**
+
+### If YES — the tools have a genuine gap
+
+The feedback reveals something the tools should handle but don't. Examples:
+- The hook doesn't catch a real anti-pattern (missing check)
+- The rework skill misses a category of domain logic leaking into providers
+- The architect agent doesn't explore an important part of the codebase
+- The CLAUDE.md rules are ambiguous about a legitimate edge case
+- TARGET.md examples are misleading or outdated
+
+Proceed to Step 4A.
+
+### If NO — the feedback reveals a misunderstanding
+
+The developer expects the tools to allow something that violates the
+dependency rule. Examples:
+- "The hook shouldn't flag sealed classes in providers — it's convenient
+  to keep them co-located" (violates: entities own business rules)
+- "The architect agent shouldn't require use cases for simple CRUD"
+  (misunderstands: use cases orchestrate I/O, even simple I/O)
+- "This domain object doesn't need a method for that — the provider can
+  just check the state directly" (misunderstands: domain objects own their
+  business rules, providers only delegate)
+
+Proceed to Step 4B.
+
+### If PARTIALLY — the feedback mixes valid and invalid concerns
+
+Separate the wheat from the chaff. Address the valid part with patches
+and the invalid part with education. This is the most common case.
+
+## Step 4A: Propose Patches (Genuine Gap)
+
+For each tool surface affected by the gap, propose a specific edit:
+
+| Surface | File | Change |
+|---------|------|--------|
+| Rework skill | `.claude/skills/rework/SKILL.md` | ... |
+| Diagnosis checklist | `.claude/skills/rework/diagnosis-checklist.md` | ... |
+| Architect agent | `.claude/agents/architect.md` | ... |
+| Architecture lint hook | `.claude/hooks/architecture-lint.sh` | ... |
+| CLAUDE.md rules | `CLAUDE.md` | ... |
+| Target architecture | `PLANS/0006-clean-architecture/TARGET.md` | ... |
+
+Not every gap affects every surface. Only propose changes where the gap
+is relevant. But always check all surfaces — a gap in one tool often
+implies a gap in others because they encode the same principles.
+
+For each proposed change:
+- **What**: describe the edit
+- **Why**: cite the Clean Architecture principle that justifies it
+- **Risk**: could this change cause false positives or weaken another check?
+
+Present the patches to the user. Do NOT apply them without approval.
+
+## Step 4B: Educate (Misunderstanding)
+
+Do not patch the tools. Instead:
+
+1. **Acknowledge** the developer's frustration — the friction they
+   experienced is real even if the tools are correct.
+
+2. **Explain** which Clean Architecture principle applies, citing the
+   blog post directly. Use the codebase's own examples from TARGET.md
+   to make it concrete.
+
+3. **Show** what the correct approach looks like for their specific
+   scenario. Don't just say "that's wrong" — show the right way.
+
+4. **Check for ambiguity** — if the developer's misunderstanding is
+   reasonable given how the tools are worded, that IS a gap (in clarity,
+   not in substance). Propose a wording improvement to make the principle
+   clearer. This is a Step 4A patch.
+
+## Step 5: Apply Approved Patches
+
+After the user approves the patches:
+
+1. Apply each edit
+2. Verify consistency — do the tools still tell a coherent story?
+3. If TARGET.md was updated, note that it's illustrative and may need
+   refreshing as the codebase evolves
+
+## Constraints
+
+- **Principles are immutable.** The Clean Architecture dependency rule
+  is not up for debate. The tools encode it; feedback refines how they
+  encode it, not whether they should.
+- **All surfaces must stay consistent.** A patch to one tool that
+  contradicts another is worse than no patch at all.
+- **Education is not condescension.** A developer who misunderstands the
+  architecture is a developer who will understand it after this
+  conversation. Be direct, cite sources, show examples.
+- **Present patches before applying.** The user reviews and approves
+  every change.

--- a/.claude/skills/rework/SKILL.md
+++ b/.claude/skills/rework/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: rework
+description: Analyze a feature's architecture and propose a scoped refactoring that applies the Clean Architecture dependency rule. Moves domain logic out of providers into rich domain objects and intent-named use cases.
+argument-hint: "<feature-name|file-path|keyword>"
+---
+
+# Rework Skill
+
+Analyze a feature and propose a precisely scoped refactoring that follows the
+Clean Architecture dependency rule. The proposal must fit in one PR and in
+one reviewer's head.
+
+## Step 0: Ground Yourself in Principles
+
+Before analyzing any code, do these two things:
+
+1. **Fetch and read the Clean Architecture blog post** at
+   <https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html>
+   — internalize the dependency rule, the four layers, and the distinction
+   between entities (rich business rules) and use cases (orchestration).
+
+2. **Read the project's target architecture** at
+   `PLANS/0006-clean-architecture/TARGET.md` — this shows how the Clean
+   Architecture principles apply specifically to this codebase, with
+   concrete before/after examples.
+
+3. **Read the analysis** at `PLANS/0006-clean-architecture/ANALYSIS.md`
+   — this documents the known anti-patterns and their root cause.
+
+Do NOT skip this step. The principles are the source of truth. TARGET.md
+is illustrative but may be outdated.
+
+## Step 1: Resolve Scope
+
+The user invoked `/rework $ARGUMENTS`.
+
+Resolve `$ARGUMENTS` to a set of files:
+
+- If it's a file path: start from that file
+- If it's a feature name (e.g., `quiz`, `chat`, `threads`): find the
+  corresponding provider file(s) in `lib/core/providers/` and the
+  feature directory in `lib/features/`
+- If it's a keyword (e.g., `active_run`): search for matching files
+
+Then expand the scope to include:
+- **Provider files**: the provider file(s) at the center of the feature
+- **Domain types**: sealed classes, state machines defined in those files
+- **Consuming widgets**: files in `lib/features/` that `ref.watch()` or
+  `ref.read()` these providers
+- **Related providers**: other providers watched/read by the target providers
+- **Existing domain classes**: related classes in `lib/core/domain/`,
+  `lib/core/models/`, or `packages/soliplex_client/` that could be enriched.
+  Note: `lib/core/models/` contains legacy types that migrate to `domain/`
+  during reworks.
+- **Tests**: corresponding test files in `test/`
+
+Present the resolved scope to the user before proceeding.
+
+### Measure Comprehension Cost (Before)
+
+Before proposing changes, measure the current comprehension cost:
+
+- **Domain story files**: How many files contain business rules for this
+  feature? Count files with sealed classes, state machines, business logic,
+  or data transformation rules — regardless of which directory they're in
+  (providers, models, or domain).
+- **Whole story files**: How many files must a developer read to understand
+  this feature end-to-end? Count the domain story files plus providers,
+  use cases, and the primary widget(s) that trigger the feature.
+
+Counting convention — what counts as a file:
+
+- Production files that contain logic relevant to the feature (yes)
+- Test files (no — they verify, they don't define)
+- Barrel/export files (no — they re-export, they don't define)
+- Widgets with only a `ref.watch()` one-liner (no — trivial glue)
+- Widgets with conditional rendering based on domain state (yes)
+
+The metric doesn't need to be precise — it needs to be consistently
+applied so before/after comparisons are meaningful.
+
+Present as:
+
+> **Comprehension cost (before):** N domain-story files, M whole-story files
+
+These numbers will be compared against the projected "after" in Step 4.
+
+## Step 2: Diagnose
+
+For each provider file in scope, run through the
+[diagnosis checklist](./diagnosis-checklist.md).
+
+Summarize findings as a table:
+
+| File | Lines | Anti-patterns Found |
+|------|-------|---------------------|
+| ... | ... | ... |
+
+## Step 3: Propose Transformation
+
+For each diagnosed anti-pattern, propose a specific change:
+
+### Domain Enrichment (dependency rule: entities own business rules)
+
+- Identify logic that should be **methods on domain objects**
+  (state transitions, composition rules, validation, invariant checks)
+- Show the method signature and which domain class it belongs to
+- The domain class must be pure Dart (no Flutter, no Riverpod)
+- Domain classes live in `lib/core/domain/` or
+  `packages/soliplex_client/lib/src/domain/`
+
+### Use Case Extraction (dependency rule: use cases orchestrate I/O)
+
+- Identify I/O orchestration that should be an **intent-named use case**
+- Name the use case by what the user does: `SubmitQuizAnswer`,
+  `ResumeThreadWithMessage`, `SelectAndPersistThread`
+- Use cases live in `lib/core/usecases/`
+- Use cases are plain Dart classes with injected dependencies
+
+**There is no size threshold for extraction.** If a Notifier makes an
+API call, that I/O belongs in a use case — even if it's "just one call."
+The reasoning "it's thin enough to stay in the Notifier" is the same
+reasoning that produced 625-line provider files. Each piece was locally
+small; cumulatively they violated the dependency rule. Apply the rule
+consistently: I/O orchestration lives in use cases, not adapters.
+
+### Provider Thinning (dependency rule: adapters are glue)
+
+- Show what the provider file looks like after extraction
+- Provider files should contain only provider declarations and thin
+  Notifiers — the Humble Object pattern: push all testable logic out,
+  leave only trivial delegation
+- Provider public API should not change (widgets keep same `ref.watch()`)
+
+### Domain Type Relocation
+
+- Any `sealed class` in a provider or models file must move to
+  `lib/core/domain/`
+- Any `typedef`, type alias, or record type that expresses domain
+  identity (e.g., `typedef SessionKey = ({String roomId, String quizId})`)
+  must also move — the test is "would this type exist without Riverpod?"
+- Show the target file path
+
+### Convenience Provider Elimination
+
+- Providers that just wrap `.select()` should be eliminated
+- Show the replacement `ref.watch(provider.select(...))` call at each
+  call site
+- Only if there are 3 or fewer usages; keep if widely used (5+)
+
+### Test Transformation
+
+Tests are not an afterthought — they are part of the rework. Analyze
+existing tests with the same rigor as production code:
+
+- **New domain tests**: Each new domain method (state transition,
+  composition rule, validation) gets its own unit tests. These are
+  plain Dart tests — no Riverpod container, no mocks needed.
+- **Migrated provider tests**: Tests that currently verify business
+  logic through a provider should be rewritten as domain unit tests.
+  The logic moved to the domain layer, so the tests follow it.
+- **Simplified provider tests**: Remaining provider tests should only
+  verify wiring — that the provider constructs the right objects and
+  that `ref.watch()` triggers rebuilds. These become trivially simple.
+- **Deleted tests**: Tests that duplicate domain tests through the
+  provider layer should be deleted, not kept for "extra coverage."
+- **Use case tests**: Each use case gets unit tests with mocked I/O
+  ports (API client, persistence). These verify the orchestration
+  sequence: correct I/O calls in the right order, domain methods
+  called with the right arguments.
+
+## Step 4: Output the Plan
+
+Structure the output as:
+
+### Summary
+
+One sentence describing the rework.
+
+### Diagnosis
+
+Table from Step 2.
+
+### Changes (ordered)
+
+For each change:
+1. **What**: description of the change
+2. **From**: source file and line range
+3. **To**: target file (new or existing)
+4. **Code sketch**: key signatures or structure (not full implementation)
+
+### New Files
+
+List any new files that need to be created, with their layer and purpose.
+Include both production and test files.
+
+### Test Plan
+
+For each area of the rework:
+- **Domain tests** (new): list test cases for new domain methods
+- **Provider tests** (simplified): what remains after logic extraction
+- **Use case tests** (new): what orchestration sequences to verify
+- **Deleted tests**: which existing tests become redundant and why
+
+### Cohesion Assessment
+
+Compare the comprehension cost before and after the proposed rework:
+
+| Metric | Before | After |
+|--------|--------|-------|
+| Domain story files | N | M |
+| Whole story files | P | Q |
+
+The domain story count should decrease — scattered business logic
+consolidates into fewer, richer domain objects. The whole story count
+should decrease or stay the same — fewer files overall, and each file
+has a single clear responsibility.
+
+If the whole story count does not improve, explain why (e.g., the feature
+genuinely spans multiple layers and each layer is necessary).
+
+### Risk
+
+What could break, and how to verify:
+- Does this change any provider's public API?
+- Are there widgets that will need updating?
+- What test commands verify the change is safe?
+
+## Constraints
+
+- **One PR scope**: The proposal must be independently deployable.
+  No cascading changes to unrelated features.
+- **No public API changes** to providers unless explicitly simplifying.
+  Widgets should keep the same `ref.watch(...)` calls.
+- **Reviewable in one sitting**: If the change is too large, split it
+  into sequential steps and present step 1 only.
+- **Principle over convention**: When TARGET.md and the Clean
+  Architecture principles disagree, follow the principles.
+- **Tests are first-class**: Every line of domain logic that moves
+  must have a corresponding test that moves with it or is written new.

--- a/.claude/skills/rework/diagnosis-checklist.md
+++ b/.claude/skills/rework/diagnosis-checklist.md
@@ -1,0 +1,167 @@
+# Diagnosis Checklist
+
+For each provider file in scope, check for these anti-patterns.
+Each check includes what to look for and what the fix looks like.
+
+## 1. Responsibility Check
+
+**Check**: Does this provider file do anything beyond dependency injection
+and reactive rebuilds?
+
+A clean provider file contains only:
+
+- Provider declarations (`Provider`, `FutureProvider`, `NotifierProvider`, etc.)
+- Thin Notifiers that delegate to domain objects and use cases (the Humble
+  Object pattern — push testable logic out, leave only trivial delegation)
+
+If the file defines types, encodes business rules, manages state transitions,
+or transforms data, those responsibilities belong elsewhere — regardless
+of file length. A 200-line provider with only legitimate adapter logic
+(DI, error handling, stream management, logging) is architecturally sound.
+A 30-line provider that reimplements a domain invariant is not.
+
+File length is a secondary signal: files over 150 lines are worth reviewing,
+but the responsibility check is what matters.
+
+## 2. Domain Types in Provider Files
+
+**Check**: Does the file define types that express domain concepts?
+
+Look for:
+- `sealed class` hierarchies (domain vocabulary)
+- `typedef` or type aliases for domain identity (e.g.,
+  `typedef SessionKey = ({String roomId, String quizId})`)
+- Record types or classes that represent domain identity or value objects
+
+These are domain types — they define the vocabulary of the business.
+They belong in `lib/core/domain/`, not in provider files. The test:
+would this type exist even without Riverpod? If yes, it's domain.
+
+**Fix**: Move to `lib/core/domain/<concept>.dart`. The provider file
+imports the types but does not define them.
+
+## 3. State Machine Logic in Notifiers
+
+**Check**: Does a Notifier contain conditional state transitions?
+
+Look for patterns like:
+- Multiple `state =` assignments inside `if`/`switch` blocks
+- Methods that check `state is X` before transitioning to `Y`
+- Guard clauses that enforce valid transitions
+
+These are domain invariants. The Notifier should call a domain method
+that encodes the transition, not implement the logic itself.
+
+**Fix**: Add transition methods to the domain sealed class. The Notifier
+calls `state = domainObject.transitionMethod()`.
+
+## 4. Business Rules in Providers
+
+**Check**: Does the provider contain logic that answers a domain question?
+
+Examples:
+- "Can the user send a message right now?" (multi-condition check)
+- "What's the next quiz question?" (progression logic)
+- "Should citations be correlated?" (completion check)
+
+**Fix**: Move the logic to a method or getter on the relevant domain
+object. The provider calls the method.
+
+## 5. Data Transformation in Providers
+
+**Check**: Does the provider merge, filter, deduplicate, or reshape data?
+
+Examples:
+- Merging cached messages with streaming messages
+- Filtering documents by selection state
+- Correlating citations with user messages
+
+**Fix**: These are composition rules that belong on the domain aggregate.
+Add a method like `conversation.withStreamingMessages(running)`.
+
+## 6. Convenience Providers
+
+**Check**: Is this provider just extracting a field from another provider?
+
+Examples:
+- `isStreamingProvider` that wraps `activeRunNotifierProvider.isRunning`
+- `currentThreadIdProvider` that extracts from `threadSelectionProvider`
+
+**Fix**:
+- If 3 or fewer usages: eliminate, use `.select()` at call sites
+- If 4+ usages: keep, but make it a one-liner using a domain getter
+
+## 7. Free Functions That Should Be Methods
+
+**Check**: Are there top-level or file-private functions that operate on
+domain objects?
+
+Examples:
+- `_mergeMessages(cached, running)` operating on `List<ChatMessage>`
+- `selectAndPersistThread(ref, roomId, threadId)` operating on thread state
+
+**Fix**: If the function's primary argument is a domain object, make it
+a method on that object. If it takes `ref` or `WidgetRef`, it's adapter
+logic — move to a use case or keep as a helper in the adapter layer.
+
+## 8. Persistence Logic in Providers
+
+**Check**: Does the provider directly access SharedPreferences, databases,
+or file storage?
+
+**Fix**: Extract to a repository or keep as adapter logic. The domain
+layer defines the state worth persisting through its structure and
+invariants — it does not have persistence-aware methods like
+`shouldPersist()`. The use case decides *when* to persist (after a
+user action) and the adapter decides *how* (SharedPreferences, DB).
+The domain just defines *what* (its own state).
+
+## 9. Navigation Logic in Providers
+
+**Check**: Does the provider file contain functions that construct routes
+or call navigation APIs?
+
+**Fix**: Navigation is adapter-layer. These functions can stay in the
+provider file or move to a separate adapter file. They should NOT be in
+domain objects.
+
+## 10. I/O Orchestration in Notifiers
+
+**Check**: Does a Notifier method make API calls, access persistence,
+or call external services?
+
+Look for patterns like:
+- `ref.read(apiProvider).someMethod(...)` inside a Notifier method
+- `SharedPreferences` reads/writes in a Notifier
+- Any `await` on an I/O operation inside a Notifier
+
+**Fix**: Extract to an intent-named use case in `lib/core/usecases/`.
+The Notifier calls the use case and updates state with the result.
+
+**There is no size threshold.** A Notifier method that makes a single
+API call still needs a use case. The reasoning "it's just one call,
+it can stay in the Notifier" is the same reasoning that built 625-line
+provider files — each piece was "small enough" individually. The
+dependency rule is structural, not volumetric. If a Notifier performs
+I/O, that I/O orchestration belongs in the application layer (use case),
+not the adapter layer (provider).
+
+A use case that today wraps a single API call is:
+- The right place for future orchestration (retry, analytics, logging)
+- Independently testable with a mocked port — no ProviderContainer
+- A named entry in the "menu" of what the system can do
+- Consistent application of the dependency rule
+
+## Severity Scoring
+
+For reporting, classify each finding:
+
+- **Critical**: Domain types in provider file, state machine in Notifier
+  (these are the core anti-pattern)
+- **Major**: Business rules or data transformation in provider,
+  I/O orchestration in Notifier without a use case
+  (domain/application logic in the wrong layer)
+- **Minor**: Convenience provider, free function that could be a method
+  (code smell, not architectural violation)
+- **Info**: File length warning, persistence logic co-located with
+  provider (may be intentional)

--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,6 @@ integration_test/test_bundle.dart
 # Claude Code local config
 .claude/*
 !.claude/skills/
+!.claude/agents/
+!.claude/hooks/
+!.claude/settings.json

--- a/PLANS/0006-clean-architecture/ADR.md
+++ b/PLANS/0006-clean-architecture/ADR.md
@@ -1,0 +1,171 @@
+# ADR: Clean Architecture — Rich Domain, Thin Providers
+
+## Status
+
+Proposed
+
+## Context
+
+The Soliplex Flutter frontend has 62 Riverpod providers across 22 files.
+Provider files have absorbed domain responsibilities — sealed class
+hierarchies, state machines, business logic, persistence — rather than
+serving as thin glue between domain logic and UI.
+
+See [ANALYSIS.md](./ANALYSIS.md) for the full inventory and root cause
+analysis.
+
+### The Problem: Cohesion Deficit
+
+Riverpod should be glue, but the whole furniture kit was stuffed into
+the tube of glue. Related domain concepts are scattered across separate
+provider files, making them hard to reason about as a whole:
+
+- Understanding "sending a message" requires reading 6 provider files
+- `quiz_provider.dart` (625 lines) contains 4 sealed class hierarchies
+  and a full state machine
+- `threads_provider.dart` (346 lines) contains 2 sealed hierarchies,
+  a notifier, persistence logic, and navigation helpers
+
+### Root Cause
+
+Claude Code's default decomposition strategy: "one concern = one file."
+Each file is locally clean, but relationships between files are implicit.
+Claude optimizes for local correctness over global cohesion.
+
+### What's Not Wrong
+
+- `soliplex_client` is well-structured with proper domain models
+- Individual provider code quality is high
+- Family providers are used correctly for isolation
+- No god providers exist
+
+## Decision
+
+Apply the Clean Architecture dependency rule to restructure the codebase:
+
+1. **Rich domain layer** (`soliplex_client` + `lib/core/domain/`):
+   Domain objects own their behavior — state machines, composition rules,
+   validation, invariants. Pure Dart, no framework imports.
+
+2. **Intent-named use cases** (`lib/core/usecases/`): Each use case is
+   a plain Dart class whose name expresses user intent:
+   `OpenCitation`, `ResumeThreadWithMessage`, `SubmitQuizAnswer`,
+   `StartThreadWithMessage`, `SelectAndPersistThread`. Use cases
+   orchestrate domain objects and I/O. They do not contain business
+   rules.
+
+3. **Thin provider layer** (`lib/core/providers/`): Providers solve
+   exactly two problems: dependency injection and reactive rebuilds.
+   Provider files contain only provider declarations and thin Notifiers
+   (the Humble Object pattern). No sealed classes, no state machines,
+   no business logic.
+
+4. **The dependency rule**: Source code dependencies can only point
+   inwards. Domain depends on nothing. Use cases depend on domain.
+   Providers depend on use cases and domain. Never the reverse.
+
+See [TARGET.md](./TARGET.md) for the complete target architecture with
+concrete transformation examples.
+
+## Three Problems, Three Tools
+
+This decision addresses three distinct problems that require different
+tools:
+
+### Problem 1: Existing Code — The `/rework` Skill
+
+Existing provider files contain domain logic that needs extraction.
+A rigid refactoring roadmap would go stale when priorities shift.
+
+**Solution**: A Claude skill (`/rework`) that encodes the architectural
+judgment from this ADR and TARGET.md. Any developer can invoke it on
+any feature, at any time, and receive a precisely scoped refactoring
+proposal sized for one PR.
+
+This approach:
+- Accommodates priority changes (interrupt without staling a plan)
+- Enables opportunistic transformation (rework when already touching it)
+- Keeps each change reviewable (fits in one human's head)
+
+See [SPEC.md](./SPEC.md) for detailed specifications of all three tools.
+
+### Problem 2: Future Code — Prevention via Claude Hooks
+
+Old habits die hard. Without guardrails, Claude (and human developers)
+will recreate the anti-patterns in new code.
+
+**Solution**: Complementary guardrails at two levels:
+
+1. **CLAUDE.md rules** codifying the dependency rule and provider
+   constraints. Claude reads these on every session — the first line
+   of defense.
+
+2. **Claude hooks** (in `.claude/settings.json`, committed to git)
+   that run after file writes and catch violations in real time.
+   Unlike git hooks (which are developer-discretionary and fire late
+   at commit time), Claude hooks are part of Claude's own execution
+   loop. They intercept the anti-pattern the moment Claude writes it
+   — before the code is even staged. The `architecture-lint.sh` hook
+   checks three directory scopes:
+   - Provider files: warn if `sealed class` or state machine patterns
+   - Models files: warn if domain types should migrate to `domain/`
+   - Domain/usecases files: warn if forbidden imports violate purity
+
+Prevention is designed after the `/rework` skill, because guardrails
+that say "don't do X" without codifying "do Y instead" confuse more
+than they help.
+
+### Problem 3: New Features — The Architect Agent
+
+The `/rework` skill fixes existing code. Prevention rules stop bad
+patterns. But neither helps when **planning a new feature from scratch**
+— translating a functional spec into an ADR/technical plan that
+respects the clean architecture from the start.
+
+Today, when Claude generates an ADR for a new feature, it defaults to
+its "one concern = one file" decomposition — the same root cause that
+created the provider sprawl. The architectural knowledge we've codified
+needs to be available at planning time, not just at refactoring time.
+
+**Solution**: A custom Claude agent (`.claude/agents/architect.md`)
+invoked with `claude --agent architect`. The agent:
+- Reads the Clean Architecture blog post to ground itself in principles
+- Takes a functional specification as input
+- Applies the dependency rule to decompose the feature into layers
+- Names use cases by intent (what the user does, not what the code does)
+- Places domain logic in rich domain objects, I/O in use cases,
+  wiring in providers
+- Produces an ADR that follows the clean architecture from the start
+
+An agent (not a skill) is the right vehicle because architectural
+planning is a conversation — the agent needs to ask questions, explore
+the codebase, and iterate on the decomposition with the developer.
+
+## Consequences
+
+### Positive
+
+- Domain logic is testable with plain Dart unit tests (no mocks)
+- Related concepts are co-located in rich domain objects
+- Provider files become trivially reviewable
+- New features naturally follow the pattern via the architect agent
+- Codebase transforms gradually without disrupting feature development
+- Use case names create a readable "menu" of what the system can do
+- Claude hooks provide immediate feedback, shortening the loop vs
+  commit-time checks
+
+### Negative
+
+- Some domain objects gain methods, increasing their surface area
+- Developers must learn to distinguish domain behavior from I/O
+  orchestration
+- Three tools to maintain (`/rework`, Claude hooks, architect agent)
+
+### Risks
+
+- Over-extraction: moving logic that genuinely belongs in the adapter
+  layer (e.g., Riverpod lifecycle hooks) into domain objects
+- Mitigation: TARGET.md explicitly lists what stays in providers
+  (dependency injection, reactive rebuilds, disposal)
+- Under-utilization: tools exist but developers bypass them
+- Mitigation: Claude hooks catch drift even when skills aren't invoked

--- a/PLANS/0006-clean-architecture/ANALYSIS.md
+++ b/PLANS/0006-clean-architecture/ANALYSIS.md
@@ -1,0 +1,241 @@
+# Provider Architecture Analysis
+
+## Context
+
+This analysis was conducted to understand and address the phenomenon of
+"providers fragmenting the domain" in the Soliplex Flutter frontend. The
+codebase was developed with Claude Code generating large batches of code,
+and the team identified that Riverpod providers had absorbed domain
+responsibilities rather than serving as thin glue between domain logic
+and UI.
+
+## Inventory
+
+### Provider Count: 62 total across 22 files
+
+| Category | Count | Files |
+|----------|-------|-------|
+| Authentication & Session | 10 | `auth_provider.dart` |
+| Configuration & Shell | 4 | `config_provider.dart`, `shell_config_provider.dart` |
+| HTTP & API Infrastructure | 8 | `api_provider.dart` |
+| HTTP Logging | 1 | `http_log_provider.dart` |
+| Connectivity | 1 | `connectivity_provider.dart` |
+| Backend Health & Version | 2 | `backend_health_provider.dart`, `backend_version_provider.dart` |
+| Rooms & Threads | 8 | `rooms_provider.dart`, `threads_provider.dart` |
+| Documents & Content | 3 | `documents_provider.dart`, `selected_documents_provider.dart` |
+| Chat & Running | 4 | `active_run_provider.dart`, `active_run_notifier.dart` |
+| History Caching | 1 | `thread_history_cache.dart` |
+| Citations & References | 2 | `source_references_provider.dart`, `citations_expanded_provider.dart` |
+| Quiz | 2 | `quiz_provider.dart` |
+| Chunk Visualization | 1 | `chunk_visualization_provider.dart` |
+| Logging & Telemetry | 11 | `logging_provider.dart`, `backend_logging_provider.dart` |
+| Routing | 1 | `app_router.dart` |
+| Rooms Screen UI | 3 | `rooms_screen.dart` |
+
+### Domain Models (in soliplex_client - well-structured)
+
+The `packages/soliplex_client/` layer is clean pure Dart:
+
+- **Aggregate root**: `Conversation` (threadId, messages, toolCalls, status, aguiState, messageStates)
+- **Entities**: `Room`, `ThreadInfo`, `RunInfo`, `Quiz`, `QuizQuestion`
+- **Value objects**: `ChatMessage` (sealed), `SourceReference`, `MessageState`, `RagDocument`, `ChunkVisualization`
+- **Sealed hierarchies**: `ConversationStatus`, `RunState`, `ChatMessage`, `QuestionType`, `QuestionLimit`, `QuizAnswerResult`
+- **Application layer**: `StreamingState`, `ActivityType`, `AgUiEventProcessor`, `CitationExtractor`
+
+### Frontend Models (in lib/core/models/)
+
+- `ActiveRunState` (sealed: Idle, Running, Completed) - wraps `Conversation` + `StreamingState`
+- `CompletionResult` (sealed: Success, Failed, Cancelled)
+- `RunHandle` - encapsulated resources for a single run
+- `AppConfig`, `SoliplexConfig`, `Features`, `LogoConfig`, `ThemeConfig`, `RouteConfig`
+
+## Diagnosis
+
+### The Core Problem: Cohesion Deficit
+
+The domain is expressed through a **flat collection of unrelated provider files**
+rather than through cohesive domain aggregates. Provider files have become
+repositories for domain concepts - they contain sealed classes, state machines,
+and business logic that should live in proper domain/application layer objects.
+
+**Metaphor**: Riverpod should be glue, but the whole furniture kit was stuffed
+into the tube of glue.
+
+### Root Cause: Claude's Default Decomposition Strategy
+
+When Claude writes Riverpod code without explicit grouping constraints, it
+follows "one concern = one file":
+1. Need to fetch documents? Create `documents_provider.dart`
+2. Need to track selection? Create `selected_documents_provider.dart`
+3. Need citations? Create `source_references_provider.dart`
+4. Need expand/collapse? Create `citations_expanded_provider.dart`
+
+Each file is internally well-structured, but relationships between files are
+implicit - existing only in the dependency graph, not in code organization.
+
+Claude optimizes for **local correctness** (each file is clean, tested,
+documented) rather than **global cohesion** (files together tell a story).
+
+### Symptoms
+
+**1. Provider files are domain concept containers**
+
+`threads_provider.dart` (346 lines) contains:
+- Data fetching (`threadsProvider`)
+- Selection state machine (`ThreadSelection` sealed class + 3 variants + notifier)
+- Current-item derivation (`currentThreadIdProvider`, `currentThreadProvider`)
+- Persistence logic (`lastViewedThreadProvider` + SharedPreferences helpers)
+- Navigation helpers (`selectThread`, `selectAndPersistThread`)
+
+`quiz_provider.dart` (625 lines) contains **four sealed class hierarchies**:
+- `QuizInput` (MultipleChoiceInput, TextInput)
+- `QuestionState` (AwaitingInput, Composing, Submitting, Answered)
+- `QuizSession` (QuizNotStarted, QuizInProgress, QuizCompleted)
+- `QuizSessionNotifier` with full state machine logic
+
+**2. Cross-file scattering of cohesive concepts**
+
+To understand "sending a message" requires reading 6 files:
+- `active_run_notifier.dart` - startRun() lifecycle
+- `active_run_provider.dart` - allMessagesProvider, canSendMessageProvider
+- `threads_provider.dart` - currentThreadProvider, threadSelectionProvider
+- `rooms_provider.dart` - currentRoomProvider, currentRoomIdProvider
+- `thread_history_cache.dart` - cached messages
+- `selected_documents_provider.dart` - document filtering state
+
+To understand "a thread's full state" is scattered across:
+- `threads_provider.dart` - ThreadInfo data, selection, last-viewed
+- `thread_history_cache.dart` - messages + AG-UI state
+- `active_run_provider.dart` - running state, streaming messages
+- `selected_documents_provider.dart` - document selections
+- `citations_expanded_provider.dart` - UI expand/collapse state
+- `source_references_provider.dart` - citation data
+
+**3. Convenience providers that could be `.select()`**
+
+- `isStreamingProvider` = `activeRunNotifierProvider.isRunning` (2 usages)
+- `currentThreadIdProvider` = extract from `threadSelectionProvider` (5+ usages)
+- `hasAppAccessProvider` = check `authProvider` type
+
+### What's NOT Wrong
+
+- `soliplex_client` is clean: proper domain models, sealed classes, well-layered
+- Family providers are used correctly: per-room, per-thread, per-quiz isolation
+- No god providers: `activeRunNotifierProvider` is complex but single-responsibility
+- Feature layer is restrained: only `rooms_screen.dart` defines local providers
+- The individual provider code quality is high
+
+## Strategy: Consolidate into Cohesive Application Layer
+
+### Philosophy
+
+Providers should be **thin glue** (interactors in Clean Architecture terms) that
+wire Riverpod-free application layer classes into the UI. Domain logic, state
+machines, and sealed class hierarchies should live in plain Dart classes that
+providers merely expose.
+
+### Approach
+
+**Extract domain/application logic from providers into plain Dart classes,
+then use providers only to expose these classes to the widget tree.**
+
+Example transformation for threads:
+
+```text
+BEFORE (spread across providers):
+  threads_provider.dart     → ThreadSelection sealed class + notifier + 5 providers
+  thread_history_cache.dart → cache logic + notifier + provider
+
+AFTER (rich domain + thin providers):
+  lib/core/domain/thread_selection.dart   → ThreadSelection, LastViewed (rich domain types)
+  lib/core/usecases/select_and_persist_thread.dart → SelectAndPersistThread (intent-named)
+  lib/core/providers/threads_provider.dart → thin: 2-3 providers delegating to domain
+```
+
+Example transformation for quiz:
+
+```text
+BEFORE:
+  quiz_provider.dart (625 lines) → 4 sealed hierarchies + state machine + 2 providers
+
+AFTER:
+  lib/core/domain/quiz_session.dart       → QuizInput, QuestionState, QuizSession (rich domain)
+  lib/core/usecases/submit_quiz_answer.dart → SubmitQuizAnswer (orchestrates API + domain)
+  lib/core/providers/quiz_provider.dart   → thin: 2 providers delegating to domain
+```
+
+### Guiding Principles
+
+1. **Sealed classes and state machines are domain concepts**, not provider
+   implementation details. They belong in `lib/core/models/` or
+   `packages/soliplex_client/`.
+
+2. **Provider files contain only DI and reactive rebuilds.** If a provider
+   defines types, encodes business rules, or manages state transitions,
+   extract that logic to `lib/core/domain/` or `lib/core/usecases/`.
+
+3. **Prefer plain Dart classes over Notifiers** for business logic. Notifiers
+   should delegate to service/domain classes.
+
+4. **Related concepts should be in the same class or module**, not in separate
+   provider files. Thread selection + thread history + thread persistence
+   are one concern.
+
+5. **Providers exist to solve two problems**: (a) dependency injection and
+   (b) reactive rebuilds. Everything else is domain/application logic.
+
+## Provider-Feature Consumption Matrix
+
+| Feature | Screens | Providers Watched | Providers Read | Local Providers |
+|---------|---------|-------------------|----------------|-----------------|
+| auth | 1 | 2 | 2 | 0 |
+| chat | 7 | 11 | 8 | 0 |
+| history | 3 | 4 | 2 | 0 |
+| home | 2 | 2 | 4 | 0 |
+| inspector | 7 | 1 | 1 | 0 |
+| log_viewer | 4 | 1 | 1 | 0 |
+| login | 1 | 1 | 2 | 0 |
+| quiz | 1 | 3 | 2 | 0 |
+| room | 1 | 6 | 5 | 0 |
+| rooms | 4 | 4 | 3 | 3 |
+| settings | 3 | 6 | 1 | 0 |
+| **TOTAL** | **34** | **41+** | **31+** | **3** |
+
+## Prevention: Claude Configuration
+
+### CLAUDE.md Provider Guidelines
+
+```markdown
+## Provider Architecture
+
+Providers are thin glue. They wire application-layer classes into
+the widget tree for dependency injection and reactive rebuilds. Nothing more.
+
+Rules:
+- DO NOT put sealed classes, state machines, or business logic in provider files
+- DO NOT create a new provider file without checking if the concept fits in
+  an existing application-layer class
+- DO NOT create convenience providers that just wrap .select() - use
+  ref.watch(provider.select(...)) at the call site
+- Provider files should be < 100 lines. Extract domain logic to models/services.
+- When adding a feature that needs state, create or extend a plain Dart class
+  first, then expose it via a provider
+- Notifiers should delegate to service/domain classes, not contain business logic
+```
+
+### Detection Hooks / CI Checks
+
+Potential automated checks:
+- Warn if a provider file exceeds 150 lines
+- Warn if `sealed class` appears in a file under `providers/`
+- Warn if a new provider file is created (prompt: should this be a method on
+  an existing service?)
+- Track provider count over time to detect sprawl
+
+### flutter_rules.md Additions
+
+Add to the State Management section:
+- Separate application logic from Riverpod wiring
+- Provider files contain only provider declarations and thin Notifiers
+- Domain types belong in `lib/core/models/` or `soliplex_client`
+- Test domain logic via plain Dart unit tests, not provider tests

--- a/PLANS/0006-clean-architecture/SPEC.md
+++ b/PLANS/0006-clean-architecture/SPEC.md
@@ -1,0 +1,229 @@
+# Specification: `/rework` Skill and Architectural Tooling
+
+## Overview
+
+Three tools that codify the Clean Architecture decisions from
+[ADR.md](./ADR.md), grounded in the principles from Robert C. Martin's
+[The Clean Architecture](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html).
+
+[TARGET.md](./TARGET.md) provides concrete examples of how these
+principles apply to this codebase, but it is a point-in-time snapshot.
+The principles themselves — the dependency rule, rich entities, thin
+adapters — are the enduring source of truth.
+
+## Foundational Reference
+
+All three tools should eagerly read the Clean Architecture blog post
+at the start of their execution to ground themselves in the original
+principles. This ensures alignment with the architecture's intent
+rather than just the letter of TARGET.md, which will inevitably
+drift as the codebase evolves.
+
+**URL**: <https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html>
+
+**Key principles to internalize**:
+
+- The dependency rule: source code dependencies point inward only
+- Entities contain enterprise-wide business rules (richest layer)
+- Use cases contain application-specific business rules (orchestration)
+- Interface adapters convert data between formats for entities/use cases
+- Frameworks and drivers are details — kept at the outermost layer
+
+## Tool 1: `/rework` Skill
+
+### Purpose
+
+Enable a developer to point Claude at any feature (by name, file, or
+provider) and receive a precisely scoped refactoring proposal that:
+- Follows the dependency rule
+- Fits in one PR
+- Fits in one reviewer's head
+
+### Invocation
+
+```text
+/rework quiz
+/rework lib/core/providers/threads_provider.dart
+/rework active_run
+/rework chat
+```
+
+The argument is a feature name, file path, or keyword. The skill
+resolves it to the relevant set of files.
+
+### Behavior
+
+1. **Read the Clean Architecture principles**: Fetch and internalize
+   the blog post to ensure the analysis is grounded in principles,
+   not just local conventions.
+
+2. **Read architectural context**: Load
+   `PLANS/0006-clean-architecture/TARGET.md` and
+   `PLANS/0006-clean-architecture/ANALYSIS.md` for codebase-specific
+   examples and known anti-patterns.
+
+3. **Resolve scope**: From the argument, identify:
+   - The provider file(s) involved
+   - The domain types they contain (sealed classes, state machines)
+   - The widgets that consume these providers
+   - Related files (other providers watched/read by these providers)
+
+4. **Diagnose**: For each provider file, run the responsibility check:
+   - [ ] Does the file do anything beyond DI and reactive rebuilds?
+   - [ ] Domain types in provider or models file — sealed classes,
+     typedefs, identity records (should be in `lib/core/domain/`)
+   - [ ] State machine logic in Notifier (should be domain methods)
+   - [ ] Business rules in provider (should be domain methods)
+   - [ ] Data transformation in provider (should be domain methods)
+   - [ ] I/O orchestration in Notifier without a use case (should be
+     in `lib/core/usecases/` — no size threshold)
+   - [ ] Convenience providers that could be `.select()` at call sites
+   - [ ] Free functions that should be methods on domain objects
+
+5. **Propose transformation**: For each diagnosed issue:
+   - What moves where (source file:line → target file)
+   - What new domain methods to add (with signatures)
+   - What the provider file looks like after (sketch, not full code)
+   - What tests need updating
+
+6. **Output a plan**: Structured as:
+   - **Summary**: One sentence describing the rework
+   - **Diagnosis**: Which anti-patterns are present
+   - **Changes**: Ordered list of file changes
+   - **New files**: Any new domain/use case files needed
+   - **Test impact**: Which test files need updating
+   - **Risk**: What could break and how to verify
+
+### Constraints
+
+- The proposal must be independently deployable (no cascading changes
+  to unrelated features)
+- Provider public API should not change (widgets keep the same
+  `ref.watch(...)` calls) unless the rework explicitly simplifies them
+- Each proposal should be reviewable in one sitting
+
+### Skill File Location
+
+`.claude/skills/rework/SKILL.md`
+
+Supporting files:
+- `.claude/skills/rework/diagnosis-checklist.md` — the diagnostic checks
+- References `PLANS/0006-clean-architecture/TARGET.md` for examples
+
+## Tool 2: Claude Hooks for Prevention
+
+### Purpose
+
+Catch anti-patterns the moment Claude writes them, before code is
+staged or committed. Claude hooks run as part of Claude's execution
+loop — they are guaranteed to fire and provide immediate feedback.
+
+### Hook: Architecture Lint (`architecture-lint.sh`)
+
+**Trigger**: After any Write or Edit to a `.dart` file.
+
+The hook checks three directory scopes with appropriate rules for each:
+
+**Provider files** (`lib/core/providers/*.dart`):
+
+1. **Sealed class**: Warn if `sealed class` keyword appears — sealed
+   classes are domain types, move to `lib/core/domain/`
+2. **State machine signals**: Warn if file contains state transition
+   patterns (multiple `state =` assignments inside conditional logic)
+
+**Models files** (`lib/core/models/*.dart`):
+
+1. **Sealed class**: Warn that domain types in `models/` should migrate
+   to `lib/core/domain/` during reworks
+
+**Domain and usecases files** (`lib/core/domain/*.dart`,
+`lib/core/usecases/*.dart`):
+
+1. **Forbidden imports**: Warn if the file imports Flutter, Riverpod,
+   or GoRouter — these violate the dependency rule
+
+**Output**: Warning message describing the violation and suggesting
+where the code should live instead.
+
+**Non-blocking**: These are warnings, not errors. Claude sees the
+feedback and can self-correct, but the write isn't prevented.
+
+### Configuration Location
+
+`.claude/settings.json` (committed to git, shared across the team)
+
+## Tool 3: Architect Agent
+
+### Purpose
+
+When planning a new feature (translating a functional spec into an ADR),
+apply the clean architecture knowledge proactively. This prevents new
+features from being born with the same anti-patterns that `/rework`
+fixes in existing code.
+
+### Invocation
+
+A custom agent at `.claude/agents/architect.md`, invoked with:
+
+```text
+claude --agent architect
+```
+
+Architectural planning is a conversation — the agent needs to ask
+questions, explore the codebase, and iterate on the decomposition
+with the developer. An agent (not a skill) is the right vehicle
+because it operates in a conversational, exploratory mode with its
+own system prompt embedding the clean architecture principles.
+
+### Behavior
+
+When given a functional specification, the agent:
+
+1. **Reads the Clean Architecture principles**: Fetches and
+   internalizes the blog post. This is not optional — the agent must
+   understand the dependency rule from its source, not from a
+   second-hand summary.
+
+2. **Reads codebase context**: Loads TARGET.md for current examples
+   and ANALYSIS.md for known anti-patterns to avoid.
+
+3. **Identifies domain concepts**: What entities, value objects, and
+   aggregates does this feature introduce or extend?
+
+4. **Designs domain behavior**: What business rules and state machines
+   does this feature need? These become methods on domain objects.
+
+5. **Names use cases by intent**: What can the user do? Each user
+   action becomes a use case class: `CreateRoom`,
+   `InviteCollaborator`, `ExportConversation`, etc.
+
+6. **Identifies I/O boundaries**: What API calls, persistence, or
+   external services does this feature need? These are orchestrated
+   by use cases, not domain objects.
+
+7. **Designs provider wiring**: What providers are needed to expose
+   domain objects and use cases to the widget tree? Each should be
+   a one-liner.
+
+8. **Produces an ADR**: Following the project's ADR template, with
+   the layer decomposition made explicit.
+
+### Key Principle
+
+The agent must resist Claude's default "one concern = one file"
+decomposition. Instead, it groups by **cohesion**: related concepts
+belong together in domain objects, not spread across provider files.
+
+### Agent File Location
+
+`.claude/agents/architect.md`
+
+### Relationship to `/rework`
+
+`/rework` and the architect agent encode the same architectural
+judgment. The difference is timing:
+- `/rework`: retroactive — fixes existing code
+- Architect agent: proactive — designs new code correctly from the start
+
+Both read the Clean Architecture blog post as their source of truth
+and use TARGET.md for codebase-specific illustration.

--- a/PLANS/0006-clean-architecture/TARGET.md
+++ b/PLANS/0006-clean-architecture/TARGET.md
@@ -1,0 +1,408 @@
+# Target Architecture
+
+## Guiding Principle: The Dependency Rule
+
+> Source code dependencies can only point inwards.
+> -- Robert C. Martin, "The Clean Architecture"
+
+Nothing in an inner circle may reference anything in an outer circle.
+The inner layers define the rules; the outer layers conform to them.
+
+```text
+┌─────────────────────────────────────────────────────┐
+│  Frameworks & Drivers                               │
+│  Flutter, Riverpod, GoRouter, HTTP client           │
+│                                                     │
+│  ┌─────────────────────────────────────────────┐    │
+│  │  Interface Adapters                         │    │
+│  │  Providers (thin glue), Repositories        │    │
+│  │                                             │    │
+│  │  ┌─────────────────────────────────────┐    │    │
+│  │  │  Application Layer (Use Cases)      │    │    │
+│  │  │  Orchestrate domain + I/O           │    │    │
+│  │  │                                     │    │    │
+│  │  │  ┌─────────────────────────────┐    │    │    │
+│  │  │  │  Domain (Entities)          │    │    │    │
+│  │  │  │  Rich objects with behavior │    │    │    │
+│  │  │  │  Pure Dart, no imports from │    │    │    │
+│  │  │  │  outer layers               │    │    │    │
+│  │  │  └─────────────────────────────┘    │    │    │
+│  │  └─────────────────────────────────────┘    │    │
+│  └─────────────────────────────────────────────┘    │
+└─────────────────────────────────────────────────────┘
+```
+
+## Layer Definitions
+
+### 1. Domain (Entities) — `soliplex_client` + `lib/core/domain/`
+
+**Contains**: Business rules, state machines, invariants, sealed hierarchies.
+Pure Dart. No Flutter, no Riverpod, no I/O.
+
+**The domain layer is rich.** Domain objects own their behavior:
+
+- State transitions as methods that return new instances
+- Validation and invariant enforcement
+- Composition rules (e.g., how messages merge)
+- Query methods that encode business knowledge
+
+**When domain logic needs I/O**, it doesn't perform it. Instead, it defines
+the *result* of a decision, and the application layer executes the side effect.
+For example, `QuizSession.answerQuestion(result)` returns the next session
+state — it doesn't call an API. The use case calls the API, then calls the
+domain method with the result.
+
+**Test strategy**: Plain Dart unit tests. No mocks needed for pure functions.
+
+### 2. Application Layer (Use Cases) — `lib/core/usecases/`
+
+**Contains**: Use cases that orchestrate domain objects and I/O.
+
+**Use cases express intent with their class name.** Each class is a
+single action the system can perform. Examples:
+- `OpenCitation` — resolves a citation reference and opens the document
+- `ResumeThreadWithMessage` — thread has history, user sends a follow-up
+  (creates run, starts AG-UI stream)
+- `StartThreadWithMessage` — creates a new thread from a first message
+- `SubmitQuizAnswer` — submits an answer and records the result
+- `SelectAndPersistThread` — selects a thread and persists it as last viewed
+
+A use case:
+1. Receives intent (named by its class)
+2. Calls I/O via injected ports (API client, persistence)
+3. Delegates business decisions to domain objects
+4. Returns the domain result
+
+**Use cases do not contain business rules.** They are orchestrators.
+The "if/switch" logic that determines state transitions belongs in the
+domain. The use case just calls `domain.doTheThing()` and handles the
+I/O around it.
+
+**Dependencies point inward**: use cases depend on domain objects,
+never the reverse.
+
+**Test strategy**: Unit tests with mocked I/O ports (API, persistence).
+
+### 3. Interface Adapters (Providers) — `lib/core/providers/`
+
+**Contains**: Riverpod providers that wire use cases into the widget tree.
+
+A provider file should contain only provider declarations and thin
+Notifiers that delegate to domain objects and use cases (the Humble
+Object pattern). That's it.
+
+Providers solve exactly two problems:
+1. **Dependency injection** — construct objects with the right dependencies
+2. **Reactive rebuilds** — `ref.watch()` triggers UI updates
+
+**Providers do not contain**:
+- Domain type definitions (sealed classes, typedefs, identity records)
+- State machines or transition logic
+- Business rules or validation
+- Data transformation or merging logic
+- I/O orchestration without a use case (if a Notifier calls an API,
+  extract a use case — no size threshold)
+
+**Test strategy**: Integration tests verifying wiring. Business logic
+is already tested at the domain/use case layer.
+
+### 4. Frameworks & Drivers — Flutter, Riverpod, GoRouter, HTTP
+
+The outermost layer. These are details. The architecture doesn't depend
+on them — they depend on the architecture.
+
+## Concrete Transformations
+
+### A. Conversation: Enrich the Aggregate Root
+
+**Current state**: `Conversation` has `with*()` copy methods but no
+business logic. Message merging lives in `active_run_provider.dart` as
+a top-level function. Citation correlation lives in
+`active_run_notifier.dart`.
+
+**Target**: `Conversation` owns its composition rules.
+
+```dart
+// packages/soliplex_client/lib/src/domain/conversation.dart
+class Conversation {
+  // ... existing fields ...
+
+  /// Merges streaming messages into the conversation, deduplicating by ID.
+  ///
+  /// Cached (historical) messages take precedence. New messages from
+  /// the active run are appended if their ID hasn't been seen.
+  Conversation withStreamingMessages(List<ChatMessage> streaming) {
+    final seenIds = <String>{};
+    final merged = <ChatMessage>[];
+    for (final msg in messages) {
+      if (seenIds.add(msg.id)) merged.add(msg);
+    }
+    for (final msg in streaming) {
+      if (seenIds.add(msg.id)) merged.add(msg);
+    }
+    return copyWith(messages: merged);
+  }
+
+  /// Correlates citations with the user message that triggered them.
+  ///
+  /// Compares previous AG-UI state with current to find new citations,
+  /// then records them as a MessageState for the given user message.
+  Conversation withCorrelatedCitations(
+    String userMessageId,
+    Map<String, dynamic> previousAguiState,
+    CitationExtractor extractor,
+  ) {
+    if (status is Running) return this; // only on completion
+    final refs = extractor.extractNew(previousAguiState, aguiState);
+    final ms = MessageState(
+      userMessageId: userMessageId,
+      sourceReferences: refs,
+    );
+    return withMessageState(userMessageId, ms);
+  }
+}
+```
+
+**What moves out of providers**:
+- `_mergeMessages()` from `active_run_provider.dart` → `Conversation.withStreamingMessages()`
+- `_correlateMessagesForRun()` from `active_run_notifier.dart` → `Conversation.withCorrelatedCitations()`
+
+### B. QuizSession: Own the State Machine
+
+**Current state**: `QuizSessionNotifier` (a Riverpod Notifier) contains
+all state transitions AND the API call for submitting answers. The sealed
+classes `QuizInput`, `QuestionState`, `QuizSession` are defined in the
+same provider file.
+
+**Target**: `QuizSession` is a rich domain object that owns its state
+machine. The Notifier delegates to it.
+
+```dart
+// lib/core/domain/quiz_session.dart  (or packages/soliplex_client/)
+sealed class QuizSession {
+  const QuizSession();
+
+  /// Starts a quiz. Returns QuizInProgress at question 0.
+  /// Throws ArgumentError if quiz has no questions.
+  static QuizInProgress start(Quiz quiz) { ... }
+}
+
+class QuizInProgress extends QuizSession {
+  // ... existing fields and getters ...
+
+  /// Updates user input. Returns new state with Composing questionState.
+  /// No-op if currently Submitting or Answered.
+  QuizInProgress withInput(QuizInput input) { ... }
+
+  /// Clears input. Returns new state with AwaitingInput.
+  QuizInProgress withInputCleared() { ... }
+
+  /// Marks the current question as being submitted.
+  /// Throws StateError if not in Composing state.
+  QuizInProgress submitting() { ... }
+
+  /// Records an answer result from the backend.
+  /// Returns new state with Answered questionState and updated results map.
+  QuizInProgress withAnswer(QuizAnswerResult result) { ... }
+
+  /// Records a submission failure. Returns to Composing with input preserved.
+  QuizInProgress withSubmissionFailed() { ... }
+
+  /// Advances to next question or completes the quiz.
+  /// Throws StateError if current question isn't Answered.
+  QuizSession advance() { ... } // Returns QuizInProgress or QuizCompleted
+}
+```
+
+The Notifier becomes trivial:
+
+```dart
+// lib/core/providers/quiz_provider.dart
+class QuizSessionNotifier extends Notifier<QuizSession> {
+  QuizSessionNotifier(this.arg);
+  final QuizSessionKey arg;
+
+  @override
+  QuizSession build() => const QuizNotStarted();
+
+  void start(Quiz quiz) => state = QuizSession.start(quiz);
+  void updateInput(QuizInput input) => _update((s) => s.withInput(input));
+  void clearInput() => _update((s) => s.withInputCleared());
+  void advance() => _update((s) => s.advance());
+  void reset() => state = const QuizNotStarted();
+
+  Future<QuizAnswerResult> submitAnswer() async {
+    final inProgress = _requireInProgress();
+    state = inProgress.submitting();
+    try {
+      final api = ref.read(apiProvider);
+      final result = await api.submitQuizAnswer(
+        arg.roomId, inProgress.quiz.id,
+        inProgress.currentQuestion.id,
+        (inProgress.questionState as Composing).input.answerText,
+      );
+      _update((s) => s.withAnswer(result));
+      return result;
+    } catch (e, st) {
+      _update((s) => s.withSubmissionFailed());
+      rethrow;
+    }
+  }
+
+  QuizInProgress _requireInProgress() => switch (state) {
+    QuizInProgress s => s,
+    _ => throw StateError('Not in progress'),
+  };
+
+  void _update(QuizSession Function(QuizInProgress) fn) {
+    final s = state;
+    if (s is QuizInProgress) state = fn(s);
+  }
+}
+```
+
+**What changes**:
+- State machine transitions move from `QuizSessionNotifier` methods → `QuizInProgress` methods
+- Sealed classes move from `quiz_provider.dart` → `lib/core/domain/quiz_session.dart`
+- Notifier shrinks from ~190 lines of logic to ~40 lines of delegation
+- API call stays in Notifier (it's I/O orchestration), but the state
+  transitions before and after the call are domain methods
+
+### C. ThreadSelection: Domain Type with Behavior
+
+**Current state**: `ThreadSelection` sealed class, `LastViewed` sealed class,
+`ThreadSelectionNotifier`, persistence functions, and navigation helpers —
+all in `threads_provider.dart` (346 lines).
+
+**Target**: Domain types in `lib/core/domain/`, persistence in a repository,
+thin provider.
+
+```dart
+// lib/core/domain/thread_selection.dart
+sealed class ThreadSelection {
+  const ThreadSelection();
+
+  /// The selected thread ID, if any.
+  String? get threadId => switch (this) {
+    ThreadSelected(:final threadId) => threadId,
+    _ => null,
+  };
+
+  /// Whether a message can target this selection.
+  bool get canSendMessage => switch (this) {
+    ThreadSelected() => true,
+    NewThreadIntent() => true,
+    NoThreadSelected() => false,
+  };
+}
+
+// lib/core/domain/last_viewed.dart
+sealed class LastViewed { ... } // Pure types, no provider coupling
+```
+
+```dart
+// lib/core/providers/threads_provider.dart  (~60 lines)
+final threadsProvider = FutureProvider.family<List<ThreadInfo>, String>(...);
+
+final threadSelectionProvider =
+    NotifierProvider<ThreadSelectionNotifier, ThreadSelection>(...);
+
+final currentThreadIdProvider = Provider<String?>((ref) {
+  return ref.watch(threadSelectionProvider).threadId;
+});
+
+final currentThreadProvider = Provider<ThreadInfo?>((ref) { ... });
+
+final lastViewedThreadProvider = FutureProvider.family<LastViewed, String>(...);
+```
+
+**What moves out**:
+- `ThreadSelection` and `LastViewed` sealed classes → `lib/core/domain/`
+- `selectThread()`, `selectAndPersistThread()` → either a use case or
+  stay as free functions but move to a separate file (they take `WidgetRef`,
+  which makes them adapter-layer, not domain)
+- SharedPreferences helpers → repository or stay co-located with
+  `lastViewedThreadProvider` (they're persistence adapters)
+
+### D. ActiveRunNotifier: Extract Orchestration to Use Case
+
+**Current state**: 557 lines. Contains run lifecycle, event processing,
+citation correlation, cache updating, navigation sync, and logging.
+
+**Target**: The notifier becomes a thin adapter. Domain logic moves to
+`Conversation`. Orchestration moves to a use case or stays in a
+drastically simplified notifier.
+
+**What moves where**:
+
+| Current location | Target | Layer |
+|---|---|---|
+| `_correlateMessagesForRun()` | `Conversation.withCorrelatedCitations()` | Domain |
+| `_mergeMessages()` (in active_run_provider) | `Conversation.withStreamingMessages()` | Domain |
+| `_mapResultForRun()` | Simplified — calls domain methods | Application |
+| `_processEventForRun()` | Simplified — calls `processEvent()` then domain methods | Application |
+| `_syncCurrentHandle()` | Stays in notifier (adapter concern) | Adapter |
+| `_updateCacheOnCompletion()` | Stays in notifier or moves to use case | Application |
+| `_logEvent()` | Stays (cross-cutting) | Application |
+| `startRun()` orchestration | Use case or stays in simplified notifier | Application |
+
+The notifier's `startRun()` currently does I/O orchestration (API calls,
+stream setup) which is legitimate application-layer work. The question is
+whether it should be a standalone use case class or remain in the notifier.
+
+**Recommendation**: Extract to intent-named use cases in `lib/core/usecases/`.
+The exact use case names should be determined during rework — the
+naming must reflect the user's intent, not implementation details.
+For example, `ResumeThreadWithMessage` means "thread has history,
+user sends a follow-up." Each use case is a plain Dart class with
+injected dependencies (API client, AG-UI client). The notifier calls
+the use case and exposes the result. Domain logic (citation
+correlation, message merging) stays in `Conversation`.
+
+### E. Provider File Sizes After Transformation
+
+| File | Current | Target | Change |
+|---|---|---|---|
+| `active_run_notifier.dart` | 557 | ~350 | Domain logic extracted to Conversation |
+| `active_run_provider.dart` | 157 | ~60 | `_mergeMessages` → domain, `isStreamingProvider` → inline `.select()` |
+| `threads_provider.dart` | 346 | ~80 | Sealed classes → domain/, helpers → separate file |
+| `quiz_provider.dart` | 625 | ~80 | Sealed classes → domain/, state machine → domain methods |
+| `documents_provider.dart` | 157 | 157 | No change (retry logic is adapter concern) |
+| `thread_history_cache.dart` | 131 | 131 | No change (cache is adapter concern) |
+
+### F. Convenience Providers: Eliminate or Justify
+
+| Provider | Current | Action |
+|---|---|---|
+| `isStreamingProvider` | Wraps `activeRunNotifierProvider.isRunning` | Eliminate. Use `ref.watch(activeRunNotifierProvider.select((s) => s.isRunning))` at call sites (2 usages). |
+| `currentThreadIdProvider` | Extracts ID from `threadSelectionProvider` | Keep. Used 5+ times, and `ThreadSelection.threadId` getter makes the provider a one-liner. |
+| `canSendMessageProvider` | Multi-provider composition | Keep. Genuine derived state combining multiple sources. But could use `ThreadSelection.canSendMessage` to simplify. |
+
+## Migration Approach
+
+These transformations are independent and can be done incrementally:
+
+1. **Quiz** (lowest risk, self-contained): Move sealed classes to domain/,
+   add domain methods to `QuizSession`, simplify notifier.
+2. **Threads** (medium): Move sealed classes to domain/, add behavior,
+   simplify provider file.
+3. **Conversation enrichment** (highest impact): Add `withStreamingMessages()`
+   and `withCorrelatedCitations()`, simplify `active_run_notifier.dart` and
+   `active_run_provider.dart`.
+
+Each step is independently deployable and testable. The domain methods
+are pure functions — they can be tested before the provider refactoring
+happens.
+
+## Non-Goals
+
+- **Not reorganizing the file tree** into feature-based directories.
+  File organization is cosmetic; this refactoring is about moving logic
+  to the right layer.
+- **Not introducing new abstractions** (repository interfaces, port
+  classes) unless a domain object genuinely needs I/O indirection.
+  The current codebase uses concrete dependencies — abstract only when
+  there's a second implementation or a testing need that mocks don't cover.
+- **Not changing the public API** of providers consumed by widgets.
+  Widgets continue to `ref.watch(activeRunNotifierProvider)` etc.
+  The refactoring is internal to the core layer.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -70,10 +70,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -496,14 +496,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -556,18 +548,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: "direct main"
     description:
@@ -982,26 +974,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.29.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.15"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
## Why a toolkit, not a roadmap

The codebase has 62 Riverpod providers across 22 files. Providers absorbed
domain responsibilities — sealed classes, state machines, business logic —
rather than serving as thin glue. The root cause: Claude's default
decomposition strategy optimizes for local correctness ("one concern = one
file") over global cohesion.

A rigid refactoring roadmap would go stale when priorities shift. Instead,
this PR introduces **four tools that codify architectural judgment** so any
developer can apply the Clean Architecture dependency rule on demand, at
the moment it matters.

## The four tools

| Tool | When | What it does |
|------|------|-------------|
| `/rework <feature>` | Touching existing code | Diagnoses anti-patterns in a feature's providers and proposes a scoped refactoring — domain logic out, rich domain objects in. One PR, one reviewer's head. |
| `claude --agent architect` | Planning a new feature | Decomposes a functional spec into Clean Architecture layers through conversation. Produces an ADR where domain concepts, use cases, and providers are designed before code is written. |
| Provider-lint hook | Every file write | Catches `sealed class` in providers, oversized files, and state machine signals the moment Claude writes them. Non-blocking feedback via Claude hooks. |
| `/rework-sharpen <feedback>` | After using any tool | Evaluates feedback against the Clean Architecture principles. Patches tools if the gap is real; educates the developer if the feedback itself violates the dependency rule. |

## What's in the box

**Analysis & design** (read these first):
- `PLANS/0004-clean-architecture/ADR.md` — the decision and rationale
- `PLANS/0004-clean-architecture/ANALYSIS.md` — provider inventory, diagnosis
- `PLANS/0004-clean-architecture/TARGET.md` — concrete before/after transformations
- `PLANS/0004-clean-architecture/SPEC.md` — specifications for all four tools

**Tools**:
- `.claude/skills/rework/` — the `/rework` skill + diagnosis checklist
- `.claude/agents/architect.md` — the architect agent
- `.claude/hooks/provider-lint.sh` + `.claude/settings.json` — the lint hook
- `.claude/skills/rework-sharpen/` — the `/rework-sharpen` skill

**Rules**:
- `CLAUDE.md` — updated with Clean Architecture provider constraints

## All tools share one source of truth

The Clean Architecture dependency rule from [Uncle Bob's blog post](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html).
Every tool eagerly reads it at execution time to stay grounded in
principles, not just local conventions. TARGET.md is illustrative but
the principles are enduring.

## Test plan

- [ ] Run `/rework quiz` — verify it diagnoses sealed classes and state machine in `quiz_provider.dart`
- [ ] Run `/rework-sharpen "the hook flagged a comment mentioning sealed class"` — verify it recognizes the hook already strips comments
- [ ] Edit a provider file to exceed 100 lines — verify the hook fires a warning
- [ ] Run `claude --agent architect` with a simple feature spec — verify it walks through the steps conversationally

🤖 Generated with [Claude Code](https://claude.com/claude-code)