### PR TITLE
feat(log-viewer): add log record export serialization (M1)

### DIFF
--- a/docs/planning/log-export/PLAN.md
+++ b/docs/planning/log-export/PLAN.md
@@ -1,0 +1,178 @@
+# Plan: Export Logs Feature
+
+## Context
+
+The log viewer screen has no way to export logs off-device. Users on mobile,
+desktop, or web can view logs in-app but can't share them for debugging or
+support. We'll add a download button next to the existing "clear logs" button
+that exports the currently **filtered** log records as JSONL. Native platforms
+get gzipped output via the OS share sheet; web gets a raw `.jsonl` browser
+download.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Native export | OS share sheet via `share_plus` | Standard platform UX |
+| Web export | Blob + anchor download (`package:web`) | No new dependency |
+| Compression | gzip on native; raw on web | Web capped at ~400 KB / 2000 records |
+| Format | JSONL (one JSON object per line) | Grep-friendly, streaming-parseable |
+| Scope | Filtered records only | Respects level/logger/search filters |
+| Serialization | Extension method in feature layer | Keeps `soliplex_logging` model lean |
+| File saver | Abstract class + factory + Riverpod provider | Matches `auth_storage.dart` pattern; enables test mocking |
+| Export order | Chronological (oldest-first) | Standard for log analysis tools (`jq`, aggregators) |
+| iPad / macOS | Pass `sharePositionOrigin` from button `RenderBox` | Required for popover positioning; crash without it |
+
+## Resolved Review Findings
+
+Issues identified by Codex, Claude, and Gemini reviews — all addressed in
+the milestone plans below.
+
+| # | Severity | Finding | Resolution |
+|---|----------|---------|------------|
+| 1 | High | iPad/macOS crash — missing `sharePositionOrigin` | `LogFileSaver.save()` accepts `Rect? shareOrigin`; screen computes from `RenderBox` |
+| 2 | High | Patrol E2E hangs — OS share sheet blocks test | Mock saver via `logFileSaverProvider` override; E2E only asserts button state, does not tap export |
+| 3 | Medium | `share_plus` API wrong | Verify installed version; use `Share.shareXFiles` or `SharePlus.instance.share(ShareParams(...))` per actual API |
+| 4 | Medium | `utf8.encode` returns `List<int>`, not `Uint8List` | Use `Uint8List.fromList(utf8.encode(...))` |
+| 5 | Medium | Pending records missed on export | Call `_flushPending()` at start of `exportFilteredAsJsonlBytes()` |
+| 6 | Medium | Facade uses top-level function, not class | Abstract `LogFileSaver` + `createLogFileSaver()` factory + `logFileSaverProvider` |
+| 7 | Low | `toExportJson()` on core model | Extension method in `lib/features/log_viewer/` instead |
+| 8 | Low | Filename colons illegal on Windows/Android | Use `YYYY-MM-DD_HH-mm-ss` format (underscores + dashes) |
+| 9 | Low | Async gap — widget may unmount before SnackBar | `mounted` check after `await saveLogFile(...)` |
+
+## Milestones
+
+```text
+Milestone 1 ─── Milestone 2 ─── Milestone 3
+serialization    UI + platform    patrol E2E
+(pure Dart)      (share_plus)     (integration)
+```
+
+---
+
+### M1: Serialization ([details](milestone-1-serialization.md))
+
+**Branch**: `feat/log-export-serialization`
+
+- [x] Create `lib/features/log_viewer/log_record_export.dart` — extension with `toExportJson()` + `_safeAttributes`/`_coerceValue` helpers
+- [x] Edit `lib/features/log_viewer/log_viewer_controller.dart` — add `exportFilteredAsJsonlBytes()`, flush pending before export
+- [x] Create `test/features/log_viewer/log_record_export_test.dart` — shape, UTC, null omission, attribute coercion, error toString
+- [x] Create `test/features/log_viewer/log_viewer_controller_test.dart` — valid JSONL, respects filters, empty state, flush, chronological order
+- [x] **Gate: pre-commit hooks pass** (dart format, flutter analyze, dart analyze packages, pymarkdown, gitleaks)
+- [x] **Gate: `dart test` in `packages/soliplex_logging/`** — no regressions
+- [x] **Gate: `flutter test`** — full suite passes
+- [ ] PR created, reviewed, merged to `main`
+
+---
+
+### M2: Platform File Saver + UI Button ([details](milestone-2-platform-ui.md))
+
+**Branch**: `feat/log-export-ui` (from `main` after M1 merged)
+
+- [ ] Edit `pubspec.yaml` — add `share_plus` dependency
+- [ ] Run `flutter pub get` — resolves cleanly
+- [ ] Create `lib/features/log_viewer/log_file_saver.dart` — abstract `LogFileSaver` class + `createLogFileSaver()` factory + `logFileSaverProvider`
+- [ ] Create `lib/features/log_viewer/log_file_saver_native.dart` — gzip + share sheet + `sharePositionOrigin`
+- [ ] Create `lib/features/log_viewer/log_file_saver_web.dart` — Blob + anchor download + `URL.revokeObjectURL`
+- [ ] Edit `lib/features/log_viewer/log_viewer_screen.dart` — add `Icons.download` button in `Builder`, `_exportLogs()` with `RenderBox` origin, `mounted` check, filesystem-safe timestamp
+- [ ] Edit `test/features/log_viewer/log_viewer_screen_test.dart` — button disabled when empty, enabled with records, correct icon/tooltip, `FakeLogFileSaver` override
+- [ ] Verify `share_plus` API against installed version (finding #3)
+- [ ] **Gate: pre-commit hooks pass** (dart format, flutter analyze, dart analyze packages, pymarkdown, gitleaks)
+- [ ] **Gate: `flutter test`** — full suite passes (no regressions from new provider)
+- [ ] **Gate: manual — Chrome** — browser downloads `.jsonl` with filtered content
+- [ ] **Gate: manual — macOS** — share sheet opens with `.jsonl.gz`, anchored to button
+- [ ] **Gate: manual — iPad** (if available) — share sheet popover anchored to button
+- [ ] PR created, reviewed, merged to `main`
+
+---
+
+### M3: Patrol E2E Test ([details](milestone-3-patrol-e2e.md))
+
+**Branch**: `test/log-export-e2e` (from `main` after M2 merged)
+
+- [ ] Edit `integration_test/patrol_helpers.dart` — add `NoOpLogFileSaver` + `logFileSaverProvider` override in both `pumpTestApp` and `pumpAuthenticatedTestApp`
+- [ ] Edit `integration_test/settings_test.dart` — append `patrolTest('settings - log viewer export button (no-auth)', ...)`
+- [ ] E2E test verifies: button enabled with boot logs, button disabled after clear, `expectNoErrors()` — does NOT tap export (avoids share sheet hang)
+- [ ] **Gate: pre-commit hooks pass** (dart format, flutter analyze, dart analyze packages, pymarkdown, gitleaks)
+- [ ] **Gate: `flutter test`** — full unit/widget suite passes
+- [ ] **Gate: existing Patrol tests pass** — `dart pub global run patrol_cli test -t "smoke"`, `dart pub global run patrol_cli test -t "settings - navigate"`, `dart pub global run patrol_cli test -t "settings - network"`
+- [ ] **Gate: new Patrol test passes** — `dart pub global run patrol_cli test -t "log viewer export"` (no-auth backend)
+- [ ] PR created, reviewed, merged to `main`
+
+---
+
+## Pre-commit Hooks Reference
+
+These hooks run automatically on every `git commit` via `.pre-commit-config.yaml`:
+
+| Hook | What it checks |
+|------|----------------|
+| `no-commit-to-branch` | Blocks direct commits to `main`/`master` |
+| `check-merge-conflict` | No leftover conflict markers |
+| `check-toml` / `check-yaml` | Config file syntax |
+| `gitleaks` | No secrets or credentials committed |
+| `dart format --set-exit-if-changed` | Formatting (excludes generated schema) |
+| `flutter analyze --fatal-infos` | Zero warnings/hints/errors (main app) |
+| `dart analyze packages` (`tool/analyze_packages.py`) | Zero issues in `soliplex_client`, `soliplex_logging`, etc. |
+| `pymarkdown` | Markdown lint on all `.md` files |
+
+All milestone gate checkboxes marked "pre-commit hooks pass" require ALL of
+the above to succeed.
+
+---
+
+## Future: Migration to DiskQueue Export
+
+The current implementation exports from `MemorySink` (in-memory ring buffer,
+~2000 records). A future enhancement could export from `DiskQueue` for access
+to persisted logs (~10 MB / thousands of records surviving app restarts).
+
+### Why not now
+
+`DiskQueue` has no read-all API — it exposes only `drain(count)` / `confirm()`
+(a streaming consume pattern designed for reliable backend shipping). Reading
+all records without consuming them requires either:
+
+- A new `snapshot()` or `readAll()` method on the abstract `DiskQueue` class
+  (+ implementations in `disk_queue_io.dart` and `disk_queue_web.dart`)
+- Or directly reading the `log_queue.jsonl` file (bypasses the abstraction)
+
+### What changes per layer
+
+| Layer | Change needed | Effort |
+|-------|---------------|--------|
+| `log_record_export.dart` | **None** — DiskQueue records are already `Map<String, Object?>`, same shape as `toExportJson()` output. Could skip the extension entirely. | Zero |
+| `log_viewer_controller.dart` | Replace `_filteredRecords.map(toExportJson)` with DiskQueue read. Filtering needs adaptation (Maps, not `LogRecord`). | Small |
+| `log_file_saver*.dart` | **None** — accepts `Uint8List`, source-agnostic | Zero |
+| `log_viewer_screen.dart` | **None** — calls controller, gets bytes | Zero |
+| `DiskQueue` abstract API | Add `Future<List<Map<String, Object?>>> snapshot()` method + implementations | Medium |
+| `disk_queue_io.dart` | Read `log_queue.jsonl` without advancing confirmed pointer | Small |
+| `disk_queue_web.dart` | Return copy of in-memory queue | Trivial |
+
+**Estimated total: ~1-2 days.**
+
+### Shortcut: raw file export
+
+The native `DiskQueue` already writes `log_queue.jsonl` — the exact same
+format we export. A future "export full disk log" could just gzip and share
+the raw file without any JSON re-serialization:
+
+```dart
+// Hypothetical — zero serialization cost
+final file = File('${dir.path}/log_queue.jsonl');
+final bytes = await file.readAsBytes();
+await saver.save(filename: 'soliplex_full_log.jsonl', bytes: bytes);
+```
+
+This bypasses filtering but gives maximum coverage for support/debugging.
+
+### Design note
+
+The M1-M3 architecture was deliberately chosen to make this migration cheap:
+
+- The `LogFileSaver` abstraction (M2) is byte-agnostic — it doesn't care
+  where the bytes come from
+- The `toExportJson()` extension (M1) is additive — DiskQueue export can
+  coexist alongside MemorySink export (user picks "export visible" vs
+  "export all persisted")
+- The UI button (M2) can offer both options via a popup menu in a future PR

--- a/docs/planning/log-export/milestone-1-serialization.md
+++ b/docs/planning/log-export/milestone-1-serialization.md
@@ -1,0 +1,139 @@
+# Milestone 1: Log Record Export Serialization
+
+**Branch**: `feat/log-export-serialization`
+**PR title**: `feat(log-viewer): add log record export serialization`
+**Depends on**: nothing
+
+## Goal
+
+Ship the pure-Dart serialization layer and controller method. No new
+dependencies, no UI changes, no platform code. Independently useful —
+`toExportJson()` and `exportFilteredAsJsonlBytes()` can be called
+programmatically (debug console, future "attach logs to ticket" feature).
+
+## Changes
+
+### 1. Add `LogRecordExport` extension
+
+**File**: `lib/features/log_viewer/log_record_export.dart` (**new**)
+
+Extension on `LogRecord` — keeps serialization out of the pure logging
+package:
+
+```dart
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+extension LogRecordExport on LogRecord {
+  Map<String, Object?> toExportJson() => {
+    'timestamp': timestamp.toUtc().toIso8601String(),
+    'level': level.name,
+    'logger': loggerName,
+    'message': message,
+    if (attributes.isNotEmpty) 'attributes': _safeAttributes(attributes),
+    if (error != null) 'error': error.toString(),
+    if (stackTrace != null) 'stackTrace': stackTrace.toString(),
+    if (spanId != null) 'spanId': spanId,
+    if (traceId != null) 'traceId': traceId,
+  };
+}
+```
+
+Plus private top-level `_safeAttributes()` / `_coerceValue()` helpers
+(~15 lines, same logic as `BackendLogSink`):
+
+```dart
+Map<String, Object?> _safeAttributes(Map<String, Object> attributes) {
+  if (attributes.isEmpty) return const {};
+  final result = <String, Object?>{};
+  for (final entry in attributes.entries) {
+    result[entry.key] = _coerceValue(entry.value);
+  }
+  return result;
+}
+
+Object? _coerceValue(Object? value) {
+  if (value == null || value is String || value is num || value is bool) {
+    return value;
+  }
+  if (value is List) {
+    return value.map(_coerceValue).toList();
+  }
+  if (value is Map) {
+    return value.map((k, v) => MapEntry(k.toString(), _coerceValue(v)));
+  }
+  return value.toString();
+}
+```
+
+### 2. Add `exportFilteredAsJsonlBytes()` to `LogViewerController`
+
+**File**: `lib/features/log_viewer/log_viewer_controller.dart`
+
+```dart
+import 'dart:convert';
+import 'dart:typed_data';
+import 'package:soliplex_frontend/features/log_viewer/log_record_export.dart';
+
+Uint8List exportFilteredAsJsonlBytes() {
+  _flushPending();  // Capture any buffered records
+  final buffer = StringBuffer();
+  for (final record in _filteredRecords) {
+    buffer.writeln(jsonEncode(record.toExportJson()));
+  }
+  return Uint8List.fromList(utf8.encode(buffer.toString()));
+}
+```
+
+Key details:
+
+- Calls `_flushPending()` first to capture buffered records (finding #5)
+- Uses `Uint8List.fromList(utf8.encode(...))` for correct return type (finding #4)
+- Exports chronological order (oldest-first) — standard for log files
+- `writeln()` trailing newline is valid POSIX/JSONL convention
+
+## Files
+
+| File | Action |
+|------|--------|
+| `lib/features/log_viewer/log_record_export.dart` | **New** — extension + helpers |
+| `lib/features/log_viewer/log_viewer_controller.dart` | Edit — add `exportFilteredAsJsonlBytes()` |
+| `test/features/log_viewer/log_record_export_test.dart` | **New** |
+| `test/features/log_viewer/log_viewer_controller_test.dart` | **New** |
+
+## Tests
+
+### `test/features/log_viewer/log_record_export_test.dart`
+
+| Test | What it verifies |
+|------|------------------|
+| `toExportJson includes all required fields` | Map has timestamp, level, logger, message |
+| `timestamp is UTC ISO8601` | Non-UTC input → UTC output string |
+| `null optional fields are omitted` | No error/stackTrace/spanId/traceId keys when null |
+| `present optional fields are included` | error, stackTrace, spanId, traceId appear when set |
+| `empty attributes omitted` | No `attributes` key when map is empty |
+| `attributes with primitives pass through` | String, int, double, bool unchanged |
+| `attributes with nested maps coerced` | Map keys → String, values recursively coerced |
+| `attributes with lists coerced` | List elements recursively coerced |
+| `attributes with custom objects use toString` | Non-primitive → `toString()` |
+| `error uses toString` | `Exception('foo')` → `'Exception: foo'` |
+
+### `test/features/log_viewer/log_viewer_controller_test.dart`
+
+| Test | What it verifies |
+|------|------------------|
+| `exportFilteredAsJsonlBytes returns valid JSONL` | Each line parses as JSON, fields match records |
+| `respects level filter` | Only filtered-in records appear in output |
+| `respects logger exclusion` | Excluded loggers absent from output |
+| `respects search query` | Only matching messages in output |
+| `empty filtered list returns empty bytes` | `Uint8List` with length 0 |
+| `flushes pending records before export` | Record written just before export is included |
+| `chronological order preserved` | First line is oldest record |
+
+## Gates
+
+1. `dart format .` — no changes
+2. `flutter analyze --fatal-infos` — 0 issues
+3. `dart test` in `packages/soliplex_logging/` — passes (no regressions)
+4. `flutter test test/features/log_viewer/log_record_export_test.dart` — passes
+5. `flutter test test/features/log_viewer/log_viewer_controller_test.dart` — passes
+6. `flutter test` — full suite passes

--- a/docs/planning/log-export/milestone-2-platform-ui.md
+++ b/docs/planning/log-export/milestone-2-platform-ui.md
@@ -1,0 +1,248 @@
+# Milestone 2: Platform File Saver + UI Button
+
+**Branch**: `feat/log-export-ui`
+**PR title**: `feat(log-viewer): add export button with platform file saver`
+**Depends on**: Milestone 1 merged
+
+## Goal
+
+Ship the user-facing feature: download button in the log viewer AppBar,
+platform-conditional file saver (class + factory + Riverpod provider),
+`share_plus` dependency, and widget tests.
+
+## Changes
+
+### 1. Add `share_plus` dependency
+
+**File**: `pubspec.yaml`
+
+```yaml
+share_plus: ^10.1.4  # verify latest compatible with flutter >=3.35.0
+```
+
+Run `flutter pub get`.
+
+### 2. Create `LogFileSaver` (class + factory + provider)
+
+Follow the `auth_storage.dart` pattern: abstract class + conditional import
+factory + Riverpod provider for test overrides.
+
+**`lib/features/log_viewer/log_file_saver.dart`** — facade:
+
+```dart
+import 'dart:typed_data';
+import 'dart:ui';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:soliplex_frontend/features/log_viewer/log_file_saver_native.dart'
+    if (dart.library.js_interop)
+        'package:soliplex_frontend/features/log_viewer/log_file_saver_web.dart'
+    as impl;
+
+abstract class LogFileSaver {
+  Future<void> save({
+    required String filename,
+    required Uint8List bytes,
+    Rect? shareOrigin,
+  });
+}
+
+LogFileSaver createLogFileSaver() => impl.createLogFileSaver();
+
+final logFileSaverProvider = Provider<LogFileSaver>(
+  (ref) => createLogFileSaver(),
+);
+```
+
+**`lib/features/log_viewer/log_file_saver_native.dart`** — gzip + share sheet:
+
+```dart
+import 'dart:io';
+import 'dart:typed_data';
+import 'dart:ui';
+
+import 'package:path_provider/path_provider.dart';
+import 'package:share_plus/share_plus.dart';
+
+import 'log_file_saver.dart';
+
+class NativeLogFileSaver implements LogFileSaver {
+  @override
+  Future<void> save({
+    required String filename,
+    required Uint8List bytes,
+    Rect? shareOrigin,
+  }) async {
+    final compressed = gzip.encode(bytes);
+    final dir = await getTemporaryDirectory();
+    final path = '${dir.path}/$filename.gz';
+    await File(path).writeAsBytes(compressed);
+
+    await Share.shareXFiles(
+      [XFile(path)],
+      sharePositionOrigin: shareOrigin,  // Required for iPad/macOS
+    );
+  }
+}
+
+LogFileSaver createLogFileSaver() => NativeLogFileSaver();
+```
+
+> **Note**: Verify `Share.shareXFiles` vs `SharePlus.instance.share(ShareParams(...))`
+> against the installed `share_plus` version. Update to match actual API.
+
+**`lib/features/log_viewer/log_file_saver_web.dart`** — browser download:
+
+```dart
+import 'dart:js_interop';
+import 'dart:typed_data';
+import 'dart:ui';
+
+import 'package:web/web.dart' as web;
+
+import 'log_file_saver.dart';
+
+class WebLogFileSaver implements LogFileSaver {
+  @override
+  Future<void> save({
+    required String filename,
+    required Uint8List bytes,
+    Rect? shareOrigin,  // Accepted but ignored on web
+  }) async {
+    final blob = web.Blob(
+      [bytes.toJS].toJS,
+      web.BlobPropertyBag(type: 'application/x-ndjson'),
+    );
+    final url = web.URL.createObjectURL(blob);
+    final anchor = web.document.createElement('a') as web.HTMLAnchorElement
+      ..href = url
+      ..style.display = 'none'
+      ..download = filename;
+    web.document.body!.appendChild(anchor);
+    anchor.click();
+    web.document.body!.removeChild(anchor);
+    web.URL.revokeObjectURL(url);
+  }
+}
+
+LogFileSaver createLogFileSaver() => WebLogFileSaver();
+```
+
+### 3. Add download button to log viewer screen
+
+**File**: `lib/features/log_viewer/log_viewer_screen.dart`
+
+Add `Icons.download` IconButton wrapped in `Builder` (for `RenderBox` access)
+before the existing clear button:
+
+```dart
+actions: [
+  Builder(
+    builder: (context) => IconButton(
+      icon: const Icon(Icons.download),
+      onPressed: records.isEmpty ? null : () => _exportLogs(context),
+      tooltip: 'Export filtered logs',
+    ),
+  ),
+  IconButton(
+    icon: const Icon(Icons.delete_outline),
+    onPressed: records.isEmpty ? null : _controller.clearLogs,
+    tooltip: 'Clear all logs',
+  ),
+],
+```
+
+`_exportLogs(BuildContext context)` method:
+
+```dart
+Future<void> _exportLogs(BuildContext context) async {
+  final messenger = ScaffoldMessenger.of(context);
+
+  // Compute share origin for iPad/macOS popover positioning.
+  final box = context.findRenderObject() as RenderBox?;
+  final origin = box != null
+      ? box.localToGlobal(Offset.zero) & box.size
+      : null;
+
+  // Build filename with filesystem-safe timestamp.
+  final now = DateTime.now();
+  final ts = '${now.year}-${_pad(now.month)}-${_pad(now.day)}'
+      '_${_pad(now.hour)}-${_pad(now.minute)}-${_pad(now.second)}';
+  final filename = 'soliplex_logs_$ts.jsonl';
+
+  try {
+    final bytes = _controller.exportFilteredAsJsonlBytes();
+    final saver = ref.read(logFileSaverProvider);
+    await saver.save(
+      filename: filename,
+      bytes: bytes,
+      shareOrigin: origin,
+    );
+  } catch (e) {
+    if (!mounted) return;  // Async gap guard (finding #9)
+    messenger.showSnackBar(
+      SnackBar(content: Text('Export failed: $e')),
+    );
+  }
+}
+
+static String _pad(int n) => n.toString().padLeft(2, '0');
+```
+
+Key details:
+
+- `Builder` wrapper gives the `IconButton`'s own `BuildContext` for `RenderBox`
+- Filesystem-safe timestamp: `YYYY-MM-DD_HH-mm-ss` (no colons — finding #8)
+- `mounted` check after `await` (finding #9)
+- Gets saver from `logFileSaverProvider` (finding #6)
+- `shareOrigin` passed through for iPad/macOS (finding #1)
+
+## Files
+
+| File | Action |
+|------|--------|
+| `pubspec.yaml` | Edit — add `share_plus` |
+| `lib/features/log_viewer/log_file_saver.dart` | **New** — abstract class + facade + provider |
+| `lib/features/log_viewer/log_file_saver_native.dart` | **New** — gzip + share sheet |
+| `lib/features/log_viewer/log_file_saver_web.dart` | **New** — Blob + anchor download |
+| `lib/features/log_viewer/log_viewer_screen.dart` | Edit — add download button + handler |
+| `test/features/log_viewer/log_viewer_screen_test.dart` | Edit — add button widget tests |
+
+## Tests
+
+### `test/features/log_viewer/log_viewer_screen_test.dart` (additions)
+
+| Test | What it verifies |
+|------|------------------|
+| `download button is disabled when empty` | `onPressed` is null with no records |
+| `download button is enabled with records` | `onPressed` is not null with records |
+| `download button shows correct icon` | `Icons.download` present |
+| `download button has correct tooltip` | `'Export filtered logs'` |
+| `download button appears before clear button` | Icon order in actions |
+
+Widget tests override `logFileSaverProvider` with a no-op fake to avoid
+platform calls:
+
+```dart
+class FakeLogFileSaver implements LogFileSaver {
+  int callCount = 0;
+  @override
+  Future<void> save({
+    required String filename,
+    required Uint8List bytes,
+    Rect? shareOrigin,
+  }) async {
+    callCount++;
+  }
+}
+```
+
+## Gates
+
+1. `dart format .` — no changes
+2. `flutter analyze --fatal-infos` — 0 issues
+3. `flutter pub get` — resolves cleanly (share_plus compatible)
+4. `flutter test test/features/log_viewer/log_viewer_screen_test.dart` — passes
+5. `flutter test` — full suite passes (no regressions from new provider)
+6. Manual: Chrome — browser downloads `.jsonl` with filtered content
+7. Manual: macOS — share sheet opens with `.jsonl.gz`, anchored to button

--- a/docs/planning/log-export/milestone-3-patrol-e2e.md
+++ b/docs/planning/log-export/milestone-3-patrol-e2e.md
@@ -1,0 +1,156 @@
+# Milestone 3: Patrol E2E Test for Log Export
+
+**Branch**: `test/log-export-e2e`
+**PR title**: `test(log-viewer): add Patrol E2E test for export button`
+**Depends on**: Milestone 2 merged
+
+## Goal
+
+Add Patrol integration test coverage for the export button. This milestone
+is separate because it modifies `patrol_helpers.dart` (which affects ALL
+existing Patrol tests via `pumpTestApp`) and requires a live backend to run.
+
+## Rationale for Separate PR
+
+- `patrol_helpers.dart` changes (`logFileSaverProvider` override) affect
+  every existing E2E test — `smoke_test.dart`, `live_chat_test.dart`,
+  `oidc_test.dart`, `settings_test.dart`
+- If the new override breaks something, it's easier to isolate and revert
+- E2E test needs a live no-auth backend; separating lets M2 land while
+  this is validated against CI
+
+## Changes
+
+### 1. Add `logFileSaverProvider` override to `pumpTestApp`
+
+**File**: `integration_test/patrol_helpers.dart`
+
+Add a no-op fake saver and include the provider override in both
+`pumpTestApp` and `pumpAuthenticatedTestApp`:
+
+```dart
+import 'package:soliplex_frontend/features/log_viewer/log_file_saver.dart';
+
+/// No-op file saver that prevents OS share sheet / browser download
+/// from opening during Patrol tests.
+class NoOpLogFileSaver implements LogFileSaver {
+  @override
+  Future<void> save({
+    required String filename,
+    required Uint8List bytes,
+    Rect? shareOrigin,
+  }) async {}
+}
+```
+
+Add to existing overrides list in `pumpTestApp`:
+
+```dart
+overrides: [
+  preloadedPrefsProvider.overrideWithValue(harness.prefs),
+  memorySinkProvider.overrideWithValue(harness.sink),
+  shellConfigProvider.overrideWithValue(...),
+  preloadedBaseUrlProvider.overrideWithValue(backendUrl),
+  authProvider.overrideWith(NoAuthNotifier.new),
+  logFileSaverProvider.overrideWithValue(NoOpLogFileSaver()),  // NEW
+],
+```
+
+Same addition to `pumpAuthenticatedTestApp`.
+
+### 2. Add dart pub global run patrol_cli test
+
+**File**: `integration_test/settings_test.dart` (append)
+
+```dart
+patrolTest('settings - log viewer export button (no-auth)', ($) async {
+  await verifyBackendOrFail(backendUrl);
+  ignoreKeyboardAssertions();
+
+  harness = TestLogHarness();
+  await harness.initialize();
+
+  try {
+    await pumpTestApp($, harness);
+
+    // Wait for app to boot.
+    final settingsButton = find.byTooltip('Open settings');
+    await waitForCondition(
+      $.tester,
+      condition: () => $.tester.any(settingsButton),
+      timeout: const Duration(seconds: 10),
+      failureMessage: 'Settings button did not appear',
+    );
+    await $.tester.tap(settingsButton);
+    await $.tester.pump(const Duration(milliseconds: 500));
+
+    // Navigate to Log Viewer (adjust finder to match actual tile).
+    await $.tester.tap(find.text('View Logs'));
+    await $.tester.pump(const Duration(milliseconds: 500));
+
+    // Export button should be enabled (boot logs exist).
+    final downloadButton = find.ancestor(
+      of: find.byIcon(Icons.download),
+      matching: find.byType(IconButton),
+    );
+    expect(downloadButton, findsOneWidget);
+    expect(
+      $.tester.widget<IconButton>(downloadButton).onPressed,
+      isNotNull,
+      reason: 'Export should be enabled — boot generated logs',
+    );
+
+    // Clear logs → export button should disable.
+    await $.tester.tap(find.byTooltip('Clear all logs'));
+    await $.tester.pump(const Duration(milliseconds: 500));
+
+    expect(
+      $.tester.widget<IconButton>(downloadButton).onPressed,
+      isNull,
+      reason: 'Export should be disabled after clearing logs',
+    );
+  } catch (e) {
+    harness.dumpLogs(last: 50);
+    rethrow;
+  } finally {
+    harness
+      ..expectNoErrors()
+      ..dispose();
+  }
+});
+```
+
+**Design decisions:**
+- Does **not** tap the export button — avoids OS share sheet hang (finding #2)
+- Serialization correctness is covered by M1 unit tests
+- Platform saver is behind `NoOpLogFileSaver` — safe even if accidentally tapped
+- Only verifies button state transitions (enabled → disabled after clear)
+- `expectNoErrors()` in finally block catches any silent exceptions
+
+### What the E2E test covers vs. manual
+
+| Covered by E2E | Must remain manual |
+|----------------|--------------------|
+| Button enabled when logs exist | OS share sheet appears (native) |
+| Button disabled after clearing logs | Browser download triggers (web) |
+| Button discoverable in AppBar | Exported file content is valid JSONL |
+| No exceptions during full app lifecycle | Share sheet anchored to button (iPad) |
+
+## Files
+
+| File | Action |
+|------|--------|
+| `integration_test/patrol_helpers.dart` | Edit — add `NoOpLogFileSaver` + provider override |
+| `integration_test/settings_test.dart` | Edit — append dart pub global run patrol_cli test |
+
+## Gates
+
+1. `dart format .` — no changes
+2. `flutter analyze --fatal-infos` — 0 issues
+3. Existing Patrol tests still pass (smoke, settings, live_chat):
+   - `dart pub global run patrol_cli test -t "smoke"` — passes
+   - `dart pub global run patrol_cli test -t "settings - navigate"` — passes
+   - `dart pub global run patrol_cli test -t "settings - network"` — passes
+4. New test passes:
+   - `dart pub global run patrol_cli test -t "log viewer export"` — passes (no-auth backend)
+5. `flutter test` — full unit/widget suite passes (no regressions)

--- a/lib/features/log_viewer/log_record_export.dart
+++ b/lib/features/log_viewer/log_record_export.dart
@@ -1,0 +1,43 @@
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+/// Serialization extension for exporting [LogRecord] to JSON.
+///
+/// Lives in the feature layer to keep `soliplex_logging` model lean.
+extension LogRecordExport on LogRecord {
+  /// Converts this record to a JSON-encodable map for JSONL export.
+  ///
+  /// Timestamps are always UTC ISO 8601. Null optional fields are omitted.
+  /// Attributes are recursively coerced to JSON-safe primitives.
+  Map<String, Object?> toExportJson() => {
+        'timestamp': timestamp.toUtc().toIso8601String(),
+        'level': level.name,
+        'logger': loggerName,
+        'message': message,
+        if (attributes.isNotEmpty) 'attributes': _safeAttributes(attributes),
+        if (error != null) 'error': error.toString(),
+        if (stackTrace != null) 'stackTrace': stackTrace.toString(),
+        if (spanId != null) 'spanId': spanId,
+        if (traceId != null) 'traceId': traceId,
+      };
+}
+
+Map<String, Object?> _safeAttributes(Map<String, Object> attributes) {
+  final result = <String, Object?>{};
+  for (final entry in attributes.entries) {
+    result[entry.key] = _coerceValue(entry.value);
+  }
+  return result;
+}
+
+Object? _coerceValue(Object? value) {
+  if (value == null || value is String || value is num || value is bool) {
+    return value;
+  }
+  if (value is List) {
+    return value.map(_coerceValue).toList();
+  }
+  if (value is Map) {
+    return value.map((k, v) => MapEntry(k.toString(), _coerceValue(v)));
+  }
+  return value.toString();
+}

--- a/test/features/log_viewer/log_record_export_test.dart
+++ b/test/features/log_viewer/log_record_export_test.dart
@@ -1,0 +1,138 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/features/log_viewer/log_record_export.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+LogRecord _makeRecord({
+  LogLevel level = LogLevel.info,
+  String message = 'Test message',
+  String loggerName = 'Test',
+  DateTime? timestamp,
+  Object? error,
+  StackTrace? stackTrace,
+  String? spanId,
+  String? traceId,
+  Map<String, Object> attributes = const {},
+}) {
+  return LogRecord(
+    level: level,
+    message: message,
+    loggerName: loggerName,
+    timestamp: timestamp ?? DateTime(2024, 1, 15, 10, 30, 45, 123),
+    error: error,
+    stackTrace: stackTrace,
+    spanId: spanId,
+    traceId: traceId,
+    attributes: attributes,
+  );
+}
+
+void main() {
+  group('LogRecordExport.toExportJson', () {
+    test('includes all required fields', () {
+      final json = _makeRecord().toExportJson();
+
+      expect(json, containsPair('timestamp', isA<String>()));
+      expect(json, containsPair('level', 'info'));
+      expect(json, containsPair('logger', 'Test'));
+      expect(json, containsPair('message', 'Test message'));
+    });
+
+    test('timestamp is UTC ISO8601', () {
+      // Use a non-UTC timestamp as input.
+      final localTime = DateTime(2024, 6, 15, 14, 30);
+      final json = _makeRecord(timestamp: localTime).toExportJson();
+
+      final ts = json['timestamp']! as String;
+      expect(ts, endsWith('Z'));
+      expect(DateTime.parse(ts).isUtc, isTrue);
+      expect(DateTime.parse(ts), equals(localTime.toUtc()));
+    });
+
+    test('null optional fields are omitted', () {
+      final json = _makeRecord().toExportJson();
+
+      expect(json.containsKey('error'), isFalse);
+      expect(json.containsKey('stackTrace'), isFalse);
+      expect(json.containsKey('spanId'), isFalse);
+      expect(json.containsKey('traceId'), isFalse);
+      expect(json.containsKey('attributes'), isFalse);
+    });
+
+    test('present optional fields are included', () {
+      final json = _makeRecord(
+        error: Exception('boom'),
+        stackTrace: StackTrace.current,
+        spanId: 'span-1',
+        traceId: 'trace-1',
+      ).toExportJson();
+
+      expect(json.containsKey('error'), isTrue);
+      expect(json.containsKey('stackTrace'), isTrue);
+      expect(json, containsPair('spanId', 'span-1'));
+      expect(json, containsPair('traceId', 'trace-1'));
+    });
+
+    test('empty attributes omitted', () {
+      final json = _makeRecord().toExportJson();
+      expect(json.containsKey('attributes'), isFalse);
+    });
+
+    test('attributes with primitives pass through', () {
+      final json = _makeRecord(
+        attributes: {
+          'str': 'hello',
+          'int': 42,
+          'double': 3.14,
+          'bool': true,
+        },
+      ).toExportJson();
+
+      final attrs = json['attributes']! as Map<String, Object?>;
+      expect(attrs['str'], 'hello');
+      expect(attrs['int'], 42);
+      expect(attrs['double'], 3.14);
+      expect(attrs['bool'], true);
+    });
+
+    test('attributes with nested maps coerced', () {
+      final json = _makeRecord(
+        attributes: {
+          'nested': <Object, Object>{1: 'one', 'two': 2},
+        },
+      ).toExportJson();
+
+      final attrs = json['attributes']! as Map<String, Object?>;
+      final nested = attrs['nested']! as Map<String, Object?>;
+      expect(nested['1'], 'one');
+      expect(nested['two'], 2);
+    });
+
+    test('attributes with lists coerced', () {
+      final json = _makeRecord(
+        attributes: {
+          'items': [1, 'two', true],
+        },
+      ).toExportJson();
+
+      final attrs = json['attributes']! as Map<String, Object?>;
+      expect(attrs['items'], [1, 'two', true]);
+    });
+
+    test('attributes with custom objects use toString', () {
+      final json = _makeRecord(
+        attributes: {
+          'uri': Uri.parse('https://example.com'),
+        },
+      ).toExportJson();
+
+      final attrs = json['attributes']! as Map<String, Object?>;
+      expect(attrs['uri'], 'https://example.com');
+    });
+
+    test('error uses toString', () {
+      final json = _makeRecord(error: Exception('foo')).toExportJson();
+
+      expect(json['error'], 'Exception: foo');
+    });
+  });
+}

--- a/test/features/log_viewer/log_viewer_controller_test.dart
+++ b/test/features/log_viewer/log_viewer_controller_test.dart
@@ -1,0 +1,169 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_frontend/features/log_viewer/log_viewer_controller.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
+
+LogRecord _makeRecord({
+  LogLevel level = LogLevel.info,
+  String message = 'Test message',
+  String loggerName = 'Test',
+  DateTime? timestamp,
+}) {
+  return LogRecord(
+    level: level,
+    message: message,
+    loggerName: loggerName,
+    timestamp: timestamp ?? DateTime(2024, 1, 15, 10, 30, 45, 123),
+  );
+}
+
+void main() {
+  group('LogViewerController.exportFilteredAsJsonlBytes', () {
+    late MemorySink sink;
+    late LogViewerController controller;
+
+    setUp(() {
+      sink = MemorySink();
+      controller = LogViewerController(sink: sink, onChanged: () {});
+    });
+
+    tearDown(() {
+      controller.dispose();
+    });
+
+    test('returns valid JSONL', () {
+      sink
+        ..write(_makeRecord(message: 'First'))
+        ..write(_makeRecord(message: 'Second'));
+      // Re-create controller to pick up records written before construction.
+      controller.dispose();
+      controller = LogViewerController(sink: sink, onChanged: () {});
+
+      final bytes = controller.exportFilteredAsJsonlBytes();
+      final lines = utf8.decode(bytes).trimRight().split('\n');
+
+      expect(lines, hasLength(2));
+      for (final line in lines) {
+        final map = jsonDecode(line) as Map<String, Object?>;
+        expect(map, containsPair('level', 'info'));
+        expect(map, containsPair('logger', 'Test'));
+      }
+      expect(
+        (jsonDecode(lines[0]) as Map)['message'],
+        'First',
+      );
+      expect(
+        (jsonDecode(lines[1]) as Map)['message'],
+        'Second',
+      );
+    });
+
+    test('respects level filter', () {
+      sink
+        ..write(_makeRecord(message: 'Info'))
+        ..write(_makeRecord(level: LogLevel.error, message: 'Error'));
+      controller.dispose();
+      controller = LogViewerController(sink: sink, onChanged: () {})
+        ..setSelectedLevels({LogLevel.error});
+
+      final bytes = controller.exportFilteredAsJsonlBytes();
+      final lines = utf8.decode(bytes).trimRight().split('\n');
+
+      expect(lines, hasLength(1));
+      expect(
+        (jsonDecode(lines[0]) as Map)['message'],
+        'Error',
+      );
+    });
+
+    test('respects logger exclusion', () {
+      sink
+        ..write(_makeRecord(loggerName: 'Auth', message: 'Auth msg'))
+        ..write(_makeRecord(loggerName: 'Chat', message: 'Chat msg'));
+      controller.dispose();
+      controller = LogViewerController(sink: sink, onChanged: () {})
+        ..setExcludedLoggers({'Auth'});
+
+      final bytes = controller.exportFilteredAsJsonlBytes();
+      final lines = utf8.decode(bytes).trimRight().split('\n');
+
+      expect(lines, hasLength(1));
+      expect(
+        (jsonDecode(lines[0]) as Map)['message'],
+        'Chat msg',
+      );
+    });
+
+    test('respects search query', () {
+      sink
+        ..write(_makeRecord(message: 'User logged in'))
+        ..write(_makeRecord(message: 'HTTP request'));
+      controller.dispose();
+      controller = LogViewerController(sink: sink, onChanged: () {})
+        ..setSearchQuery('logged');
+
+      final bytes = controller.exportFilteredAsJsonlBytes();
+      final lines = utf8.decode(bytes).trimRight().split('\n');
+
+      expect(lines, hasLength(1));
+      expect(
+        (jsonDecode(lines[0]) as Map)['message'],
+        'User logged in',
+      );
+    });
+
+    test('empty filtered list returns empty bytes', () {
+      // No records written — controller has nothing.
+      final bytes = controller.exportFilteredAsJsonlBytes();
+      expect(bytes.length, 0);
+    });
+
+    test('flushes pending records before export', () async {
+      // Write a record after controller construction — it goes into the
+      // pending buffer and hasn't been flushed yet.
+      sink.write(_makeRecord(message: 'Pending'));
+
+      // Don't wait for the flush timer — export should flush internally.
+      final bytes = controller.exportFilteredAsJsonlBytes();
+      final lines = utf8.decode(bytes).trimRight().split('\n');
+
+      expect(lines, hasLength(1));
+      expect(
+        (jsonDecode(lines[0]) as Map)['message'],
+        'Pending',
+      );
+    });
+
+    test('chronological order preserved', () {
+      sink
+        ..write(
+          _makeRecord(
+            message: 'Old',
+            timestamp: DateTime(2024, 1, 15, 10),
+          ),
+        )
+        ..write(
+          _makeRecord(
+            message: 'New',
+            timestamp: DateTime(2024, 1, 15, 11),
+          ),
+        );
+      controller.dispose();
+      controller = LogViewerController(sink: sink, onChanged: () {});
+
+      final bytes = controller.exportFilteredAsJsonlBytes();
+      final lines = utf8.decode(bytes).trimRight().split('\n');
+
+      expect(lines, hasLength(2));
+      expect(
+        (jsonDecode(lines[0]) as Map)['message'],
+        'Old',
+      );
+      expect(
+        (jsonDecode(lines[1]) as Map)['message'],
+        'New',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add `toExportJson()` extension on `LogRecord` for JSONL export serialization
- Add `exportFilteredAsJsonlBytes()` to `LogViewerController` with flush-before-export
- Timestamps in UTC ISO 8601, null fields omitted, attributes recursively coerced

## Changes
- **`lib/features/log_viewer/log_record_export.dart`**: Extension with `toExportJson()` + `_safeAttributes`/`_coerceValue` helpers
- **`lib/features/log_viewer/log_viewer_controller.dart`**: `exportFilteredAsJsonlBytes()`, flushes pending before export, chronological order
- **`test/features/log_viewer/log_record_export_test.dart`**: Shape, UTC, null omission, attribute coercion, error toString
- **`test/features/log_viewer/log_viewer_controller_test.dart`**: Valid JSONL, respects filters, empty state, flush, chronological order

## Stack
1. **This PR (M1)** — serialization (pure Dart)
2. M2 — platform file saver + UI button
3. M3 — Patrol E2E test

## Test plan
- [x] `flutter test` — 1350 tests pass
- [x] `flutter analyze --fatal-infos` — 0 issues
- [x] Pre-commit hooks pass