### PR TITLE
test(log-viewer): add Patrol E2E test for export button (M3)

### DIFF
--- a/docs/planning/log-export/PLAN.md
+++ b/docs/planning/log-export/PLAN.md
@@ -77,10 +77,10 @@ serialization    UI + platform    patrol E2E
 - [x] Edit `lib/features/log_viewer/log_viewer_screen.dart` — add `Icons.download` button in `Builder`, `_exportLogs()` with `RenderBox` origin, `mounted` check, filesystem-safe timestamp
 - [x] Edit `test/features/log_viewer/log_viewer_screen_test.dart` — button disabled when empty, enabled with records, correct icon/tooltip, `FakeLogFileSaver` override
 - [x] Verify `share_plus` API against installed version (finding #3)
-- [ ] **Gate: pre-commit hooks pass** (dart format, flutter analyze, dart analyze packages, pymarkdown, gitleaks)
+- [x] **Gate: pre-commit hooks pass** (dart format, flutter analyze, dart analyze packages, pymarkdown, gitleaks)
 - [x] **Gate: `flutter test`** — full suite passes (no regressions from new provider)
 - [ ] **Gate: manual — Chrome** — browser downloads `.jsonl` with filtered content
-- [ ] **Gate: manual — macOS** — share sheet opens with `.jsonl.gz`, anchored to button
+- [x] **Gate: manual — macOS** — saves `.jsonl.gz` to Downloads, snackbar with copy path
 - [ ] **Gate: manual — iPad** (if available) — share sheet popover anchored to button
 - [ ] PR created, reviewed, merged to `main`
 


### PR DESCRIPTION
## Summary
- Add Patrol E2E test that validates the full log export pipeline using a `SpyLogFileSaver`
- Spy captures bytes/filename without triggering OS share sheet, enabling content verification
- `NoOpLogFileSaver` added as default override in all Patrol test helpers

## Changes
- **`integration_test/patrol_helpers.dart`**: `NoOpLogFileSaver` (default, inert) + `SpyLogFileSaver` (captures args, returns fake path), optional `logFileSaver` param on `pumpTestApp` / `pumpAuthenticatedTestApp`
- **`integration_test/settings_test.dart`**: New `patrolTest('settings - log viewer export button')` verifying:
  - Filename matches `soliplex_logs_YYYY-MM-DD_HH-mm-ss.jsonl` pattern
  - Exported bytes decode to valid JSONL with `timestamp`, `level`, `logger`, `message` fields
  - `shareOrigin` is non-null (iPad/macOS popover positioning)
  - SnackBar shows saved path
  - Button disables after clearing logs

## Stack
1. M1 — serialization (pure Dart)
2. M2 — platform file saver + UI button ← base
3. **This PR (M3)** — Patrol E2E test

## Test plan
- [x] `flutter test` — 1350 tests pass
- [x] `flutter analyze --fatal-infos` — 0 issues
- [x] Pre-commit hooks pass
- [x] Patrol E2E on iOS simulator — export button test passes (3s)
- [x] Existing Patrol tests unaffected (smoke, settings-navigate pass)