### PR TITLE
docs: plan for configurable login message

### DIFF
--- a/PLANS/0005-login-message/ADR.md
+++ b/PLANS/0005-login-message/ADR.md
@@ -1,0 +1,209 @@
+# ADR: Configurable Login Message
+
+## Status
+
+Proposed
+
+## Context
+
+DoD deployments require a consent-to-monitoring banner before system access
+([#751](https://github.com/enfold/afsoc-rag/issues/751),
+[#815](https://github.com/enfold/afsoc-rag/issues/815)). This must be
+configurable — non-DoD deployments should not see it.
+
+See [SPEC.md](./SPEC.md) for requirements and use cases.
+
+### Current Architecture
+
+The login screen (`LoginScreen`) is a chrome-less `Scaffold` that shows the
+app name, "Sign in to continue", and a list of OIDC providers. There is no
+mechanism for pre-login messaging.
+
+```dart
+// login_screen.dart — current structure
+Scaffold(
+  body: Center(
+    child: Column(
+      children: [
+        Text(appName),           // App name
+        Text('Sign in to...'),   // Subtitle
+        issuersAsync.when(...),  // Provider buttons
+      ],
+    ),
+  ),
+)
+```
+
+Post-logout on web, `WebAuthFlow.endSession` sets
+`post_logout_redirect_uri: frontendOrigin`. After KC redirects, the app
+reloads and the router sends unauthenticated users to `/login` or `/`.
+However, issue #751 reports users landing on `/#/auth/callback` — this
+happens when KC's `post_logout_redirect_uri` isn't properly registered, or
+when an older code path used the callback URL as the redirect target.
+
+## Decision
+
+### 1. LoginMessage as a Configuration Model
+
+Add `LoginMessage` to `SoliplexConfig`:
+
+```dart
+@immutable
+class LoginMessage {
+  const LoginMessage({
+    required this.title,
+    required this.body,
+    this.acknowledgmentLabel = 'OK',
+  });
+
+  final String title;
+  final String body;
+  final String acknowledgmentLabel;
+}
+```
+
+```dart
+class SoliplexConfig {
+  const SoliplexConfig({
+    // ...existing fields...
+    this.loginMessage,
+  });
+
+  final LoginMessage? loginMessage;
+}
+```
+
+**Rationale:** Compile-time configuration via `SoliplexConfig` matches the
+existing pattern for white-label customization (app name, features, routes,
+theme). The message varies by deployment, not by runtime state.
+
+**Why nullable:** The default is "no message". `null` means no interstitial.
+This is simpler than a boolean flag plus message fields, and eliminates the
+invalid state of `showBanner: true` with empty message text.
+
+**Why `body` is a plain String:** DoD requires verbatim use of the Standard
+Mandatory Notice and Consent Banner text (~1,300 chars). The body is rendered
+in a scrollable view. No markdown or rich text needed — the official text is
+plain prose. Shell apps pass the exact required text.
+
+### 2. Interstitial Within the Login Screen (Not a Separate Route)
+
+The message is shown as a state within the existing `LoginScreen` widget.
+Before acknowledgment, the login options are hidden. After acknowledgment,
+they appear.
+
+```text
+┌─────────────────────────────────────┐
+│          Login Screen               │
+│                                     │
+│  loginMessage == null?              │
+│    ├─ YES → show login options      │
+│    └─ NO → show interstitial        │
+│             ├─ acknowledged?        │
+│             │  ├─ YES → show login  │
+│             │  └─ NO → show message │
+│             └───────────────────────│
+└─────────────────────────────────────┘
+```
+
+**Rationale:**
+
+- **No new routes.** Adding a `/consent` route would require router changes,
+  redirect logic, and a new public route entry. The interstitial is part of
+  the login flow, not a navigation destination.
+- **Simple state.** A single `_acknowledged` boolean in `_LoginScreenState`
+  controls visibility. Resets automatically when the widget rebuilds (logout
+  recreates the route, resetting state).
+- **Session-scoped by default.** Widget state is ephemeral — destroyed on
+  logout/navigation. No persistence needed.
+
+**DoD compliance via existing router architecture:**
+
+The DoD rules require the banner before deep links and after session timeout.
+Both are already handled by the router's auth guard:
+
+- **Deep link (no session):** User opens `/rooms/42` → router detects
+  `!hasAccess && !isPublicRoute` → redirects to `/login` → interstitial
+  shows (fresh widget state).
+- **Session timeout:** Token refresh fails → `Unauthenticated` state →
+  router redirects to `/login` → interstitial shows.
+- **Logout:** `Unauthenticated(explicitSignOut)` → router redirects to
+  `/login` (or `/` then `/login`) → interstitial shows.
+- **Active session navigation:** Authenticated users never see `/login` →
+  banner never re-shows during a session.
+
+No router changes needed. The existing auth guard + login screen interstitial
+satisfies all DoD banner display rules.
+
+**Alternative considered:** Separate `/consent` route.
+Rejected because it adds routing complexity for a UI-only concern. The
+interstitial is not a destination users navigate to — it's a gate before
+login. The existing router already ensures all unauthenticated access flows
+through `/login`.
+
+### 3. Post-Logout Redirect Fix
+
+The current `WebAuthFlow.endSession` sets:
+
+```dart
+'post_logout_redirect_uri': frontendOrigin,
+```
+
+This redirects to the bare origin (e.g., `http://localhost:59001`), which
+then loads the app, detects unauthenticated state, and the router sends the
+user to `/login`.
+
+The issue (#751) reports KC redirecting to `/#/auth/callback`. Investigation
+shows this is because `post_logout_redirect_uri` was set to the callback URL
+in an older version of the code. The current code is correct but we need to
+ensure:
+
+1. The `post_logout_redirect_uri` sent to KC matches a URI registered in the
+   KC client's "Valid post logout redirect URIs" setting.
+2. On web with hash routing, the bare origin loads the app at `/` which the
+   router redirects to `/login`.
+
+**No code change needed** for the redirect itself — the current implementation
+is correct. The fix is a KC configuration concern (documented in the
+implementation plan).
+
+However, we should add a **defensive improvement**: if the app loads at
+`/auth/callback` without valid token parameters, the `AuthCallbackScreen`
+should redirect to `/login` instead of showing an error. This handles the
+case where KC is misconfigured or the user bookmarks the callback URL.
+
+### 4. Acknowledgment Is Widget State (Not Provider State)
+
+The `_acknowledged` flag lives in `_LoginScreenState`, not in a Riverpod
+provider.
+
+**Rationale:**
+
+- Session-scoping is free: widget state resets on rebuild.
+- No persistence needed (DoD requires re-acknowledgment every session).
+- No cross-widget communication needed (only the login screen cares).
+- YAGNI: a provider would be needed if other screens checked acknowledgment
+  status. They don't.
+
+## Consequences
+
+### Positive
+
+- Zero impact on deployments without `loginMessage` configured
+- Follows existing `SoliplexConfig` pattern — no new mechanism to learn
+- Minimal code change (one new model, login screen modification)
+- Session-scoped acknowledgment is automatic (widget lifecycle)
+- No new routes, providers, or dependencies
+
+### Negative
+
+- If multiple screens ever need to check acknowledgment, we'd need to
+  promote to a provider (unlikely — acknowledgment is a login concern)
+
+### Risks
+
+- **KC configuration:** The post-logout redirect depends on KC having the
+  correct `post_logout_redirect_uri` registered. This is a deployment
+  concern, not a code concern. Documented in implementation plan.
+- **DoD banner text accuracy:** The exact required text varies by
+  organization. We provide the mechanism; the shell app provides the text.

--- a/PLANS/0005-login-message/IMPLEMENTATION.md
+++ b/PLANS/0005-login-message/IMPLEMENTATION.md
@@ -1,0 +1,274 @@
+# Implementation Plan: Configurable Login Message
+
+## Overview
+
+Two slices. Slice 1 adds the configurable login message (interstitial).
+Slice 2 hardens the post-logout redirect path.
+
+## Slice Summary
+
+| # | Slice | ~Lines | Customer Value |
+|---|-------|--------|----------------|
+| 1 | Login message config + interstitial | ~120 | DoD consent banner before login |
+| 2 | Post-logout redirect hardening | ~30 | Clean redirect after logout |
+
+## Dependency Structure
+
+```text
+[1] Login message + interstitial
+         │
+         ▼
+[2] Post-logout redirect hardening
+```
+
+Slice 2 is independent in code but logically follows slice 1 — after
+adding the interstitial, we want logout to land back on it cleanly.
+
+---
+
+## Slice 1: Login Message Configuration + Interstitial
+
+**Branch:** `feat/login-message`
+
+**Target:** ~120 lines
+
+**Customer value:** DoD deployments can configure a consent banner that
+appears before login. Regular deployments are unaffected.
+
+### Tasks
+
+1. Create `lib/core/models/login_message.dart` — immutable model with
+   `title`, `body`, `acknowledgmentLabel`
+2. Add optional `loginMessage` field to `SoliplexConfig`
+3. Modify `LoginScreen` to read `loginMessage` from config
+4. When `loginMessage` is non-null and not yet acknowledged:
+   - Show the message title, body (scrollable), and acknowledgment button
+   - Hide the OIDC provider list
+5. When acknowledged (or no message configured), show login options as today
+6. Write tests (TDD)
+
+### Files Created
+
+- `lib/core/models/login_message.dart`
+- `test/core/models/login_message_test.dart`
+- `test/features/login/login_screen_test.dart` (or extend existing)
+
+### Files Modified
+
+- `lib/core/models/soliplex_config.dart` (add `loginMessage` field)
+- `lib/features/login/login_screen.dart` (show interstitial)
+- `test/core/models/soliplex_config_test.dart` (if exists, update)
+
+### LoginMessage Model
+
+```dart
+@immutable
+class LoginMessage {
+  const LoginMessage({
+    required this.title,
+    required this.body,
+    this.acknowledgmentLabel = 'OK',
+  });
+
+  final String title;
+  final String body;
+  final String acknowledgmentLabel;
+}
+```
+
+### Login Screen Changes
+
+```dart
+class _LoginScreenState extends ConsumerState<LoginScreen> {
+  bool _isAuthenticating = false;
+  String? _errorMessage;
+  bool _messageAcknowledged = false;  // NEW
+
+  @override
+  Widget build(BuildContext context) {
+    final config = ref.watch(shellConfigProvider);
+    final loginMessage = config.loginMessage;
+
+    // If message configured and not acknowledged, show interstitial
+    final showInterstitial =
+        loginMessage != null && !_messageAcknowledged;
+
+    return Scaffold(
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 400),
+          child: Padding(
+            padding: const EdgeInsets.all(SoliplexSpacing.s6),
+            child: showInterstitial
+                ? _buildInterstitial(loginMessage)
+                : _buildLoginContent(context),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildInterstitial(LoginMessage message) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(message.title, style: ...headlineMedium, textAlign: center),
+        const SizedBox(height: 24),
+        Expanded(  // scrollable body for long DoD text
+          child: SingleChildScrollView(
+            child: Text(message.body, style: ...bodyMedium),
+          ),
+        ),
+        const SizedBox(height: 24),
+        FilledButton(
+          onPressed: () => setState(() => _messageAcknowledged = true),
+          child: Text(message.acknowledgmentLabel),
+        ),
+      ],
+    );
+  }
+}
+```
+
+### Tests (TDD)
+
+1. **No message configured:** Login screen shows provider list immediately
+   (existing behavior preserved).
+2. **Message configured, not acknowledged:** Login screen shows message
+   title, body, and acknowledgment button. Provider list is NOT visible.
+3. **Message configured, acknowledged:** After tapping the acknowledgment
+   button, provider list becomes visible. Message disappears.
+4. **Custom acknowledgment label:** Button shows the configured label text.
+5. **Default acknowledgment label:** Button shows "OK" when label not
+   specified.
+6. **LoginMessage equality and toString.**
+
+### Acceptance Criteria
+
+- [ ] `LoginMessage` model created with `title`, `body`,
+      `acknowledgmentLabel`
+- [ ] `SoliplexConfig.loginMessage` is optional (null by default)
+- [ ] Login screen shows interstitial when configured
+- [ ] Login options hidden until acknowledgment
+- [ ] No change when `loginMessage` is null
+- [ ] All tests pass (TDD)
+- [ ] `dart format .` clean
+- [ ] `flutter analyze --fatal-infos` reports 0 issues
+
+---
+
+## Slice 2: Post-Logout Redirect Hardening
+
+**Branch:** `feat/login-message` (same branch, separate commit)
+
+**Target:** ~30 lines
+
+**Customer value:** After logout, users always land on the login screen
+(with interstitial if configured), never on a confusing error page.
+
+### Tasks
+
+1. In `AuthCallbackScreen`, detect "empty callback" (no tokens, no error
+   in URL) and redirect to `/login` instead of showing an error
+2. Verify `WebAuthFlow.endSession` sets `post_logout_redirect_uri` correctly
+3. Document KC configuration requirement for `post_logout_redirect_uri`
+4. Write tests
+
+### Context: Why This Matters
+
+Issue #751 reports that after KC logout, users land on `/#/auth/callback`.
+This happens when:
+
+- KC's "Valid post logout redirect URIs" doesn't include the bare origin, so
+  KC falls back to a registered redirect URI (the OAuth callback URL)
+- A user bookmarks or manually navigates to `/auth/callback`
+
+The current `WebAuthFlow.endSession` code is correct — it sets
+`post_logout_redirect_uri: frontendOrigin`. But the `AuthCallbackScreen`
+should handle the case where it loads without valid parameters gracefully.
+
+### Files Modified
+
+- `lib/features/auth/auth_callback_screen.dart` (handle empty callback)
+- `test/features/auth/auth_callback_screen_test.dart` (add test)
+
+### AuthCallbackScreen Change
+
+```dart
+// In the build method, when capturedParams has no tokens and no error:
+// Instead of showing "Missing access token" error, redirect to /login.
+if (capturedParams is NoCallbackParams) {
+  // No OAuth callback in progress — redirect to login.
+  // This handles: post-logout KC redirect, direct navigation, bookmarks.
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    if (mounted) context.go('/login');
+  });
+  return const SizedBox.shrink();
+}
+```
+
+### Tests
+
+1. **AuthCallbackScreen with no params:** Redirects to `/login`.
+2. **AuthCallbackScreen with valid tokens:** Completes auth (existing).
+3. **AuthCallbackScreen with error:** Shows error (existing).
+
+### KC Configuration Note
+
+For web deployments, the Keycloak client must register the app's origin URL
+in "Valid post logout redirect URIs":
+
+```text
+https://your-app-domain.com
+```
+
+Without this, KC ignores the `post_logout_redirect_uri` parameter and
+redirects to a default URL (often the OAuth callback), causing the issue
+described in #751.
+
+### Acceptance Criteria
+
+- [ ] `AuthCallbackScreen` redirects to `/login` when loaded without params
+- [ ] Existing callback behavior (tokens, errors) unchanged
+- [ ] Tests cover the empty-params case
+- [ ] `dart format .` clean
+- [ ] `flutter analyze --fatal-infos` reports 0 issues
+
+---
+
+## Critical Files
+
+**Created:**
+
+- `lib/core/models/login_message.dart` — Message model (slice 1)
+
+**Modified:**
+
+- `lib/core/models/soliplex_config.dart` — Add `loginMessage` field
+  (slice 1)
+- `lib/features/login/login_screen.dart` — Show interstitial (slice 1)
+- `lib/features/auth/auth_callback_screen.dart` — Handle empty callback
+  (slice 2)
+
+## Definition of Done (per slice)
+
+- [ ] All tasks completed
+- [ ] All tests written and passing (TDD)
+- [ ] Code formatted (`dart format .`)
+- [ ] No analyzer issues (`flutter analyze --fatal-infos`)
+- [ ] PR reviewed and approved
+- [ ] Merged to main
+
+## Open Questions
+
+1. **Exact DoD banner text:** The Google Doc linked in #815 wasn't
+   accessible. The shell app (appshell) will provide the exact text via
+   `LoginMessage`. We provide the mechanism; they provide the content.
+
+2. **Backend logout endpoint:** Issue #751 mentions a possible
+   `/api/auth/{system}/logout` backend endpoint for backchannel logout.
+   This is a backend concern — our frontend handles whatever redirect
+   comes back. If the backend adds this endpoint, the frontend's
+   `WebAuthFlow.endSession` could call it instead of redirecting to KC
+   directly. This is out of scope for this plan.

--- a/PLANS/0005-login-message/SPEC.md
+++ b/PLANS/0005-login-message/SPEC.md
@@ -1,0 +1,139 @@
+# Feature Specification: Configurable Login Message
+
+## Overview
+
+Add a configurable interstitial message to the login screen and fix
+post-logout redirect behavior. DoD deployments require a consent-to-monitoring
+banner before system access; regular deployments should not be affected.
+
+## Problem Statement
+
+**Issues:** [#751](https://github.com/enfold/afsoc-rag/issues/751),
+[#815](https://github.com/enfold/afsoc-rag/issues/815)
+
+Three problems exist today:
+
+1. **No consent banner.** DoD requires a "Notice and Consent" interstitial
+   before users can access the system. There is no mechanism to show a message
+   on the login screen.
+
+2. **No configurability.** The interstitial must be opt-in — regular deployments
+   don't want a DoD banner. The message text varies by organization.
+
+3. **Post-logout redirect lands on `/auth/callback`.** After Keycloak logout,
+   the browser redirects to `/#/auth/callback` (the OAuth return URL) instead
+   of the login screen. This shows a confusing "missing token" error.
+
+## DoD Banner Compliance Rules
+
+Source: [DoD Banner Rules](https://docs.google.com/document/d/14cl3wVZIUeOWav4LBdCSrMYXBuETUYcmW8BpbpRcZfc)
+(DoDI 8500.01, DISA STIGs)
+
+| Scenario | Banner Required? | Click-Through? | Notes |
+|----------|-----------------|----------------|-------|
+| Initial login | YES | YES | Must block login form until accepted |
+| Logout & log back in | YES | YES | Fresh entry — banner reappears |
+| Session timeout | YES | YES | Redirect to login triggers banner |
+| Page navigation (active session) | NO | NO | Don't re-show during session |
+| Deep link (no session) | YES | YES | Redirect to banner before deep link |
+
+**Key rules:**
+
+- The banner is a legal "Notice and Consent" mechanism that removes the user's
+  expectation of privacy. It must display **before** the login form.
+- A positive action ("I Agree" / "OK") is required. The login form must not
+  appear until the button is pressed.
+- The verbatim Standard Mandatory DoD Notice and Consent Banner text
+  (~1,300 chars) must be used. It cannot be summarized.
+- If a user deep-links to an internal page without a session, the system must
+  redirect to the banner first.
+
+## Requirements
+
+### Functional Requirements
+
+1. Shell apps can configure an optional login message via `SoliplexConfig`.
+2. When configured, the login screen shows the message as a **blocking
+   interstitial** — the login form is hidden until the user clicks the
+   acknowledgment button.
+3. The message includes a configurable title, body, and button label.
+4. Acknowledgment is session-scoped: the banner reappears after every logout,
+   session timeout, app restart, or browser refresh.
+5. Deep links to protected routes without a session redirect through the
+   banner (already handled by router → `/login` redirect).
+6. After OIDC logout on web, the user lands on the login screen (with the
+   interstitial if configured), not on `/auth/callback`.
+7. When no login message is configured, the login screen works exactly as it
+   does today — no behavioral change.
+
+### Non-Functional Requirements
+
+- The login message configuration is compile-time (part of `SoliplexConfig`),
+  not fetched from the backend. Shell apps define it in their `main.dart`.
+- No new routes. The interstitial lives within the existing login screen.
+- No new packages.
+
+## Use Cases
+
+### Use Case 1: DoD Deployment — First Visit
+
+1. Alice navigates to the Soliplex deployment.
+2. The login screen shows the DoD consent banner with title, body text, and
+   an "I Accept" button. The login form is not visible.
+3. Alice reads the banner and taps "I Accept".
+4. The login screen reveals the OIDC provider list.
+5. Alice signs in normally.
+
+### Use Case 2: DoD Deployment — After Logout
+
+1. Bob is signed in and clicks "Sign out".
+2. The app clears tokens and redirects to the IdP logout endpoint.
+3. Keycloak redirects back to the app origin.
+4. The app loads, detects unauthenticated state, shows the login screen.
+5. Bob sees the DoD consent banner again (acknowledgment was session-scoped).
+
+### Use Case 3: Regular Deployment — No Banner
+
+1. Carol navigates to a regular Soliplex deployment (no `loginMessage` in
+   config).
+2. The login screen shows the OIDC provider list immediately, with no
+   interstitial.
+3. Behavior is identical to today.
+
+### Use Case 4: Web Logout — Clean Redirect
+
+1. Dave is on web, clicks "Sign out".
+2. App clears tokens, sets `Unauthenticated(explicitSignOut)`.
+3. Web auth flow redirects to KC's `end_session_endpoint` with
+   `post_logout_redirect_uri` set to the app's origin.
+4. KC redirects Dave back to the app.
+5. Dave sees the login screen (not `/auth/callback`).
+
+### Use Case 5: Deep Link Without Session
+
+1. Eve bookmarks `/rooms/42` and closes the browser.
+2. Eve opens the bookmark in a new session (no stored tokens).
+3. Router detects unauthenticated state, redirects to `/login`.
+4. Login screen shows the DoD consent banner (interstitial).
+5. Eve acknowledges, signs in, and lands on the authenticated landing route.
+
+### Use Case 6: Session Timeout
+
+1. Frank's session expires while on `/rooms/42`.
+2. Token refresh fails, auth state becomes `Unauthenticated(sessionExpired)`.
+3. Router redirects to `/login`.
+4. Login screen rebuilds with fresh widget state — interstitial reappears.
+5. Frank acknowledges the banner and signs in again.
+
+## Acceptance Criteria
+
+- [ ] `LoginMessage` model exists with `title`, `body`, `acknowledgmentLabel`
+- [ ] `SoliplexConfig` accepts an optional `loginMessage`
+- [ ] Login screen shows blocking interstitial when `loginMessage` is configured
+- [ ] Login form is hidden until user clicks acknowledgment button
+- [ ] Acknowledgment resets on logout / session timeout (session-scoped)
+- [ ] Deep links without session redirect to banner via `/login`
+- [ ] Post-logout redirect lands on login screen on web
+- [ ] No behavioral change when `loginMessage` is null (default)
+- [ ] All existing tests pass
+- [ ] New tests cover interstitial display, acknowledgment, and hide behavior


### PR DESCRIPTION
## Summary

- Adds SPEC, ADR, and IMPLEMENTATION plan for a configurable login message interstitial (issues enfold/afsoc-rag#751, enfold/afsoc-rag#815)
- `LoginMessage` config model + login screen interstitial (~120 lines)

## Test plan

- [ ] Review SPEC.md for completeness
- [ ] Review ADR.md design decisions (interstitial in login screen vs separate route, widget state vs provider)
- [ ] Review IMPLEMENTATION.md slice breakdown and TDD plan
- [ ] Verify compliance scenarios are addressed (initial login, logout, session timeout, deep link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)