### PR TITLE
feat(feedback): slice 1 — data foundation

### DIFF
--- a/lib/core/providers/active_run_notifier.dart
+++ b/lib/core/providers/active_run_notifier.dart
@@ -553,6 +553,7 @@ class ActiveRunNotifier extends Notifier<ActiveRunState> {
     final messageState = MessageState(
       userMessageId: handle.userMessageId,
       sourceReferences: sourceReferences,
+      runId: handle.runId,
     );
 
     return conversation.withMessageState(handle.userMessageId, messageState);

--- a/packages/soliplex_client/lib/src/domain/domain.dart
+++ b/packages/soliplex_client/lib/src/domain/domain.dart
@@ -7,6 +7,7 @@ export 'chat_message.dart';
 export 'chunk_visualization.dart';
 export 'citation_formatting.dart';
 export 'conversation.dart';
+export 'feedback_type.dart';
 export 'message_state.dart';
 export 'quiz.dart';
 export 'rag_document.dart';

--- a/packages/soliplex_client/lib/src/domain/feedback_type.dart
+++ b/packages/soliplex_client/lib/src/domain/feedback_type.dart
@@ -1,0 +1,14 @@
+/// The type of feedback a user can give on an assistant run.
+enum FeedbackType {
+  /// Positive feedback.
+  thumbsUp,
+
+  /// Negative feedback.
+  thumbsDown;
+
+  /// Serializes this value to the string expected by the backend.
+  String toJson() => switch (this) {
+        FeedbackType.thumbsUp => 'thumbs_up',
+        FeedbackType.thumbsDown => 'thumbs_down',
+      };
+}

--- a/packages/soliplex_client/lib/src/domain/message_state.dart
+++ b/packages/soliplex_client/lib/src/domain/message_state.dart
@@ -6,13 +6,15 @@ import 'package:soliplex_client/src/domain/source_reference.dart';
 /// State associated with a user message and its response.
 ///
 /// Keyed by user message ID, this captures the source references (citations)
-/// that were retrieved during the assistant's response to that message.
+/// that were retrieved during the assistant's response to that message,
+/// and the run ID needed for feedback submission.
 @immutable
 class MessageState {
   /// Creates a message state.
   MessageState({
     required this.userMessageId,
     required List<SourceReference> sourceReferences,
+    this.runId,
   }) : sourceReferences = List.unmodifiable(sourceReferences);
 
   /// The ID of the user message this state is associated with.
@@ -21,23 +23,32 @@ class MessageState {
   /// Source references (citations) retrieved for the assistant's response.
   final List<SourceReference> sourceReferences;
 
+  /// The run ID that produced the assistant's response.
+  ///
+  /// Used to submit feedback via the feedback endpoint. Null when the run ID
+  /// is not available (e.g., legacy history without run tracking).
+  final String? runId;
+
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other is! MessageState) return false;
     const listEquals = ListEquality<SourceReference>();
     return userMessageId == other.userMessageId &&
-        listEquals.equals(sourceReferences, other.sourceReferences);
+        listEquals.equals(sourceReferences, other.sourceReferences) &&
+        runId == other.runId;
   }
 
   @override
   int get hashCode => Object.hash(
         userMessageId,
         const ListEquality<SourceReference>().hash(sourceReferences),
+        runId,
       );
 
   @override
   String toString() => 'MessageState('
       'userMessageId: $userMessageId, '
-      'sourceReferences: ${sourceReferences.length})';
+      'sourceReferences: ${sourceReferences.length}, '
+      'runId: $runId)';
 }

--- a/packages/soliplex_client/test/domain/message_state_test.dart
+++ b/packages/soliplex_client/test/domain/message_state_test.dart
@@ -12,6 +12,17 @@ void main() {
 
       expect(state.userMessageId, 'user-123');
       expect(state.sourceReferences, isEmpty);
+      expect(state.runId, isNull);
+    });
+
+    test('creates with runId', () {
+      final state = MessageState(
+        userMessageId: 'user-123',
+        sourceReferences: const [],
+        runId: 'run-456',
+      );
+
+      expect(state.runId, 'run-456');
     });
 
     test('creates with source references', () {
@@ -64,6 +75,35 @@ void main() {
         final state2 = MessageState(
           userMessageId: 'user-456',
           sourceReferences: const [],
+        );
+
+        expect(state1, isNot(equals(state2)));
+      });
+
+      test('different runId makes states unequal', () {
+        final state1 = MessageState(
+          userMessageId: 'user-123',
+          sourceReferences: const [],
+          runId: 'run-1',
+        );
+        final state2 = MessageState(
+          userMessageId: 'user-123',
+          sourceReferences: const [],
+          runId: 'run-2',
+        );
+
+        expect(state1, isNot(equals(state2)));
+      });
+
+      test('null and non-null runId makes states unequal', () {
+        final state1 = MessageState(
+          userMessageId: 'user-123',
+          sourceReferences: const [],
+        );
+        final state2 = MessageState(
+          userMessageId: 'user-123',
+          sourceReferences: const [],
+          runId: 'run-1',
         );
 
         expect(state1, isNot(equals(state2)));


### PR DESCRIPTION
## Summary

- Add `runId` field to `MessageState` so the UI layer can construct feedback API calls
- Add `FeedbackType` enum (`thumbsUp`/`thumbsDown`) to `soliplex_client` domain layer
- Add `submitFeedback()` method to `SoliplexApi` (POST to `/v1/rooms/{room_id}/agui/{thread_id}/{run_id}/feedback`)
- Populate `runId` in both live runs (`ActiveRunNotifier`) and history replay (`SoliplexApi._replayEventsToHistory`)

## Test plan

- [x] `MessageState` tests cover `runId` field (creation, equality, null vs non-null)
- [x] `SoliplexApi.submitFeedback` tests cover thumbs_up/thumbs_down, reason, input validation, error propagation, cancellation
- [x] Existing history replay tests updated to assert `runId` populated
- [x] `flutter analyze --fatal-infos` clean
- [x] `flutter test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)