### PR TITLE
fix(logging): snake_case log payload keys to match backend schema

### DIFF
--- a/packages/soliplex_logging/lib/src/sinks/backend_log_sink.dart
+++ b/packages/soliplex_logging/lib/src/sinks/backend_log_sink.dart
@@ -359,14 +359,14 @@ class BackendLogSink implements LogSink {
       'message': record.message,
       'attributes': _safeAttributes(record.attributes),
       'error': record.error?.toString(),
-      'stackTrace': record.stackTrace?.toString(),
-      'spanId': record.spanId,
-      'traceId': record.traceId,
-      'installId': installId,
-      'sessionId': sessionId,
-      'userId': userId,
-      'activeRun':
-          threadId != null ? {'threadId': threadId, 'runId': runId} : null,
+      'stack_trace': record.stackTrace?.toString(),
+      'span_id': record.spanId,
+      'trace_id': record.traceId,
+      'install_id': installId,
+      'session_id': sessionId,
+      'user_id': userId,
+      'active_run':
+          threadId != null ? {'thread_id': threadId, 'run_id': runId} : null,
     };
   }
 

--- a/packages/soliplex_logging/test/integration/backend_sink_pipeline_test.dart
+++ b/packages/soliplex_logging/test/integration/backend_sink_pipeline_test.dart
@@ -59,7 +59,7 @@ void main() {
     expect(first['message'], 'Hello from pipeline');
     expect(first['level'], 'info');
     expect(first['logger'], 'Integration');
-    expect(first['installId'], 'i-1');
+    expect(first['install_id'], 'i-1');
     expect(
       (first['attributes']! as Map<String, Object?>)['view'],
       'home',
@@ -88,8 +88,8 @@ void main() {
       'logger': 'Test',
       'message': 'Before crash',
       'attributes': <String, Object?>{},
-      'installId': 'i-1',
-      'sessionId': 's-1',
+      'install_id': 'i-1',
+      'session_id': 's-1',
     });
     await queue1.close();
 

--- a/packages/soliplex_logging/test/sinks/backend_log_sink_test.dart
+++ b/packages/soliplex_logging/test/sinks/backend_log_sink_test.dart
@@ -90,9 +90,9 @@ void main() {
       expect(logs, hasLength(1));
 
       final log = logs[0] as Map<String, Object?>;
-      expect(log['installId'], 'install-001');
-      expect(log['sessionId'], 'session-001');
-      expect(log['userId'], 'user-001');
+      expect(log['install_id'], 'install-001');
+      expect(log['session_id'], 'session-001');
+      expect(log['user_id'], 'user-001');
       expect(log['message'], 'Test message');
       expect(log['level'], 'info');
     });
@@ -1044,10 +1044,10 @@ void main() {
             jsonDecode(capturedRequests.first.body) as Map<String, Object?>;
         final logs = body['logs']! as List<Object?>;
         final record = logs.first! as Map<String, Object?>;
-        final activeRun = record['activeRun']! as Map<String, Object?>;
+        final activeRun = record['active_run']! as Map<String, Object?>;
 
-        expect(activeRun['threadId'], 'thread-123');
-        expect(activeRun['runId'], 'run-456');
+        expect(activeRun['thread_id'], 'thread-123');
+        expect(activeRun['run_id'], 'run-456');
       });
 
       test('activeRun is null when threadId not set', () async {
@@ -1060,7 +1060,7 @@ void main() {
         final logs = body['logs']! as List<Object?>;
         final record = logs.first! as Map<String, Object?>;
 
-        expect(record['activeRun'], isNull);
+        expect(record['active_run'], isNull);
       });
     });
   });


### PR DESCRIPTION
## Summary
- Backend Pydantic `LogEntry` model expects snake_case fields (`install_id`, `session_id`, etc.) but `BackendLogSink._recordToJson()` was sending camelCase (`installId`, `sessionId`, etc.)
- This caused 422 validation errors on every POST to `/v1/logs`

## Changes
- **backend_log_sink.dart**: `_recordToJson()` now emits snake_case keys: `install_id`, `session_id`, `user_id`, `active_run`, `thread_id`, `run_id`, `stack_trace`, `span_id`, `trace_id`
- **Tests**: Updated assertions in `backend_log_sink_test.dart` and `backend_sink_pipeline_test.dart` to match

## Test plan
- [x] `dart test` in `packages/soliplex_logging/` — 236 tests pass
- [ ] Deploy and verify POST `/v1/logs` returns 200