### PR TITLE
feat(models): add ExecutingToolsState, RunContinued, and replaceRun

### DIFF
--- a/lib/core/logging/loggers.dart
+++ b/lib/core/logging/loggers.dart
@@ -46,4 +46,7 @@ abstract final class Loggers {
 
   /// Telemetry and backend log shipping events.
   static final telemetry = LogManager.instance.getLogger('Telemetry');
+
+  /// Client-side tool execution orchestration.
+  static final toolExecution = LogManager.instance.getLogger('ToolExecution');
 }

--- a/lib/core/models/run_lifecycle_event.dart
+++ b/lib/core/models/run_lifecycle_event.dart
@@ -23,6 +23,15 @@ class RunStarted extends RunLifecycleEvent {
   const RunStarted({required super.key});
 }
 
+/// Emitted when a run is replaced by a continuation (tool execution loop).
+///
+/// Unlike [RunCompleted], this does NOT trigger unread indicators — the
+/// conversation is still in progress, just starting a new backend run.
+@immutable
+class RunContinued extends RunLifecycleEvent {
+  const RunContinued({required super.key});
+}
+
 /// Emitted when a run reaches a terminal state (success, failure, or cancel).
 @immutable
 class RunCompleted extends RunLifecycleEvent {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -70,10 +70,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -496,14 +496,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -556,18 +548,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: "direct main"
     description:
@@ -982,26 +974,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.29.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.15"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- Add `ExecutingToolsState` sealed subclass to `ActiveRunState` with `isRunning=true`
- Add `RunContinued` lifecycle event for continuation run handoffs
- Add `RunRegistry.replaceRun()` atomic CAS swap (register new before disposing old)
- Add `Loggers.toolExecution` dedicated logger

## Changes
- **active_run_state.dart**: New `ExecutingToolsState` with `conversation`, `pendingTools`, equality, `streaming => AwaitingText()`
- **run_lifecycle_event.dart**: `RunContinued` event (not handled by unread-run logic)
- **run_registry.dart**: `replaceRun()` with disposal error swallowing, `RunContinued` emission
- **loggers.dart**: `Loggers.toolExecution` accessor

## Test plan
- [x] `ExecutingToolsState` equality, hashCode, toString, isRunning, pattern matching (8 tests)
- [x] `replaceRun` happy path, stale handle, disposal errors, disposed registry (5 tests)
- [x] Exhaustive switch updated for new sealed member
- [x] `flutter analyze --fatal-infos` — 0 issues
- [x] Full suite: 1401 tests pass

**Stack:** 3a of 3 → #3b → #3c