### PR TITLE
feat(ui): show tool execution status in StatusIndicator

### DIFF
--- a/lib/features/chat/chat_panel.dart
+++ b/lib/features/chat/chat_panel.dart
@@ -109,9 +109,8 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
                     },
                   ),
 
-                  // Status indicator (above input, shown only when streaming)
-                  if (isStreaming)
-                    StatusIndicator(streaming: runState.streaming),
+                  // Status indicator (above input, shown when running)
+                  if (isStreaming) StatusIndicator(runState: runState),
 
                   // Input
                   ChatInput(

--- a/test/features/chat/widgets/status_indicator_test.dart
+++ b/test/features/chat/widgets/status_indicator_test.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soliplex_client/soliplex_client.dart';
+import 'package:soliplex_client/soliplex_client.dart' as domain show Running;
+import 'package:soliplex_frontend/core/models/active_run_state.dart';
+import 'package:soliplex_frontend/features/chat/widgets/status_indicator.dart';
+
+void main() {
+  group('StatusIndicator', () {
+    Widget buildWidget(ActiveRunState runState) {
+      return MaterialApp(
+        home: Scaffold(
+          body: StatusIndicator(runState: runState),
+        ),
+      );
+    }
+
+    testWidgets('shows "Executing: tool1, tool2" for ExecutingToolsState', (
+      WidgetTester tester,
+    ) async {
+      const state = ExecutingToolsState(
+        conversation: Conversation(
+          threadId: 'thread-1',
+          status: domain.Running(runId: 'run-1'),
+        ),
+        pendingTools: [
+          ToolCallInfo(id: 'tc-1', name: 'search'),
+          ToolCallInfo(id: 'tc-2', name: 'fetch'),
+        ],
+      );
+
+      await tester.pumpWidget(buildWidget(state));
+
+      expect(find.text('Executing: search, fetch'), findsOneWidget);
+    });
+
+    testWidgets('shows "Calling: tool1" for ToolCallActivity in streaming',
+        (WidgetTester tester) async {
+      const state = RunningState(
+        conversation: Conversation(
+          threadId: 'thread-1',
+          status: domain.Running(runId: 'run-1'),
+        ),
+        streaming: AwaitingText(
+          currentActivity: ToolCallActivity(toolName: 'search'),
+        ),
+      );
+
+      await tester.pumpWidget(buildWidget(state));
+
+      expect(find.text('Calling: search'), findsOneWidget);
+    });
+
+    testWidgets('shows "Thinking" for ThinkingActivity',
+        (WidgetTester tester) async {
+      const state = RunningState(
+        conversation: Conversation(
+          threadId: 'thread-1',
+          status: domain.Running(runId: 'run-1'),
+        ),
+        streaming: AwaitingText(currentActivity: ThinkingActivity()),
+      );
+
+      await tester.pumpWidget(buildWidget(state));
+
+      expect(find.text('Thinking'), findsOneWidget);
+    });
+
+    testWidgets('shows "Responding" for RespondingActivity',
+        (WidgetTester tester) async {
+      const state = RunningState(
+        conversation: Conversation(
+          threadId: 'thread-1',
+          status: domain.Running(runId: 'run-1'),
+        ),
+        streaming: TextStreaming(
+          messageId: 'msg-1',
+          user: ChatUser.assistant,
+          text: 'Hello',
+        ),
+      );
+
+      await tester.pumpWidget(buildWidget(state));
+
+      expect(find.text('Responding'), findsOneWidget);
+    });
+
+    testWidgets('shows "Executing: search" for single tool',
+        (WidgetTester tester) async {
+      const state = ExecutingToolsState(
+        conversation: Conversation(
+          threadId: 'thread-1',
+          status: domain.Running(runId: 'run-1'),
+        ),
+        pendingTools: [ToolCallInfo(id: 'tc-1', name: 'search')],
+      );
+
+      await tester.pumpWidget(buildWidget(state));
+
+      expect(find.text('Executing: search'), findsOneWidget);
+    });
+
+    testWidgets('has correct semantics label', (WidgetTester tester) async {
+      const state = ExecutingToolsState(
+        conversation: Conversation(
+          threadId: 'thread-1',
+          status: domain.Running(runId: 'run-1'),
+        ),
+        pendingTools: [ToolCallInfo(id: 'tc-1', name: 'search')],
+      );
+
+      await tester.pumpWidget(buildWidget(state));
+
+      final semantics = tester.getSemantics(find.byType(StatusIndicator));
+      expect(semantics.label, 'Executing: search');
+    });
+
+    testWidgets('shows progress indicator', (WidgetTester tester) async {
+      const state = ExecutingToolsState(
+        conversation: Conversation(
+          threadId: 'thread-1',
+          status: domain.Running(runId: 'run-1'),
+        ),
+        pendingTools: [ToolCallInfo(id: 'tc-1', name: 'search')],
+      );
+
+      await tester.pumpWidget(buildWidget(state));
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Update `StatusIndicator` to accept `ActiveRunState` instead of `StreamingState`
- Show "Executing: tool1, tool2" during client-side tool execution

## Changes
- **status_indicator.dart**: Parameter changed to `ActiveRunState runState`; `ExecutingToolsState` case shows tool names; `excludeSemantics: true` prevents label duplication; extracted `_streamingStatusText` helper
- **chat_panel.dart**: Updated call site: `StatusIndicator(runState: runState)`

## Test plan
- [x] "Executing: search, fetch" for `ExecutingToolsState` with two tools
- [x] "Calling: search" for `ToolCallActivity` in streaming
- [x] "Thinking" for `ThinkingActivity`
- [x] "Responding" for `RespondingActivity`
- [x] "Executing: search" for single tool
- [x] Correct semantics label
- [x] Progress indicator present
- [x] `flutter analyze --fatal-infos` — 0 issues
- [x] Full suite: 1401 tests pass

**Stack:** #349 → #350 → 3c of 3