### PR TITLE
feat(chat): rotate PDF chunk visualization images

### DIFF
--- a/test/features/chat/widgets/chunk_visualization_page_test.dart
+++ b/test/features/chat/widgets/chunk_visualization_page_test.dart
@@ -7,6 +7,11 @@ import 'package:soliplex_frontend/features/chat/widgets/chunk_visualization_page
 
 import '../../../helpers/test_helpers.dart';
 
+/// Minimal valid 1x1 transparent PNG for test images.
+const _base64Png =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk'
+    '+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
 void main() {
   late MockSoliplexApi mockApi;
 
@@ -14,241 +19,379 @@ void main() {
     mockApi = MockSoliplexApi();
   });
 
+  Widget buildPage({
+    String roomId = 'room-1',
+    String chunkId = 'chunk-1',
+    String documentTitle = 'Test Document',
+  }) {
+    return createTestApp(
+      home: ChunkVisualizationPage(
+        roomId: roomId,
+        chunkId: chunkId,
+        documentTitle: documentTitle,
+      ),
+      overrides: [apiProvider.overrideWithValue(mockApi)],
+    );
+  }
+
   group('ChunkVisualizationPage', () {
-    testWidgets('shows loading indicator while fetching', (tester) async {
-      // Never complete the future to keep loading state
-      when(() => mockApi.getChunkVisualization(any(), any()))
-          .thenAnswer((_) => Future.delayed(const Duration(days: 1)));
+    group('loading state', () {
+      testWidgets('shows loading indicator while fetching', (tester) async {
+        when(
+          () => mockApi.getChunkVisualization(any(), any()),
+        ).thenAnswer((_) => Future.delayed(const Duration(days: 1)));
 
-      await tester.pumpWidget(
-        createTestApp(
-          home: const ChunkVisualizationPage(
-            roomId: 'room-1',
-            chunkId: 'chunk-1',
-            documentTitle: 'Test Document',
-          ),
-          overrides: [apiProvider.overrideWithValue(mockApi)],
-        ),
-      );
+        await tester.pumpWidget(buildPage());
 
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
-      expect(find.text('Test Document'), findsOneWidget);
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        expect(find.text('Test Document'), findsOneWidget);
+      });
+
+      testWidgets('hides rotate button during loading', (tester) async {
+        when(
+          () => mockApi.getChunkVisualization(any(), any()),
+        ).thenAnswer((_) => Future.delayed(const Duration(days: 1)));
+
+        await tester.pumpWidget(buildPage());
+
+        expect(find.byIcon(Icons.rotate_right), findsNothing);
+      });
     });
 
-    testWidgets('shows images when loaded successfully', (tester) async {
-      // Use a minimal valid PNG (1x1 transparent pixel)
-      const base64Png =
-          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk'
-          '+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+    group('error state', () {
+      testWidgets('shows error with retry on NotFoundException', (
+        tester,
+      ) async {
+        when(
+          () => mockApi.getChunkVisualization('room-1', 'chunk-1'),
+        ).thenThrow(const NotFoundException(message: 'Chunk not found'));
 
-      when(() => mockApi.getChunkVisualization('room-1', 'chunk-1')).thenAnswer(
-        (_) async => ChunkVisualization(
-          chunkId: 'chunk-1',
-          documentUri: 'doc.pdf',
-          imagesBase64: const [base64Png, base64Png],
-        ),
-      );
+        await tester.pumpWidget(buildPage());
+        await tester.pumpAndSettle();
 
-      await tester.pumpWidget(
-        createTestApp(
-          home: const ChunkVisualizationPage(
-            roomId: 'room-1',
-            chunkId: 'chunk-1',
-            documentTitle: 'Test Document',
-          ),
-          overrides: [apiProvider.overrideWithValue(mockApi)],
-        ),
-      );
+        expect(
+          find.text('Page images not available for this citation.'),
+          findsOneWidget,
+        );
+        expect(find.byIcon(Icons.error_outline), findsOneWidget);
+        expect(find.text('Retry'), findsOneWidget);
+      });
 
-      await tester.pumpAndSettle();
+      testWidgets('shows error with retry on NetworkException', (tester) async {
+        when(
+          () => mockApi.getChunkVisualization('room-1', 'chunk-1'),
+        ).thenThrow(const NetworkException(message: 'Connection failed'));
 
-      // Should show page numbers
-      expect(find.text('Page 1 of 2'), findsOneWidget);
-      expect(find.text('Page 2 of 2'), findsOneWidget);
+        await tester.pumpWidget(buildPage());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Could not connect to server.'), findsOneWidget);
+        expect(find.text('Retry'), findsOneWidget);
+        expect(find.byIcon(Icons.refresh), findsOneWidget);
+      });
+
+      testWidgets('hides rotate button on error', (tester) async {
+        when(
+          () => mockApi.getChunkVisualization('room-1', 'chunk-1'),
+        ).thenThrow(const NetworkException(message: 'Connection failed'));
+
+        await tester.pumpWidget(buildPage());
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.rotate_right), findsNothing);
+      });
     });
 
-    testWidgets('shows empty state when no images', (tester) async {
-      when(() => mockApi.getChunkVisualization('room-1', 'chunk-1')).thenAnswer(
-        (_) async => ChunkVisualization(
-          chunkId: 'chunk-1',
-          documentUri: null,
-          imagesBase64: const [],
-        ),
-      );
-
-      await tester.pumpWidget(
-        createTestApp(
-          home: const ChunkVisualizationPage(
-            roomId: 'room-1',
+    group('empty state', () {
+      testWidgets('shows empty state when no images', (tester) async {
+        when(
+          () => mockApi.getChunkVisualization('room-1', 'chunk-1'),
+        ).thenAnswer(
+          (_) async => ChunkVisualization(
             chunkId: 'chunk-1',
-            documentTitle: 'Test Document',
+            documentUri: null,
+            imagesBase64: const [],
           ),
-          overrides: [apiProvider.overrideWithValue(mockApi)],
-        ),
-      );
+        );
 
-      await tester.pumpAndSettle();
+        await tester.pumpWidget(buildPage());
+        await tester.pumpAndSettle();
 
-      expect(find.text('No page images available.'), findsOneWidget);
-      expect(find.byIcon(Icons.image_not_supported_outlined), findsOneWidget);
+        expect(find.text('No page images available.'), findsOneWidget);
+        expect(find.byIcon(Icons.image_not_supported_outlined), findsOneWidget);
+      });
     });
 
-    testWidgets('shows error state with retry on NotFoundException',
-        (tester) async {
-      when(() => mockApi.getChunkVisualization('room-1', 'chunk-1'))
-          .thenThrow(const NotFoundException(message: 'Chunk not found'));
+    group('AppBar', () {
+      testWidgets('displays document title and PDF icon', (tester) async {
+        when(
+          () => mockApi.getChunkVisualization(any(), any()),
+        ).thenAnswer((_) => Future.delayed(const Duration(days: 1)));
 
-      await tester.pumpWidget(
-        createTestApp(
-          home: const ChunkVisualizationPage(
-            roomId: 'room-1',
+        await tester.pumpWidget(
+          buildPage(documentTitle: 'My Important Document.pdf'),
+        );
+
+        expect(find.text('My Important Document.pdf'), findsOneWidget);
+        expect(find.byIcon(Icons.picture_as_pdf), findsOneWidget);
+      });
+
+      testWidgets('shows rotate button when data is loaded', (tester) async {
+        when(
+          () => mockApi.getChunkVisualization('room-1', 'chunk-1'),
+        ).thenAnswer(
+          (_) async => ChunkVisualization(
             chunkId: 'chunk-1',
-            documentTitle: 'Test Document',
+            documentUri: 'doc.pdf',
+            imagesBase64: const [_base64Png],
           ),
-          overrides: [apiProvider.overrideWithValue(mockApi)],
-        ),
-      );
+        );
 
-      await tester.pumpAndSettle();
+        await tester.pumpWidget(buildPage());
+        await tester.pumpAndSettle();
 
-      expect(
-        find.text('Page images not available for this citation.'),
-        findsOneWidget,
-      );
-      expect(find.byIcon(Icons.error_outline), findsOneWidget);
-      expect(find.text('Retry'), findsOneWidget);
-    });
+        expect(find.byIcon(Icons.rotate_right), findsOneWidget);
+      });
 
-    testWidgets('shows error state with retry on NetworkException',
-        (tester) async {
-      when(() => mockApi.getChunkVisualization('room-1', 'chunk-1'))
-          .thenThrow(const NetworkException(message: 'Connection failed'));
-
-      await tester.pumpWidget(
-        createTestApp(
-          home: const ChunkVisualizationPage(
-            roomId: 'room-1',
+      testWidgets('back button pops the page', (tester) async {
+        when(
+          () => mockApi.getChunkVisualization('room-1', 'chunk-1'),
+        ).thenAnswer(
+          (_) async => ChunkVisualization(
             chunkId: 'chunk-1',
-            documentTitle: 'Test Document',
+            documentUri: null,
+            imagesBase64: const [],
           ),
-          overrides: [apiProvider.overrideWithValue(mockApi)],
-        ),
-      );
+        );
 
-      await tester.pumpAndSettle();
-
-      expect(find.text('Could not connect to server.'), findsOneWidget);
-      expect(find.text('Retry'), findsOneWidget);
-    });
-
-    testWidgets('retry button is present on error', (tester) async {
-      when(() => mockApi.getChunkVisualization('room-1', 'chunk-1'))
-          .thenThrow(const NetworkException(message: 'Connection failed'));
-
-      await tester.pumpWidget(
-        createTestApp(
-          home: const ChunkVisualizationPage(
-            roomId: 'room-1',
-            chunkId: 'chunk-1',
-            documentTitle: 'Test Document',
-          ),
-          overrides: [apiProvider.overrideWithValue(mockApi)],
-        ),
-      );
-
-      await tester.pumpAndSettle();
-
-      // Shows error state with retry button
-      expect(find.text('Could not connect to server.'), findsOneWidget);
-      expect(find.text('Retry'), findsOneWidget);
-      expect(find.byIcon(Icons.refresh), findsOneWidget);
-    });
-
-    testWidgets('back button pops the page', (tester) async {
-      when(() => mockApi.getChunkVisualization('room-1', 'chunk-1')).thenAnswer(
-        (_) async => ChunkVisualization(
-          chunkId: 'chunk-1',
-          documentUri: null,
-          imagesBase64: const [],
-        ),
-      );
-
-      await tester.pumpWidget(
-        createTestApp(
-          home: Builder(
-            builder: (context) => ElevatedButton(
-              onPressed: () => ChunkVisualizationPage.show(
-                context: context,
-                roomId: 'room-1',
-                chunkId: 'chunk-1',
-                documentTitle: 'Test Document',
+        await tester.pumpWidget(
+          createTestApp(
+            home: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () => ChunkVisualizationPage.show(
+                  context: context,
+                  roomId: 'room-1',
+                  chunkId: 'chunk-1',
+                  documentTitle: 'Test Document',
+                ),
+                child: const Text('Open Page'),
               ),
-              child: const Text('Open Page'),
             ),
+            overrides: [apiProvider.overrideWithValue(mockApi)],
           ),
-          overrides: [apiProvider.overrideWithValue(mockApi)],
-        ),
-      );
+        );
 
-      // Open page
-      await tester.tap(find.text('Open Page'));
-      await tester.pumpAndSettle();
+        await tester.tap(find.text('Open Page'));
+        await tester.pumpAndSettle();
 
-      expect(find.byType(ChunkVisualizationPage), findsOneWidget);
+        expect(find.byType(ChunkVisualizationPage), findsOneWidget);
 
-      // Tap back button
-      await tester.tap(find.byIcon(Icons.arrow_back));
-      await tester.pumpAndSettle();
+        await tester.tap(find.byIcon(Icons.arrow_back));
+        await tester.pumpAndSettle();
 
-      expect(find.byType(ChunkVisualizationPage), findsNothing);
+        expect(find.byType(ChunkVisualizationPage), findsNothing);
+      });
     });
 
-    testWidgets('displays document title in app bar', (tester) async {
-      when(() => mockApi.getChunkVisualization(any(), any()))
-          .thenAnswer((_) => Future.delayed(const Duration(days: 1)));
-
-      await tester.pumpWidget(
-        createTestApp(
-          home: const ChunkVisualizationPage(
-            roomId: 'room-1',
+    group('PageView', () {
+      testWidgets('renders PageView with correct item count', (tester) async {
+        when(
+          () => mockApi.getChunkVisualization('room-1', 'chunk-1'),
+        ).thenAnswer(
+          (_) async => ChunkVisualization(
             chunkId: 'chunk-1',
-            documentTitle: 'My Important Document.pdf',
+            documentUri: 'doc.pdf',
+            imagesBase64: const [_base64Png, _base64Png],
           ),
-          overrides: [apiProvider.overrideWithValue(mockApi)],
-        ),
-      );
+        );
 
-      expect(find.text('My Important Document.pdf'), findsOneWidget);
-      expect(find.byIcon(Icons.picture_as_pdf), findsOneWidget);
+        await tester.pumpWidget(buildPage());
+        await tester.pumpAndSettle();
+
+        expect(find.byType(PageView), findsOneWidget);
+      });
+
+      testWidgets('has InteractiveViewer for zoom support', (tester) async {
+        when(
+          () => mockApi.getChunkVisualization('room-1', 'chunk-1'),
+        ).thenAnswer(
+          (_) async => ChunkVisualization(
+            chunkId: 'chunk-1',
+            documentUri: 'doc.pdf',
+            imagesBase64: const [_base64Png],
+          ),
+        );
+
+        await tester.pumpWidget(buildPage());
+        await tester.pumpAndSettle();
+
+        expect(find.byType(InteractiveViewer), findsOneWidget);
+      });
+
+      testWidgets('swiping changes page', (tester) async {
+        when(
+          () => mockApi.getChunkVisualization('room-1', 'chunk-1'),
+        ).thenAnswer(
+          (_) async => ChunkVisualization(
+            chunkId: 'chunk-1',
+            documentUri: 'doc.pdf',
+            imagesBase64: const [_base64Png, _base64Png],
+          ),
+        );
+
+        await tester.pumpWidget(buildPage());
+        await tester.pumpAndSettle();
+
+        final pageView = tester.widget<PageView>(find.byType(PageView));
+        expect(pageView.controller!.page, 0);
+
+        // Use controller to jump (drag is intercepted by gesture arena).
+        pageView.controller!.jumpToPage(1);
+        await tester.pumpAndSettle();
+
+        expect(pageView.controller!.page, 1);
+      });
     });
 
-    testWidgets('has InteractiveViewer for zoom support', (tester) async {
-      const base64Png =
-          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk'
-          '+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
-
-      when(() => mockApi.getChunkVisualization('room-1', 'chunk-1')).thenAnswer(
-        (_) async => ChunkVisualization(
-          chunkId: 'chunk-1',
-          documentUri: 'doc.pdf',
-          imagesBase64: const [base64Png],
-        ),
-      );
-
-      await tester.pumpWidget(
-        createTestApp(
-          home: const ChunkVisualizationPage(
-            roomId: 'room-1',
+    group('dot indicator', () {
+      testWidgets('shows dots for multi-page', (tester) async {
+        when(
+          () => mockApi.getChunkVisualization('room-1', 'chunk-1'),
+        ).thenAnswer(
+          (_) async => ChunkVisualization(
             chunkId: 'chunk-1',
-            documentTitle: 'Test Document',
+            documentUri: 'doc.pdf',
+            imagesBase64: const [_base64Png, _base64Png],
           ),
-          overrides: [apiProvider.overrideWithValue(mockApi)],
-        ),
-      );
+        );
 
-      await tester.pumpAndSettle();
+        await tester.pumpWidget(buildPage());
+        await tester.pumpAndSettle();
 
-      expect(find.byType(InteractiveViewer), findsOneWidget);
+        expect(find.bySemanticsLabel('Page 1 of 2'), findsOneWidget);
+      });
+
+      testWidgets('hides dots for single-page', (tester) async {
+        when(
+          () => mockApi.getChunkVisualization('room-1', 'chunk-1'),
+        ).thenAnswer(
+          (_) async => ChunkVisualization(
+            chunkId: 'chunk-1',
+            documentUri: 'doc.pdf',
+            imagesBase64: const [_base64Png],
+          ),
+        );
+
+        await tester.pumpWidget(buildPage());
+        await tester.pumpAndSettle();
+
+        expect(find.bySemanticsLabel(RegExp(r'Page \d+ of \d+')), findsNothing);
+      });
+    });
+
+    group('rotation', () {
+      testWidgets('tapping rotate cycles RotatedBox quarterTurns', (
+        tester,
+      ) async {
+        when(
+          () => mockApi.getChunkVisualization('room-1', 'chunk-1'),
+        ).thenAnswer(
+          (_) async => ChunkVisualization(
+            chunkId: 'chunk-1',
+            documentUri: 'doc.pdf',
+            imagesBase64: const [_base64Png],
+          ),
+        );
+
+        await tester.pumpWidget(buildPage());
+        await tester.pumpAndSettle();
+
+        RotatedBox rotatedBox() =>
+            tester.widget<RotatedBox>(find.byType(RotatedBox));
+
+        expect(rotatedBox().quarterTurns, 0);
+
+        await tester.tap(find.byIcon(Icons.rotate_right));
+        await tester.pumpAndSettle();
+        expect(rotatedBox().quarterTurns, 1);
+
+        await tester.tap(find.byIcon(Icons.rotate_right));
+        await tester.pumpAndSettle();
+        expect(rotatedBox().quarterTurns, 2);
+
+        await tester.tap(find.byIcon(Icons.rotate_right));
+        await tester.pumpAndSettle();
+        expect(rotatedBox().quarterTurns, 3);
+
+        // Wraps back to 0.
+        await tester.tap(find.byIcon(Icons.rotate_right));
+        await tester.pumpAndSettle();
+        expect(rotatedBox().quarterTurns, 0);
+      });
+
+      testWidgets('rotation is per-page', (tester) async {
+        when(
+          () => mockApi.getChunkVisualization('room-1', 'chunk-1'),
+        ).thenAnswer(
+          (_) async => ChunkVisualization(
+            chunkId: 'chunk-1',
+            documentUri: 'doc.pdf',
+            imagesBase64: const [_base64Png, _base64Png],
+          ),
+        );
+
+        await tester.pumpWidget(buildPage());
+        await tester.pumpAndSettle();
+
+        // Rotate page 1.
+        await tester.tap(find.byIcon(Icons.rotate_right));
+        await tester.pumpAndSettle();
+
+        final firstRotation = tester.widget<RotatedBox>(
+          find.byType(RotatedBox),
+        );
+        expect(firstRotation.quarterTurns, 1);
+
+        // Navigate to page 2 via controller.
+        final pageView = tester.widget<PageView>(find.byType(PageView));
+        pageView.controller!.jumpToPage(1);
+        await tester.pumpAndSettle();
+
+        // Page 2 should be unrotated.
+        final secondRotation = tester.widget<RotatedBox>(
+          find.byType(RotatedBox),
+        );
+        expect(secondRotation.quarterTurns, 0);
+      });
+    });
+
+    group('zoom gestures', () {
+      testWidgets('double-tap resets zoom', (tester) async {
+        when(
+          () => mockApi.getChunkVisualization('room-1', 'chunk-1'),
+        ).thenAnswer(
+          (_) async => ChunkVisualization(
+            chunkId: 'chunk-1',
+            documentUri: 'doc.pdf',
+            imagesBase64: const [_base64Png],
+          ),
+        );
+
+        await tester.pumpWidget(buildPage());
+        await tester.pumpAndSettle();
+
+        // Find the GestureDetector wrapping InteractiveViewer.
+        final gestureDetector = find.byWidgetPredicate(
+          (w) => w is GestureDetector && w.onDoubleTap != null,
+        );
+        expect(gestureDetector, findsOneWidget);
+
+        // Double-tap should not crash.
+        await tester.tap(gestureDetector);
+        await tester.pump(const Duration(milliseconds: 50));
+        await tester.tap(gestureDetector);
+        await tester.pumpAndSettle();
+      });
     });
   });
 }


### PR DESCRIPTION
## Summary
- Replace vertical Column + single InteractiveViewer with horizontal PageView carousel
- Add per-image rotation via AppBar rotate button (client-side RotatedBox)
- Pinch-to-zoom with TransformationController, double-tap to reset zoom
- Dot page indicator with Semantics accessibility label
- Disable PageView swiping when zoomed (panEnabled toggle + NeverScrollableScrollPhysics)

## Changes
- **chunk_visualization_page.dart**: ConsumerWidget → ConsumerStatefulWidget with PageView.builder, per-page rotation state, TransformationController with deduplicated listener, GestureDetector double-tap reset, cached base64 decode, null-safe image fallback, _DotIndicator widget
- **chunk_visualization_page_test.dart**: Expanded from 6 → 17 tests covering rotation, PageView, dot indicator, zoom gestures, AppBar state, edge cases

## Test plan
- [x] `flutter analyze --fatal-infos` — 0 issues on both files
- [x] `flutter test` — 17/17 tests passing
- [ ] Manual: verify rotate button cycles image 90° on each tap
- [ ] Manual: verify pinch-to-zoom works, double-tap resets
- [ ] Manual: verify page swiping between multi-page chunks
- [ ] Manual: verify dot indicator updates on swipe

Closes #200