### PR TITLE
feat(chat): tappable dot indicator, page numbers, and UX polish

### DIFF
--- a/lib/features/chat/widgets/citations_section.dart
+++ b/lib/features/chat/widgets/citations_section.dart
@@ -393,6 +393,7 @@ class _PdfViewButton extends ConsumerWidget {
         roomId: roomId,
         chunkId: sourceReference.chunkId,
         documentTitle: sourceReference.displayTitle,
+        pageNumbers: sourceReference.pageNumbers,
       ),
       tooltip: 'View page',
       visualDensity: VisualDensity.compact,


### PR DESCRIPTION
## Summary
- **Tappable dots**: Dot page indicator now responds to taps, navigating to the selected page with animated transition (300ms ease-in-out). Essential for desktop/web where swiping is awkward.
- **Actual PDF page numbers**: AppBar displays real page numbers (e.g. `53 / 56`) instead of `1 / 4` when `pageNumbers` are available from the citation source reference.
- **Centered & larger dots**: Dots are now centered horizontally and enlarged (10px, up from 8px) with better spacing for easier click targets.

## Changes
- **`chunk_visualization_page.dart`**: Added `pageNumbers` param, `_pageLabel()` helper, `onPageTap` callback on `_DotIndicator`, `Center` wrapper, larger dots (10x10)
- **`citations_section.dart`**: Pass `sourceReference.pageNumbers` to `ChunkVisualizationPage.show()`
- **`chunk_visualization_page_test.dart`**: +5 new tests (tappable dots, page number display, actual PDF page numbers, single-page hidden label)

## Test plan
- [x] 21 widget tests pass
- [x] `flutter analyze --fatal-infos` — 0 issues
- [x] `dart format` — 0 changes
- [x] Manual: tapped dots navigate pages on macOS desktop
- [x] Manual: AppBar shows actual PDF page numbers (e.g. 53/56)
- [x] Manual: dots centered and visually larger

🤖 Generated with [Claude Code](https://claude.com/claude-code)