### PR TITLE
chore(deps): bump connectivity_plus from 6.1.5 to 7.0.0

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -126,10 +126,10 @@ packages:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: b5e72753cf63becce2c61fd04dfe0f1c430cc5278b53a1342dc5ad839eab29ec
+      sha256: "33bae12a398f841c6cda09d1064212957265869104c478e5ad51e2fb26c3973c"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.5"
+    version: "7.0.0"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   flutter: '>=3.35.0'
 
 dependencies:
-  connectivity_plus: ^6.1.4
+  connectivity_plus: ^7.0.0
   cupertino_icons: ^1.0.8
   device_info_plus: ^12.3.0
   flutter:


### PR DESCRIPTION
## Summary

- Bump `connectivity_plus` from 6.1.5 to 7.0.0 (major version)

## Changes

- **`pubspec.yaml`**: `^6.1.4` -> `^7.0.0`
- **`pubspec.lock`**: resolved to 7.0.0

No breaking API changes — our usage (`Connectivity()`, `ConnectivityResult`, `checkConnectivity()`, `onConnectivityChanged`) across 6 files is unchanged in this major version.

## Test plan

- [x] `flutter analyze --fatal-infos` — 0 issues
- [x] `flutter test` — 1371 tests pass
- [ ] CI passes

Supersedes Dependabot #288.