### PR TITLE
chore(ci): speed up lint and test jobs

### DIFF
--- a/.github/workflows/flutter.yaml
+++ b/.github/workflows/flutter.yaml
@@ -6,14 +6,12 @@ on:
     paths-ignore:
       - "docs/**"
       - "**.md"
-      - ".markdownlint.json"
       - "LICENSE"
   pull_request:
     branches: [main, 'feat/**', 'fix/**', 'refactor/**', 'chore/**']
     paths-ignore:
       - "docs/**"
       - "**.md"
-      - ".markdownlint.json"
       - "LICENSE"
   workflow_dispatch:
 
@@ -48,12 +46,18 @@ jobs:
 
       - name: Check documentation
         run: |
-          dart doc --dry-run
+          pids=()
+          dart doc --dry-run &
+          pids+=($!)
           for dir in packages/*/; do
-            echo "::group::dart doc $dir"
-            (cd "$dir" && dart doc --dry-run)
-            echo "::endgroup::"
+            (cd "$dir" && dart doc --dry-run) &
+            pids+=($!)
           done
+          fail=0
+          for pid in "${pids[@]}"; do
+            wait "$pid" || fail=1
+          done
+          exit $fail
 
       - name: Lint markdown
         run: |
@@ -113,11 +117,13 @@ jobs:
           echo "::error::Tests failed with ordering seed: $SEED"
           echo "Reproduce with: --test-randomize-ordering-seed=$SEED"
 
+      - name: Install lcov
+        if: matrix.target.name == 'app'
+        uses: hrishikesh-kadam/setup-lcov@v1
+
       - name: Check coverage threshold
         if: matrix.target.name == 'app'
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq lcov
           COVERAGE=$(lcov --summary coverage/lcov.info 2>&1 \
             | grep "lines" | sed 's/.*: \([0-9.]*\)%.*/\1/')
           echo "Coverage: ${COVERAGE}%"

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,9 +1,0 @@
-{
-  "default": true,
-  "MD013": false,
-  "MD024": false,
-  "MD033": false,
-  "MD036": false,
-  "MD041": false,
-  "MD060": false
-}

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,5 +1,0 @@
-ios/Pods/
-macos/Pods/
-.dart_tool/
-build/
-node_modules/


### PR DESCRIPTION
## Summary
- Parallelize `dart doc --dry-run` across root + all packages (~65s -> ~20s)
- Replace `sudo apt-get install lcov` with cached `hrishikesh-kadam/setup-lcov@v1` (saves ~24s per run)
- Remove stale `.markdownlint.json` and `.markdownlintignore` (replaced by pymarkdown in #354)

## Changes
- **`.github/workflows/flutter.yaml`**: Parallel dart doc via background processes + wait; swap apt-get lcov for setup-lcov action; remove `.markdownlint.json` from paths-ignore
- **`.markdownlint.json`**: Deleted (stale Node.js markdownlint config)
- **`.markdownlintignore`**: Deleted (stale Node.js markdownlint ignore)

## Test plan
- [x] Pre-commit hooks pass (yaml, analyze, secrets)
- [ ] CI lint job passes with parallel dart doc
- [ ] CI test (app) job passes with cached lcov
- [ ] Estimated ~45s faster per CI run