### PR TITLE
fix(chat): thinking section — always collapsed, fixed height, copy button

### DIFF
--- a/test/features/chat/widgets/chat_message_widget_test.dart
+++ b/test/features/chat/widgets/chat_message_widget_test.dart
@@ -950,5 +950,115 @@ void main() {
         expect(capturedReason, isNull);
       });
     });
+
+    group('ThinkingSection', () {
+      Widget buildThinkingSection({
+        String thinkingText = 'Some reasoning',
+        bool isStreaming = false,
+      }) {
+        return createTestApp(
+          home: Scaffold(
+            body: ThinkingSection(
+              thinkingText: thinkingText,
+              isStreaming: isStreaming,
+            ),
+          ),
+        );
+      }
+
+      testWidgets('starts collapsed', (tester) async {
+        await tester.pumpWidget(
+          buildThinkingSection(thinkingText: 'Hidden reasoning'),
+        );
+
+        expect(find.text('Thinking'), findsOneWidget);
+        expect(find.text('Hidden reasoning'), findsNothing);
+      });
+
+      testWidgets('stays collapsed when streaming', (tester) async {
+        await tester.pumpWidget(
+          buildThinkingSection(isStreaming: true),
+        );
+
+        expect(find.text('Thinking'), findsOneWidget);
+        expect(find.text('Some reasoning'), findsNothing);
+      });
+
+      testWidgets('expands when header is tapped', (tester) async {
+        await tester.pumpWidget(
+          buildThinkingSection(thinkingText: 'Visible reasoning'),
+        );
+
+        expect(find.text('Visible reasoning'), findsNothing);
+
+        await tester.tap(find.text('Thinking'));
+        await tester.pump();
+
+        expect(find.text('Visible reasoning'), findsOneWidget);
+      });
+
+      testWidgets('collapses when header is tapped again', (tester) async {
+        await tester.pumpWidget(
+          buildThinkingSection(thinkingText: 'Toggle me'),
+        );
+
+        // Expand
+        await tester.tap(find.text('Thinking'));
+        await tester.pump();
+        expect(find.text('Toggle me'), findsOneWidget);
+
+        // Collapse
+        await tester.tap(find.text('Thinking'));
+        await tester.pump();
+        expect(find.text('Toggle me'), findsNothing);
+      });
+
+      testWidgets('shows copy icon in header', (tester) async {
+        await tester.pumpWidget(
+          buildThinkingSection(),
+        );
+
+        expect(
+          find.descendant(
+            of: find.byType(ThinkingSection),
+            matching: find.byIcon(Icons.copy),
+          ),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets(
+        'copy icon changes to check on tap and reverts after 2 seconds',
+        (tester) async {
+          await tester.pumpWidget(
+            buildThinkingSection(thinkingText: 'Copy this'),
+          );
+
+          final copyFinder = find.descendant(
+            of: find.byType(ThinkingSection),
+            matching: find.byIcon(Icons.copy),
+          );
+          final checkFinder = find.descendant(
+            of: find.byType(ThinkingSection),
+            matching: find.byIcon(Icons.check),
+          );
+
+          expect(copyFinder, findsOneWidget);
+          expect(checkFinder, findsNothing);
+
+          await tester.tap(copyFinder);
+          await tester.pump();
+
+          expect(copyFinder, findsNothing);
+          expect(checkFinder, findsOneWidget);
+
+          // After 2 seconds, reverts
+          await tester.pump(const Duration(seconds: 2));
+
+          expect(copyFinder, findsOneWidget);
+          expect(checkFinder, findsNothing);
+        },
+      );
+    });
   });
 }

--- a/test/helpers/test_helpers.dart
+++ b/test/helpers/test_helpers.dart
@@ -397,12 +397,14 @@ class TestData {
     ChatUser user = ChatUser.user,
     String text = 'Test message',
     bool isStreaming = false,
+    String thinkingText = '',
   }) {
     return TextMessage.create(
       id: id,
       user: user,
       text: text,
       isStreaming: isStreaming,
+      thinkingText: thinkingText,
     );
   }
 


### PR DESCRIPTION
## Summary
- ThinkingSection now always starts collapsed — users expand manually when they want to read reasoning
- Expanded content capped at 200px with scroll overflow
- Copy icon in header swaps to checkmark for 2s on success; failures logged silently (no snackbar)

## Test plan
- [x] 6 new widget tests for ThinkingSection behavior
- [x] All 45 existing + new tests pass
- [x] `dart format` clean
- [x] `flutter analyze --fatal-infos` clean
- [x] Manual: verify thinking section starts collapsed during streaming
- [x] Manual: verify copy icon feedback animation
- [x] Manual: verify scroll on long thinking content

🤖 Generated with [Claude Code](https://claude.com/claude-code)