### PR TITLE
fix: feedback modal to be Text Area (multi-line text field)

### DIFF
--- a/lib/features/chat/widgets/feedback_reason_dialog.dart
+++ b/lib/features/chat/widgets/feedback_reason_dialog.dart
@@ -28,7 +28,6 @@ class _FeedbackReasonDialogState extends State<FeedbackReasonDialog> {
         controller: _controller,
         autofocus: true,
         maxLines: 5,
-        minLines: 1,
         decoration: const InputDecoration(
           hintText: 'Add a reason (optional)',
         ),


### PR DESCRIPTION
# Summary

Feedback modal to be a multiline text field
