### PR TITLE
feat(web): add loading progress bar for WASM download

### DIFF
--- a/web/flutter_bootstrap.js
+++ b/web/flutter_bootstrap.js
@@ -1,0 +1,41 @@
+{{flutter_js}}
+{{flutter_build_config}}
+
+const bar = document.getElementById('progress-bar');
+const status = document.getElementById('loading-status');
+let progress = 0;
+
+function setProgress(value) {
+  progress = value;
+  if (bar) bar.style.width = progress + '%';
+}
+
+function setStatus(text) {
+  if (status) status.textContent = text;
+}
+
+const trickle = setInterval(() => {
+  if (progress < 85) {
+    setProgress(progress + (85 - progress) * 0.04);
+  }
+}, 200);
+
+_flutter.loader.load({
+  onEntrypointLoaded: async function (engineInitializer) {
+    try {
+      setStatus('Initializing...');
+      setProgress(90);
+
+      const appRunner = await engineInitializer.initializeEngine();
+
+      setStatus('Starting...');
+      setProgress(95);
+
+      await appRunner.runApp();
+
+      setProgress(100);
+    } finally {
+      clearInterval(trickle);
+    }
+  },
+});

--- a/web/index.html
+++ b/web/index.html
@@ -89,11 +89,53 @@
       bottom: 0;
       right: 0;
     }
+
+    #loading-status {
+      position: fixed;
+      bottom: 32px;
+      left: 0;
+      right: 0;
+      text-align: center;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      font-size: 13px;
+      color: #AAAAAA;
+      letter-spacing: 0.02em;
+    }
+
+    #progress-track {
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      height: 3px;
+      background: #333333;
+    }
+
+    #progress-bar {
+      height: 100%;
+      width: 0%;
+      background: #FAFAFA;
+      transition: width 0.4s ease-out;
+    }
+
+    @media (prefers-color-scheme: light) {
+      #loading-status {
+        color: #717182;
+      }
+      #progress-track {
+        background: #E9EBEF;
+      }
+      #progress-bar {
+        background: #030213;
+      }
+    }
   </style>
   <script id="splash-screen-script">
     function removeSplashFromWeb() {
       document.getElementById("splash")?.remove();
       document.getElementById("splash-branding")?.remove();
+      document.getElementById("loading-status")?.remove();
+      document.getElementById("progress-track")?.remove();
       document.body.style.background = "transparent";
     }
   </script>
@@ -104,7 +146,8 @@
       <source srcset="splash/img/dark-1x.png 1x, splash/img/dark-2x.png 2x, splash/img/dark-3x.png 3x, splash/img/dark-4x.png 4x" media="(prefers-color-scheme: dark)">
       <img class="center" aria-hidden="true" src="splash/img/light-1x.png" alt="">
   </picture>
-  
+  <div id="loading-status">Loading...</div>
+  <div id="progress-track"><div id="progress-bar"></div></div>
   <!--
     You can customize the "flutter_bootstrap.js" script.
     This is useful to provide a custom configuration to the Flutter loader

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -3,7 +3,7 @@
     "short_name": "Soliplex",
     "start_url": ".",
     "display": "standalone",
-    "background_color": "#0175C2",
+    "background_color": "#424242",
     "theme_color": "#0175C2",
     "description": "A new Flutter project.",
     "orientation": "portrait-primary",


### PR DESCRIPTION
## Summary
- Adds a trickle progress bar + phase status text to the web splash screen so users see feedback during the 30+ second WASM binary download
- Fixes `manifest.json` background_color mismatch (`#0175C2` → `#424242`) to prevent blue flash

## Changes
- **web/index.html**: Added CSS for progress track/bar (3px, fixed bottom) and status text with dark/light theme support via `prefers-color-scheme`. Updated `removeSplashFromWeb()` to clean up loading UI.
- **web/flutter_bootstrap.js**: New custom bootstrap with trickle interval (asymptotic toward 85%), `onEntrypointLoaded` hook driving phases: "Loading..." → "Initializing..." (90%) → "Starting..." (95%) → 100% snap. `try/finally` ensures interval cleanup on errors.
- **web/manifest.json**: Fixed `background_color` to match splash background.

## Test plan
- [x] `flutter build web --wasm` succeeds with custom bootstrap
- [x] Progress bar visible and animates on page load
- [x] Status text cycles through phases correctly
- [x] Bar snaps to 100% and loading UI disappears when app renders
- [x] Dark and light `prefers-color-scheme` both styled correctly
- [x] `flutter analyze --fatal-infos` — 0 issues
- [x] `flutter test` — all 1440 tests pass

Closes #363