### PR TITLE
fix(rooms): invalidate room list cache on screen visit

### DIFF
--- a/test/features/rooms/rooms_screen_test.dart
+++ b/test/features/rooms/rooms_screen_test.dart
@@ -14,6 +14,31 @@ import '../../helpers/test_helpers.dart';
 
 void main() {
   group('RoomsScreen', () {
+    testWidgets('shows fresh data, not stale cache', (tester) async {
+      var fetchCount = 0;
+
+      await tester.pumpWidget(
+        createTestApp(
+          home: const RoomsScreen(),
+          onContainerCreated: (container) {
+            container.read(roomsProvider);
+          },
+          overrides: [
+            roomsProvider.overrideWith((ref) async {
+              fetchCount++;
+              return fetchCount == 1
+                  ? [TestData.createRoom(id: 'stale', name: 'Stale')]
+                  : [TestData.createRoom(id: 'fresh', name: 'Fresh')];
+            }),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Fresh'), findsOneWidget);
+      expect(find.text('Stale'), findsNothing);
+    });
+
     testWidgets('displays loading indicator while fetching', (tester) async {
       // Use a completer to control when the async operation completes
       final completer = Completer<List<Room>>();


### PR DESCRIPTION
## Summary
- Fix stale room list after server restart by invalidating `roomsProvider` on every `RoomsScreen` mount
- Localize search state (`filteredRoomsProvider`, `roomSearchQueryProvider`) to widget state — search is ephemeral UI, not global
- 2 global providers removed; `rooms_provider.dart` untouched

## Test plan
- [x] New test: "shows fresh data, not stale cache" — pre-caches stale data, verifies screen displays fresh fetch
- [x] All 1535 existing tests pass
- [x] `dart format`, `flutter analyze` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)