### PR TITLE
feat(http): send X-Monty-Version header on AG-UI connections (S4)

### DIFF
--- a/lib/core/constants/monty_bridge.dart
+++ b/lib/core/constants/monty_bridge.dart
@@ -1,0 +1,9 @@
+/// Monty bridge protocol version.
+///
+/// Sent as the [montyVersionHeader] header on AG-UI SSE connections.
+/// The backend uses this to gate which auto-generated monty skills are
+/// included in the agent context.
+const int montyBridgeVersion = 1;
+
+/// HTTP header name for the monty bridge version.
+const String montyVersionHeader = 'X-Monty-Version';

--- a/lib/core/providers/api_provider.dart
+++ b/lib/core/providers/api_provider.dart
@@ -3,6 +3,7 @@ import 'package:http/http.dart' as http;
 import 'package:soliplex_client/soliplex_client.dart';
 import 'package:soliplex_client_native/soliplex_client_native.dart';
 import 'package:soliplex_frontend/core/auth/auth_provider.dart';
+import 'package:soliplex_frontend/core/constants/monty_bridge.dart';
 import 'package:soliplex_frontend/core/logging/loggers.dart';
 import 'package:soliplex_frontend/core/providers/config_provider.dart';
 import 'package:soliplex_frontend/core/providers/http_log_provider.dart';
@@ -241,6 +242,9 @@ final agUiClientProvider = Provider<AgUiClient>((ref) {
       baseUrl: '${config.baseUrl}/api/v1',
       requestTimeout: const Duration(seconds: 600),
       connectionTimeout: const Duration(seconds: 600),
+      defaultHeaders: const {
+        montyVersionHeader: '$montyBridgeVersion',
+      },
     ),
     httpClient: protectedClient,
   );

--- a/test/core/providers/api_provider_test.dart
+++ b/test/core/providers/api_provider_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:soliplex_client/soliplex_client.dart';
+import 'package:soliplex_frontend/core/constants/monty_bridge.dart';
 import 'package:soliplex_frontend/core/models/app_config.dart';
 import 'package:soliplex_frontend/core/providers/api_provider.dart';
 import 'package:soliplex_frontend/core/providers/config_provider.dart';
@@ -342,6 +343,22 @@ void main() {
 
       expect(registry.toolDefinitions, hasLength(1));
       expect(registry.toolDefinitions.first.name, equals('test_tool'));
+    });
+  });
+
+  group('agUiClientProvider', () {
+    test('includes X-Monty-Version header in default headers', () {
+      final container = createContainerWithMockedAuth();
+      addTearDown(container.dispose);
+
+      final client = container.read(agUiClientProvider);
+
+      // AgUiClient._buildHeaders() merges config.defaultHeaders into every
+      // request. Verify the monty version header is present and correct.
+      expect(
+        client.config.defaultHeaders,
+        containsPair(montyVersionHeader, '$montyBridgeVersion'),
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- Add `montyBridgeVersion` and `montyVersionHeader` constants to `lib/core/constants/monty_bridge.dart`
- Inject `X-Monty-Version: 1` header into `AgUiClientConfig.defaultHeaders` in `agUiClientProvider`
- Backend uses this header to gate which auto-generated monty skills are included in agent context

## Changes
- **lib/core/constants/monty_bridge.dart**: New file — protocol version constant and header name
- **lib/core/providers/api_provider.dart**: Pass monty version header via `defaultHeaders` on `AgUiClientConfig`
- **test/core/providers/api_provider_test.dart**: Test verifying header is present in `client.config.defaultHeaders`

## Test plan
- [x] `flutter analyze --fatal-infos` — 0 issues
- [x] `dart format .` — no changes
- [x] `flutter test test/core/providers/api_provider_test.dart` — 22 tests pass
- [x] Pre-commit hooks pass (format, analyze, secrets)
- [x] Slice review approved by Gemini principal engineer

## Context
Part of the monty skills bridge (S2–S4). Pairs with backend S3 (`monty_capabilities.py`) which reads this header to filter skills.