### PR TITLE
fix(tools): wire tool definitions + harden failure handling

### DIFF
--- a/lib/core/providers/active_run_notifier.dart
+++ b/lib/core/providers/active_run_notifier.dart
@@ -202,11 +202,14 @@ class ActiveRunNotifier extends Notifier<ActiveRunState> {
       }
 
       // Create the input for the run
+      final tools =
+          _toolRegistry.isEmpty ? null : _toolRegistry.toolDefinitions;
       final input = SimpleRunAgentInput(
         threadId: threadId,
         runId: runId,
         messages: aguiMessages,
         state: mergedState,
+        tools: tools,
       );
 
       // Start streaming
@@ -392,16 +395,12 @@ class ActiveRunNotifier extends Notifier<ActiveRunState> {
     );
 
     final handleState = handle.state;
-    if (handleState is RunningState) {
+    if (handleState is RunningState || handleState is ExecutingToolsState) {
       final errorMsg = error.toString();
-      final completed = CompletedState(
-        conversation: handleState.conversation.withStatus(
-          domain.Failed(error: errorMsg),
-        ),
-        result: FailedResult(errorMessage: errorMsg, stackTrace: stackTrace),
+      _abortToCompleted(
+        handle,
+        FailedResult(errorMessage: errorMsg, stackTrace: stackTrace),
       );
-      _registry.completeRun(handle, completed);
-      _syncUiState(handle, completed);
     }
   }
 
@@ -564,11 +563,14 @@ class ActiveRunNotifier extends Notifier<ActiveRunState> {
       final endpoint =
           'rooms/${handle.key.roomId}/agui/${handle.key.threadId}/${runInfo.id}';
 
+      final tools =
+          _toolRegistry.isEmpty ? null : _toolRegistry.toolDefinitions;
       final input = SimpleRunAgentInput(
         threadId: handle.key.threadId,
         runId: runInfo.id,
         messages: aguiMessages,
         state: conversation.aguiState,
+        tools: tools,
       );
 
       // Start streaming the continuation.

--- a/lib/features/history/history_panel.dart
+++ b/lib/features/history/history_panel.dart
@@ -79,9 +79,9 @@ class HistoryPanel extends ConsumerWidget {
 
         // Get active run state to show indicators
         final activeRunState = ref.watch(activeRunNotifierProvider);
-        // Extract threadId from running state (only RunningState has threadId)
         final activeThreadId = switch (activeRunState) {
           RunningState(:final threadId) => threadId,
+          ExecutingToolsState(:final threadId) => threadId,
           _ => null,
         };
         final currentThreadId = ref.watch(currentThreadIdProvider);

--- a/test/core/providers/active_run_notifier_tool_call_test.dart
+++ b/test/core/providers/active_run_notifier_tool_call_test.dart
@@ -554,6 +554,99 @@ void main() {
       });
     });
 
+    group('tools param', () {
+      test('startRun passes tool definitions in SimpleRunAgentInput', () async {
+        final toolRegistry = buildRegistry({
+          'search': (_) async => 'result',
+        });
+
+        SimpleRunAgentInput? capturedInput;
+        fakeAgUiClient.onRunAgent = (endpoint, input) {
+          capturedInput ??= input;
+          return buildMockEventStream(textResponseEvents());
+        };
+
+        stubCreateRun();
+
+        final container = createContainer(toolRegistry: toolRegistry);
+        addTearDown(container.dispose);
+
+        await container.read(activeRunNotifierProvider.notifier).startRun(
+          key: (roomId: 'room-1', threadId: 'thread-1'),
+          userMessage: 'Search',
+        );
+
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        expect(capturedInput, isNotNull);
+        expect(capturedInput!.tools, isNotNull);
+        expect(capturedInput!.tools, hasLength(1));
+        expect(capturedInput!.tools!.first.name, 'search');
+      });
+
+      test('continuation run passes tool definitions in SimpleRunAgentInput',
+          () async {
+        final toolRegistry = buildRegistry({
+          'search': (_) async => 'result',
+        });
+
+        final capturedInputs = <SimpleRunAgentInput>[];
+        var runCallCount = 0;
+        fakeAgUiClient.onRunAgent = (endpoint, input) {
+          capturedInputs.add(input);
+          runCallCount++;
+          if (runCallCount == 1) {
+            return buildMockEventStream(toolCallEvents());
+          }
+          return buildMockEventStream(textResponseEvents());
+        };
+
+        stubCreateRun();
+
+        final container = createContainer(toolRegistry: toolRegistry);
+        addTearDown(container.dispose);
+
+        await container.read(activeRunNotifierProvider.notifier).startRun(
+          key: (roomId: 'room-1', threadId: 'thread-1'),
+          userMessage: 'Search for dart',
+        );
+
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+
+        expect(capturedInputs, hasLength(2));
+
+        // Both initial and continuation should have tools.
+        for (final input in capturedInputs) {
+          expect(input.tools, isNotNull);
+          expect(input.tools, hasLength(1));
+          expect(input.tools!.first.name, 'search');
+        }
+      });
+
+      test('empty registry does not pass tools', () async {
+        SimpleRunAgentInput? capturedInput;
+        fakeAgUiClient.onRunAgent = (endpoint, input) {
+          capturedInput ??= input;
+          return buildMockEventStream(textResponseEvents());
+        };
+
+        stubCreateRun();
+
+        final container = createContainer();
+        addTearDown(container.dispose);
+
+        await container.read(activeRunNotifierProvider.notifier).startRun(
+          key: (roomId: 'room-1', threadId: 'thread-1'),
+          userMessage: 'No tools',
+        );
+
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        expect(capturedInput, isNotNull);
+        expect(capturedInput!.tools, isNull);
+      });
+    });
+
     group('state transitions', () {
       test('ExecutingToolsState.isRunning is true', () {
         const conversation = Conversation(


### PR DESCRIPTION
## Summary
- Wire `tools: toolRegistry.toolDefinitions` in `SimpleRunAgentInput` for both `startRun` and continuation runs so backend knows available client-side tools
- Fix `_handleFailureForRun` to handle `ExecutingToolsState` via `_abortToCompleted` (was only handling `RunningState`)
- Show active thread indicator in history panel during `ExecutingToolsState`

## Changes
- **active_run_notifier.dart**: Pass tools param in both initial and continuation `SimpleRunAgentInput`; use `_abortToCompleted` in `_handleFailureForRun` for both `RunningState` and `ExecutingToolsState`
- **history_panel.dart**: Add `ExecutingToolsState(:final threadId)` case to active thread detection
- **active_run_notifier_tool_call_test.dart**: 3 new tests — tools param in initial run, continuation run, and empty registry

## Test plan
- [x] 18/18 tool call orchestration tests pass (15 existing + 3 new)
- [x] 169 related tests pass (model, registry, notifier, status indicator)
- [x] 10 history panel tests pass
- [x] `flutter analyze --fatal-infos` — 0 issues on changed files
- [x] Gemini 3.1 Pro adversarial review — approved