### PR TITLE
fix(deps): use soliplex fork of wakelock_plus

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1117,10 +1117,11 @@ packages:
   wakelock_plus:
     dependency: "direct main"
     description:
-      name: wakelock_plus
-      sha256: "9296d40c9adbedaba95d1e704f4e0b434be446e2792948d0e4aa977048104228"
-      url: "https://pub.dev"
-    source: hosted
+      path: wakelock_plus
+      ref: HEAD
+      resolved-ref: c592df48d5e489865f7dcf34babb4a86f2291b6b
+      url: "https://github.com/soliplex/wakelock_plus.git"
+    source: git
     version: "1.4.0"
   wakelock_plus_platform_interface:
     dependency: transitive

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,7 +37,10 @@ dependencies:
     path: packages/soliplex_logging
   url_launcher: ^6.3.2
   uuid: ^4.5.1
-  wakelock_plus: ^1.4.0
+  wakelock_plus:
+    git:
+      url: https://github.com/soliplex/wakelock_plus.git
+      path: wakelock_plus
   web: ^1.1.1
 
 dev_dependencies:


### PR DESCRIPTION
## Summary

- Switch `wakelock_plus` dependency from pub.dev to the [soliplex fork](https://github.com/soliplex/wakelock_plus) which includes the fix for [fluttercommunity/wakelock_plus#19](https://github.com/fluttercommunity/wakelock_plus/issues/19)
- The fork uses `ui_web.assetManager.getAssetUrl()` instead of hardcoding `./assets/packages/...`, so the `no_sleep.js` script URL respects Flutter's `assetBase` configuration

Fixes https://github.com/enfold/afsoc-rag/issues/1062

## Test plan

- [x] Build with pub.dev `wakelock_plus`, simulate cache-bust, serve — `no_sleep.js` requested at `/assets/...` → **404**
- [x] Build with soliplex fork, simulate cache-bust, serve — `no_sleep.js` requested at `/v0.99.0-test/assets/...` → **200**
- [x] Zero console errors related to `no_sleep.js` with the fork

🤖 Generated with [Claude Code](https://claude.com/claude-code)