### PR TITLE
fix(http): graceful SSE stream close + socket leak prevention

### DIFF
--- a/packages/soliplex_client/lib/src/http/dart_http_client.dart
+++ b/packages/soliplex_client/lib/src/http/dart_http_client.dart
@@ -124,14 +124,23 @@ class DartHttpClient implements SoliplexHttpClient {
 
     late StreamController<List<int>> controller;
     StreamSubscription<List<int>>? subscription;
+    var isCancelled = false;
 
     controller = StreamController<List<int>>(
       onListen: () async {
         try {
           final streamedResponse = await _client.send(request);
 
+          // If cancelled while awaiting headers, drain to release socket.
+          if (isCancelled) {
+            unawaited(streamedResponse.stream.listen((_) {}).cancel());
+            return;
+          }
+
           // Check for HTTP errors before streaming
           if (streamedResponse.statusCode >= 400) {
+            // Drain the body stream to release the underlying socket.
+            unawaited(streamedResponse.stream.listen((_) {}).cancel());
             controller.addError(
               NetworkException(
                 message: 'HTTP ${streamedResponse.statusCode}: '
@@ -178,8 +187,27 @@ class DartHttpClient implements SoliplexHttpClient {
           await controller.close();
         }
       },
-      onCancel: () async {
-        await subscription?.cancel();
+      onCancel: () {
+        isCancelled = true;
+
+        if (subscription == null) return;
+
+        // Graceful drain: mute callbacks to prevent pumping data/errors
+        // into a closed controller, then give the server a brief window
+        // to send TCP FIN before force-cancelling.
+        subscription!.onData((_) {});
+        subscription!.onError((_) {});
+
+        // Fire-and-forget so the caller's cancel() resolves immediately.
+        unawaited(() async {
+          try {
+            await subscription!.asFuture<void>().timeout(
+                  const Duration(seconds: 2),
+                );
+          } catch (_) {
+            await subscription!.cancel();
+          }
+        }());
       },
     );
 

--- a/packages/soliplex_client/test/http/dart_http_client_test.dart
+++ b/packages/soliplex_client/test/http/dart_http_client_test.dart
@@ -755,6 +755,139 @@ void main() {
       });
     });
 
+    group('requestStream graceful close', () {
+      test('drains socket when cancelled during connection phase', () async {
+        // Simulate slow connection: send() completes after cancel
+        final sendCompleter = Completer<http.StreamedResponse>();
+        when(() => mockClient.send(any()))
+            .thenAnswer((_) => sendCompleter.future);
+
+        final stream = client.requestStream(
+          'GET',
+          Uri.parse('https://example.com/sse'),
+        );
+
+        final subscription = stream.listen((_) {});
+
+        // Cancel before send() resolves — this is the race condition
+        await subscription.cancel();
+
+        // Track whether the body stream was listened to (drained)
+        var wasDrained = false;
+        final bodyController = StreamController<List<int>>(
+          onListen: () => wasDrained = true,
+        );
+        sendCompleter.complete(
+          http.StreamedResponse(bodyController.stream, 200),
+        );
+
+        // Give onListen a chance to drain
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        // The body stream should have been listened to for draining
+        expect(wasDrained, isTrue);
+
+        await bodyController.close();
+      });
+
+      test('drains socket on HTTP error status', () async {
+        var wasDrained = false;
+        final bodyController = StreamController<List<int>>(
+          onListen: () => wasDrained = true,
+        );
+        final streamedResponse = http.StreamedResponse(
+          bodyController.stream,
+          500,
+          reasonPhrase: 'Internal Server Error',
+        );
+
+        when(() => mockClient.send(any()))
+            .thenAnswer((_) async => streamedResponse);
+
+        final stream = client.requestStream(
+          'GET',
+          Uri.parse('https://example.com/sse'),
+        );
+
+        await expectLater(stream, emitsError(isA<NetworkException>()));
+
+        // Body stream should have been drained
+        expect(wasDrained, isTrue);
+
+        await bodyController.close();
+      });
+
+      test('allows server to close gracefully on cancel after data', () async {
+        final bodyController = StreamController<List<int>>();
+        final streamedResponse = http.StreamedResponse(
+          bodyController.stream,
+          200,
+          reasonPhrase: 'OK',
+        );
+
+        when(() => mockClient.send(any()))
+            .thenAnswer((_) async => streamedResponse);
+
+        final stream = client.requestStream(
+          'GET',
+          Uri.parse('https://example.com/sse'),
+        );
+
+        final chunks = <List<int>>[];
+        final subscription = stream.listen(chunks.add);
+
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+
+        bodyController.add([1, 2, 3]);
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+
+        // Cancel the subscription (simulates app receiving terminal event)
+        await subscription.cancel();
+
+        // Server closes gracefully within the 2s window
+        await bodyController.close();
+
+        // Verify we received data before cancel
+        expect(
+          chunks,
+          equals([
+            [1, 2, 3],
+          ]),
+        );
+      });
+
+      test('force-cancels after timeout if server does not close', () async {
+        final bodyController = StreamController<List<int>>();
+        final streamedResponse = http.StreamedResponse(
+          bodyController.stream,
+          200,
+          reasonPhrase: 'OK',
+        );
+
+        when(() => mockClient.send(any()))
+            .thenAnswer((_) async => streamedResponse);
+
+        final stream = client.requestStream(
+          'GET',
+          Uri.parse('https://example.com/sse'),
+        );
+
+        final subscription = stream.listen((_) {});
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+
+        // Cancel — server will NOT close, so the 2s timeout should fire
+        await subscription.cancel();
+
+        // Wait for the 2s grace period + margin
+        await Future<void>.delayed(const Duration(seconds: 3));
+
+        // The body stream should have been force-cancelled
+        expect(bodyController.hasListener, isFalse);
+
+        await bodyController.close();
+      });
+    });
+
     group('HTTP methods', () {
       test('supports PUT request', () async {
         final streamedResponse = _createStreamedResponse(

--- a/packages/soliplex_client_native/lib/src/clients/cupertino_http_client.dart
+++ b/packages/soliplex_client_native/lib/src/clients/cupertino_http_client.dart
@@ -135,14 +135,23 @@ class CupertinoHttpClient implements SoliplexHttpClient {
 
     late StreamController<List<int>> controller;
     StreamSubscription<List<int>>? subscription;
+    var isCancelled = false;
 
     controller = StreamController<List<int>>(
       onListen: () async {
         try {
           final streamedResponse = await _client.send(request);
 
+          // If cancelled while awaiting headers, drain to release socket.
+          if (isCancelled) {
+            unawaited(streamedResponse.stream.listen((_) {}).cancel());
+            return;
+          }
+
           // Check for HTTP errors before streaming
           if (streamedResponse.statusCode >= 400) {
+            // Drain the body stream to release the underlying socket.
+            unawaited(streamedResponse.stream.listen((_) {}).cancel());
             controller.addError(
               NetworkException(
                 message: 'HTTP ${streamedResponse.statusCode}: '
@@ -182,8 +191,27 @@ class CupertinoHttpClient implements SoliplexHttpClient {
           await controller.close();
         }
       },
-      onCancel: () async {
-        await subscription?.cancel();
+      onCancel: () {
+        isCancelled = true;
+
+        if (subscription == null) return;
+
+        // Graceful drain: mute callbacks to prevent pumping data/errors
+        // into a closed controller, then give the server a brief window
+        // to send TCP FIN before force-cancelling.
+        subscription!.onData((_) {});
+        subscription!.onError((_) {});
+
+        // Fire-and-forget so the caller's cancel() resolves immediately.
+        unawaited(() async {
+          try {
+            await subscription!.asFuture<void>().timeout(
+                  const Duration(seconds: 2),
+                );
+          } catch (_) {
+            await subscription!.cancel();
+          }
+        }());
       },
     );
 


### PR DESCRIPTION
## Summary
- Fix TCP socket leak race condition in `requestStream` when consumer cancels during connection phase
- Fix TCP RST on normal SSE completion by replacing eager `subscription.cancel()` with graceful 2-second drain window
- Drain response body on HTTP 4xx/5xx to prevent socket leaks
- Mirror fixes in both `DartHttpClient` and `CupertinoHttpClient`

## Problem
Two issues in the SSE streaming path:

1. **Socket leak (severity: high):** If the consumer cancelled the stream while `await _client.send()` was still pending, the `onCancel` callback fired with `subscription == null`. When `send()` resolved, the response body stream was never drained, permanently leaking the TCP socket. Under rapid cancel/retry patterns this exhausts the connection pool.

2. **TCP RST poisoning server DB pools:** `onCancel` immediately called `subscription.cancel()`, sending TCP RST to the server before it could close gracefully. After `RunFinishedEvent`, the server expects to close the connection itself — the client-side RST cascades through uvicorn → SQLAlchemy → asyncpg, poisoning the DB connection pool.

## Changes
- **`packages/soliplex_client/lib/src/http/dart_http_client.dart`**: Add `isCancelled` flag for cancel-during-connect detection + socket drain. Drain body on HTTP errors. Replace eager cancel with muted graceful drain (2s timeout, then force-cancel).
- **`packages/soliplex_client_native/lib/src/clients/cupertino_http_client.dart`**: Identical fix for iOS/macOS.
- **`packages/soliplex_client/test/http/dart_http_client_test.dart`**: 4 new tests — cancel-during-connect drain, HTTP error drain, graceful server close, force-cancel timeout.

**No API changes** — `SoliplexHttpClient` interface is unchanged. No app-layer modifications required.

## Test plan
- [x] 1154/1154 soliplex_client tests pass (1150 existing + 4 new)
- [x] 33/33 soliplex_client_native tests pass
- [x] `dart analyze` clean on both packages
- [x] `dart format` clean
- [ ] Manual: start SSE run, let it complete, verify no "Connection reset" in server logs
- [ ] Manual: cancel mid-stream, verify RST is still sent (intentional cancel works)