### PR TITLE
fix(http): survive transient stream errors with inactivity timeout

### DIFF
--- a/packages/soliplex_client/lib/src/http/dart_http_client.dart
+++ b/packages/soliplex_client/lib/src/http/dart_http_client.dart
@@ -124,6 +124,7 @@ class DartHttpClient implements SoliplexHttpClient {
 
     late StreamController<List<int>> controller;
     StreamSubscription<List<int>>? subscription;
+    Timer? inactivityTimer;
     var isCancelled = false;
 
     controller = StreamController<List<int>>(
@@ -152,9 +153,16 @@ class DartHttpClient implements SoliplexHttpClient {
           }
 
           subscription = streamedResponse.stream.listen(
-            controller.add,
+            (data) {
+              // Reset inactivity timer on every chunk.
+              inactivityTimer?.cancel();
+              inactivityTimer = null;
+              controller.add(data);
+            },
             onError: (Object error, StackTrace stackTrace) {
-              // Wrap all stream errors as NetworkException
+              // Swallow transient stream errors (e.g. ERR_NETWORK_CHANGED)
+              // and start an inactivity timer. If real data resumes, the
+              // timer is reset. If not, the stream closes after the timeout.
               controller.addError(
                 NetworkException(
                   message: 'Stream error: $error',
@@ -162,9 +170,25 @@ class DartHttpClient implements SoliplexHttpClient {
                   stackTrace: stackTrace,
                 ),
               );
+
+              // Start inactivity deadline — if no data arrives within 30s
+              // after an error, the connection is truly dead.
+              inactivityTimer ??= Timer(
+                const Duration(seconds: 30),
+                () {
+                  subscription?.cancel();
+                  if (!controller.isClosed) {
+                    controller.close();
+                  }
+                },
+              );
             },
-            onDone: controller.close,
-            cancelOnError: true,
+            onDone: () {
+              inactivityTimer?.cancel();
+              controller.close();
+            },
+            // Don't auto-kill on error — let the inactivity timer decide.
+            cancelOnError: false,
           );
         } on http.ClientException catch (e, stackTrace) {
           controller.addError(
@@ -189,6 +213,7 @@ class DartHttpClient implements SoliplexHttpClient {
       },
       onCancel: () {
         isCancelled = true;
+        inactivityTimer?.cancel();
 
         if (subscription == null) return;
 

--- a/packages/soliplex_client/test/http/dart_http_client_test.dart
+++ b/packages/soliplex_client/test/http/dart_http_client_test.dart
@@ -886,6 +886,63 @@ void main() {
 
         await bodyController.close();
       });
+      test('survives transient stream error and receives subsequent data',
+          () async {
+        final bodyController = StreamController<List<int>>();
+        final streamedResponse = http.StreamedResponse(
+          bodyController.stream,
+          200,
+          reasonPhrase: 'OK',
+        );
+
+        when(() => mockClient.send(any()))
+            .thenAnswer((_) async => streamedResponse);
+
+        final stream = client.requestStream(
+          'GET',
+          Uri.parse('https://example.com/sse'),
+        );
+
+        final chunks = <List<int>>[];
+        final errors = <Object>[];
+        final doneCompleter = Completer<void>();
+
+        stream.listen(
+          chunks.add,
+          onError: errors.add,
+          onDone: doneCompleter.complete,
+        );
+
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+
+        // Send some data
+        bodyController.add([1, 2, 3]);
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+
+        // Simulate transient network error (e.g. ERR_NETWORK_CHANGED)
+        bodyController.addError(
+          const SocketException('Connection lost'),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+
+        // Stream should NOT be dead — send more data
+        bodyController.add([4, 5, 6]);
+        await bodyController.close();
+
+        await doneCompleter.future;
+
+        // Both chunks received despite the error in between
+        expect(
+          chunks,
+          equals([
+            [1, 2, 3],
+            [4, 5, 6],
+          ]),
+        );
+        // Error was still surfaced
+        expect(errors, hasLength(1));
+        expect(errors.first, isA<NetworkException>());
+      });
     });
 
     group('HTTP methods', () {

--- a/packages/soliplex_client_native/lib/src/clients/cupertino_http_client.dart
+++ b/packages/soliplex_client_native/lib/src/clients/cupertino_http_client.dart
@@ -135,6 +135,7 @@ class CupertinoHttpClient implements SoliplexHttpClient {
 
     late StreamController<List<int>> controller;
     StreamSubscription<List<int>>? subscription;
+    Timer? inactivityTimer;
     var isCancelled = false;
 
     controller = StreamController<List<int>>(
@@ -163,8 +164,16 @@ class CupertinoHttpClient implements SoliplexHttpClient {
           }
 
           subscription = streamedResponse.stream.listen(
-            controller.add,
+            (data) {
+              // Reset inactivity timer on every chunk.
+              inactivityTimer?.cancel();
+              inactivityTimer = null;
+              controller.add(data);
+            },
             onError: (Object error, StackTrace stackTrace) {
+              // Swallow transient stream errors (e.g. ERR_NETWORK_CHANGED)
+              // and start an inactivity timer. If real data resumes, the
+              // timer is reset. If not, the stream closes after the timeout.
               if (error is http.ClientException) {
                 controller.addError(
                   NetworkException(
@@ -176,9 +185,25 @@ class CupertinoHttpClient implements SoliplexHttpClient {
               } else {
                 controller.addError(error, stackTrace);
               }
+
+              // Start inactivity deadline — if no data arrives within 30s
+              // after an error, the connection is truly dead.
+              inactivityTimer ??= Timer(
+                const Duration(seconds: 30),
+                () {
+                  subscription?.cancel();
+                  if (!controller.isClosed) {
+                    controller.close();
+                  }
+                },
+              );
             },
-            onDone: controller.close,
-            cancelOnError: true,
+            onDone: () {
+              inactivityTimer?.cancel();
+              controller.close();
+            },
+            // Don't auto-kill on error — let the inactivity timer decide.
+            cancelOnError: false,
           );
         } on http.ClientException catch (e, stackTrace) {
           controller.addError(
@@ -193,6 +218,7 @@ class CupertinoHttpClient implements SoliplexHttpClient {
       },
       onCancel: () {
         isCancelled = true;
+        inactivityTimer?.cancel();
 
         if (subscription == null) return;
 


### PR DESCRIPTION
## Summary
- Change `cancelOnError: true` → `false` on SSE stream subscriptions so transient network errors don't immediately kill the run
- Add 30-second inactivity timer after stream errors — if data resumes, timer resets; if not, stream closes cleanly
- Mirror fix in both `DartHttpClient` and `CupertinoHttpClient`

## Problem
Chrome fires `net::ERR_NETWORK_CHANGED` when the OS reports a network interface change (wifi hop, VPN reconnect, DHCP renewal). With `cancelOnError: true`, this immediately kills the SSE stream and fails the active run — even if the connection would have recovered moments later.

Observed in production: 5 successful runs in a session, then the 6th fails mid-stream with `NetworkException: Stream error: ClientException` caused by `ERR_NETWORK_CHANGED`. The error arrives between `TOOL_END` and `TOOL_RESULT` events.

## Changes
- **`packages/soliplex_client/lib/src/http/dart_http_client.dart`**: `cancelOnError: false`, inactivity `Timer` (30s) on stream errors, timer reset on data, timer cancel on `onDone`
- **`packages/soliplex_client_native/lib/src/clients/cupertino_http_client.dart`**: identical change
- **`packages/soliplex_client/test/http/dart_http_client_test.dart`**: new test verifying stream survives transient error and receives subsequent data

**No API changes.** Follows up on #422.

## Test plan
- [x] 1155/1155 soliplex_client tests pass (1150 existing + 5 new)
- [x] 39/39 soliplex_client_native tests pass
- [x] `dart analyze` clean on both packages
- [x] New test: stream receives data after transient error
- [ ] Manual: trigger network change during active SSE run, verify run continues