### PR TITLE
revert(http): remove inactivity timer from SSE streams

### DIFF
--- a/packages/soliplex_client/lib/src/http/dart_http_client.dart
+++ b/packages/soliplex_client/lib/src/http/dart_http_client.dart
@@ -124,7 +124,6 @@ class DartHttpClient implements SoliplexHttpClient {
 
     late StreamController<List<int>> controller;
     StreamSubscription<List<int>>? subscription;
-    Timer? inactivityTimer;
     var isCancelled = false;
 
     controller = StreamController<List<int>>(
@@ -153,16 +152,9 @@ class DartHttpClient implements SoliplexHttpClient {
           }
 
           subscription = streamedResponse.stream.listen(
-            (data) {
-              // Reset inactivity timer on every chunk.
-              inactivityTimer?.cancel();
-              inactivityTimer = null;
-              controller.add(data);
-            },
+            controller.add,
             onError: (Object error, StackTrace stackTrace) {
-              // Swallow transient stream errors (e.g. ERR_NETWORK_CHANGED)
-              // and start an inactivity timer. If real data resumes, the
-              // timer is reset. If not, the stream closes after the timeout.
+              // Wrap all stream errors as NetworkException
               controller.addError(
                 NetworkException(
                   message: 'Stream error: $error',
@@ -170,25 +162,9 @@ class DartHttpClient implements SoliplexHttpClient {
                   stackTrace: stackTrace,
                 ),
               );
-
-              // Start inactivity deadline — if no data arrives within 30s
-              // after an error, the connection is truly dead.
-              inactivityTimer ??= Timer(
-                const Duration(seconds: 30),
-                () {
-                  subscription?.cancel();
-                  if (!controller.isClosed) {
-                    controller.close();
-                  }
-                },
-              );
             },
-            onDone: () {
-              inactivityTimer?.cancel();
-              controller.close();
-            },
-            // Don't auto-kill on error — let the inactivity timer decide.
-            cancelOnError: false,
+            onDone: controller.close,
+            cancelOnError: true,
           );
         } on http.ClientException catch (e, stackTrace) {
           controller.addError(
@@ -213,7 +189,6 @@ class DartHttpClient implements SoliplexHttpClient {
       },
       onCancel: () {
         isCancelled = true;
-        inactivityTimer?.cancel();
 
         if (subscription == null) return;
 

--- a/packages/soliplex_client/test/http/dart_http_client_test.dart
+++ b/packages/soliplex_client/test/http/dart_http_client_test.dart
@@ -886,63 +886,6 @@ void main() {
 
         await bodyController.close();
       });
-      test('survives transient stream error and receives subsequent data',
-          () async {
-        final bodyController = StreamController<List<int>>();
-        final streamedResponse = http.StreamedResponse(
-          bodyController.stream,
-          200,
-          reasonPhrase: 'OK',
-        );
-
-        when(() => mockClient.send(any()))
-            .thenAnswer((_) async => streamedResponse);
-
-        final stream = client.requestStream(
-          'GET',
-          Uri.parse('https://example.com/sse'),
-        );
-
-        final chunks = <List<int>>[];
-        final errors = <Object>[];
-        final doneCompleter = Completer<void>();
-
-        stream.listen(
-          chunks.add,
-          onError: errors.add,
-          onDone: doneCompleter.complete,
-        );
-
-        await Future<void>.delayed(const Duration(milliseconds: 10));
-
-        // Send some data
-        bodyController.add([1, 2, 3]);
-        await Future<void>.delayed(const Duration(milliseconds: 10));
-
-        // Simulate transient network error (e.g. ERR_NETWORK_CHANGED)
-        bodyController.addError(
-          const SocketException('Connection lost'),
-        );
-        await Future<void>.delayed(const Duration(milliseconds: 10));
-
-        // Stream should NOT be dead — send more data
-        bodyController.add([4, 5, 6]);
-        await bodyController.close();
-
-        await doneCompleter.future;
-
-        // Both chunks received despite the error in between
-        expect(
-          chunks,
-          equals([
-            [1, 2, 3],
-            [4, 5, 6],
-          ]),
-        );
-        // Error was still surfaced
-        expect(errors, hasLength(1));
-        expect(errors.first, isA<NetworkException>());
-      });
     });
 
     group('HTTP methods', () {

--- a/packages/soliplex_client_native/lib/src/clients/cupertino_http_client.dart
+++ b/packages/soliplex_client_native/lib/src/clients/cupertino_http_client.dart
@@ -135,7 +135,6 @@ class CupertinoHttpClient implements SoliplexHttpClient {
 
     late StreamController<List<int>> controller;
     StreamSubscription<List<int>>? subscription;
-    Timer? inactivityTimer;
     var isCancelled = false;
 
     controller = StreamController<List<int>>(
@@ -164,16 +163,8 @@ class CupertinoHttpClient implements SoliplexHttpClient {
           }
 
           subscription = streamedResponse.stream.listen(
-            (data) {
-              // Reset inactivity timer on every chunk.
-              inactivityTimer?.cancel();
-              inactivityTimer = null;
-              controller.add(data);
-            },
+            controller.add,
             onError: (Object error, StackTrace stackTrace) {
-              // Swallow transient stream errors (e.g. ERR_NETWORK_CHANGED)
-              // and start an inactivity timer. If real data resumes, the
-              // timer is reset. If not, the stream closes after the timeout.
               if (error is http.ClientException) {
                 controller.addError(
                   NetworkException(
@@ -185,25 +176,9 @@ class CupertinoHttpClient implements SoliplexHttpClient {
               } else {
                 controller.addError(error, stackTrace);
               }
-
-              // Start inactivity deadline — if no data arrives within 30s
-              // after an error, the connection is truly dead.
-              inactivityTimer ??= Timer(
-                const Duration(seconds: 30),
-                () {
-                  subscription?.cancel();
-                  if (!controller.isClosed) {
-                    controller.close();
-                  }
-                },
-              );
             },
-            onDone: () {
-              inactivityTimer?.cancel();
-              controller.close();
-            },
-            // Don't auto-kill on error — let the inactivity timer decide.
-            cancelOnError: false,
+            onDone: controller.close,
+            cancelOnError: true,
           );
         } on http.ClientException catch (e, stackTrace) {
           controller.addError(
@@ -218,7 +193,6 @@ class CupertinoHttpClient implements SoliplexHttpClient {
       },
       onCancel: () {
         isCancelled = true;
-        inactivityTimer?.cancel();
 
         if (subscription == null) return;
 


### PR DESCRIPTION
## Summary
- Reverts PR #426 (`fix(http): survive transient stream errors with inactivity timeout`)
- Restores `cancelOnError: true` on SSE stream subscriptions
- Removes 30-second inactivity timer from `DartHttpClient` and `CupertinoHttpClient`

## Why
The inactivity timer was designed to survive transient `ERR_NETWORK_CHANGED` errors, but Gemini analysis confirmed the approach is fundamentally flawed: when a network change occurs, the TCP socket's 4-tuple is broken and no data can ever arrive again. The timer just delays the inevitable failure by 30 seconds while the user sees a frozen UI.

The correct fix is SSE reconnection (Start+Stream pattern), which requires server-side changes. Until that's ready, failing fast with `cancelOnError: true` is the safer behavior.

## Changes
- **`dart_http_client.dart`**: Remove `Timer` import, `inactivityTimer` variable, timer logic in `onData`/`onError`/`onDone`/`onCancel`. Restore `cancelOnError: true`.
- **`cupertino_http_client.dart`**: Same changes.
- **`dart_http_client_test.dart`**: Remove `survives transient stream error` test.

## Test plan
- [x] Existing SSE stream tests still pass (graceful drain, cancel-during-connect, HTTP error drain)
- [x] Reverted test removed