### PR TITLE
fix(chat): show error indicator on document filter button

### DIFF
--- a/lib/features/chat/widgets/chat_input.dart
+++ b/lib/features/chat/widgets/chat_input.dart
@@ -5,6 +5,7 @@ import 'package:soliplex_client/soliplex_client.dart';
 import 'package:soliplex_frontend/core/logging/loggers.dart';
 import 'package:soliplex_frontend/core/providers/active_run_provider.dart';
 import 'package:soliplex_frontend/core/providers/documents_provider.dart';
+import 'package:soliplex_frontend/design/color/color_scheme_extensions.dart';
 import 'package:soliplex_frontend/design/tokens/breakpoints.dart';
 import 'package:soliplex_frontend/design/tokens/spacing.dart';
 import 'package:soliplex_frontend/shared/utils/file_type_icons.dart';
@@ -140,18 +141,26 @@ class _ChatInputState extends ConsumerState<ChatInput> {
     final hasRoom = roomId != null;
     final selectedDocs = widget.selectedDocuments;
 
-    // Check if room has documents for picker button state
-    // Only disable when we KNOW the room is empty (not during loading/error)
     final documentsAsync =
         hasRoom ? ref.watch(documentsProvider(roomId)) : null;
-    final isEmptyRoom = documentsAsync?.maybeWhen(
-          data: (docs) => docs.isEmpty,
-          orElse: () => false,
-        ) ??
-        false;
-    final pickerEnabled = canSend && !isEmptyRoom;
-    final pickerTooltip =
-        isEmptyRoom ? 'No documents in this room' : 'Select document';
+    final (:pickerEnabled, :pickerTooltip, :hasDocumentError) =
+        switch (documentsAsync) {
+      AsyncData(value: final docs) when docs.isEmpty => (
+          pickerEnabled: false,
+          pickerTooltip: 'No documents in this room',
+          hasDocumentError: false,
+        ),
+      AsyncError() => (
+          pickerEnabled: canSend,
+          pickerTooltip: 'Could not load documents',
+          hasDocumentError: true,
+        ),
+      _ => (
+          pickerEnabled: canSend,
+          pickerTooltip: 'Select document',
+          hasDocumentError: false,
+        ),
+    };
 
     final showChips = widget.showSuggestions && widget.suggestions.isNotEmpty;
 
@@ -231,7 +240,12 @@ class _ChatInputState extends ConsumerState<ChatInput> {
                 IconButton(
                   tooltip: pickerTooltip,
                   onPressed: pickerEnabled ? _showDocumentPicker : null,
-                  icon: const Icon(Icons.filter_alt),
+                  icon: Icon(
+                    Icons.filter_alt,
+                    color: hasDocumentError
+                        ? Theme.of(context).colorScheme.warning
+                        : null,
+                  ),
                 ),
               const SizedBox(width: 8),
               // Text field
@@ -438,12 +452,23 @@ class _DocumentPickerDialogState extends ConsumerState<_DocumentPickerDialog> {
             );
           },
           loading: () => const Center(child: CircularProgressIndicator()),
-          error: (error, stackTrace) => ErrorDisplay(
-            error: error,
-            stackTrace: stackTrace,
-            onRetry: () {
-              ref.read(documentsProvider(widget.roomId).notifier).retry();
-            },
+          error: (error, stackTrace) => LayoutBuilder(
+            builder: (context, constraints) => SingleChildScrollView(
+              child: ConstrainedBox(
+                constraints: BoxConstraints(minHeight: constraints.maxHeight),
+                child: ErrorDisplay(
+                  error: error,
+                  stackTrace: stackTrace,
+                  onRetry: () {
+                    ref
+                        .read(
+                          documentsProvider(widget.roomId).notifier,
+                        )
+                        .retry();
+                  },
+                ),
+              ),
+            ),
           ),
         ),
       ),

--- a/test/features/chat/widgets/chat_input_test.dart
+++ b/test/features/chat/widgets/chat_input_test.dart
@@ -13,6 +13,7 @@ import 'package:soliplex_frontend/core/providers/api_provider.dart';
 import 'package:soliplex_frontend/core/providers/documents_provider.dart';
 import 'package:soliplex_frontend/core/providers/rooms_provider.dart';
 import 'package:soliplex_frontend/core/providers/threads_provider.dart';
+import 'package:soliplex_frontend/design/color/color_scheme_extensions.dart';
 import 'package:soliplex_frontend/features/chat/widgets/chat_input.dart';
 
 import '../../../helpers/test_helpers.dart';
@@ -2176,6 +2177,133 @@ void main() {
         // Assert - no retry button for auth errors (ErrorDisplay hides it)
         expect(find.text('Retry'), findsNothing);
         expect(find.textContaining('Session expired'), findsOneWidget);
+      });
+    });
+
+    group('Document Picker Error Indicator', () {
+      testWidgets('button enabled with error tooltip when fetch fails', (
+        tester,
+      ) async {
+        // Arrange
+        final mockRoom = TestData.createRoom();
+        final mockThread = TestData.createThread();
+        final mockApi = MockSoliplexApi();
+
+        when(() => mockApi.getDocuments(mockRoom.id)).thenAnswer((_) async {
+          throw const ApiException(
+            statusCode: 500,
+            message: 'Internal Server Error',
+          );
+        });
+
+        // Act
+        await tester.pumpWidget(
+          createTestApp(
+            home: Scaffold(
+              body: ChatInput(onSend: (_) {}, roomId: mockRoom.id),
+            ),
+            overrides: [
+              currentRoomProvider.overrideWith((ref) => mockRoom),
+              currentThreadProvider.overrideWith((ref) => mockThread),
+              activeRunNotifierOverride(const IdleState()),
+              apiProvider.overrideWithValue(mockApi),
+              documentsRetryDelaysProvider.overrideWithValue(_testDelays),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Assert - button should be enabled with error tooltip
+        final button = tester.widget<IconButton>(
+          find.widgetWithIcon(IconButton, Icons.filter_alt),
+        );
+        expect(button.onPressed, isNotNull);
+        expect(button.tooltip, 'Could not load documents');
+      });
+
+      testWidgets('icon tinted warning color when fetch errors', (
+        tester,
+      ) async {
+        // Arrange
+        final mockRoom = TestData.createRoom();
+        final mockThread = TestData.createThread();
+        final mockApi = MockSoliplexApi();
+
+        when(() => mockApi.getDocuments(mockRoom.id)).thenAnswer((_) async {
+          throw const ApiException(
+            statusCode: 500,
+            message: 'Internal Server Error',
+          );
+        });
+
+        // Act
+        await tester.pumpWidget(
+          createTestApp(
+            home: Scaffold(
+              body: ChatInput(onSend: (_) {}, roomId: mockRoom.id),
+            ),
+            overrides: [
+              currentRoomProvider.overrideWith((ref) => mockRoom),
+              currentThreadProvider.overrideWith((ref) => mockThread),
+              activeRunNotifierOverride(const IdleState()),
+              apiProvider.overrideWithValue(mockApi),
+              documentsRetryDelaysProvider.overrideWithValue(_testDelays),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Assert - icon should have warning color
+        final icon = tester.widget<Icon>(
+          find.descendant(
+            of: find.widgetWithIcon(IconButton, Icons.filter_alt),
+            matching: find.byType(Icon),
+          ),
+        );
+        final context = tester.element(find.byType(ChatInput));
+        final expectedColor = Theme.of(context).colorScheme.warning;
+        expect(icon.color, expectedColor);
+      });
+
+      testWidgets('icon not tinted when documents load successfully', (
+        tester,
+      ) async {
+        // Arrange
+        final mockRoom = TestData.createRoom();
+        final mockThread = TestData.createThread();
+        final mockApi = MockSoliplexApi();
+        final documents = [
+          TestData.createDocument(id: 'doc-1', title: 'Doc 1.pdf'),
+        ];
+
+        when(
+          () => mockApi.getDocuments(mockRoom.id),
+        ).thenAnswer((_) async => documents);
+
+        // Act
+        await tester.pumpWidget(
+          createTestApp(
+            home: Scaffold(
+              body: ChatInput(onSend: (_) {}, roomId: mockRoom.id),
+            ),
+            overrides: [
+              currentRoomProvider.overrideWith((ref) => mockRoom),
+              currentThreadProvider.overrideWith((ref) => mockThread),
+              activeRunNotifierOverride(const IdleState()),
+              apiProvider.overrideWithValue(mockApi),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Assert - icon should not have warning color
+        final icon = tester.widget<Icon>(
+          find.descendant(
+            of: find.widgetWithIcon(IconButton, Icons.filter_alt),
+            matching: find.byType(Icon),
+          ),
+        );
+        expect(icon.color, isNull);
       });
     });
 


### PR DESCRIPTION
## Summary

Closes enfold/afsoc-rag#1133

- When the documents fetch fails (e.g., backend returns 500), the filter button icon tints orange with tooltip "Could not load documents". Button stays enabled so users can click to see error details and retry.
- Replaced separate `isEmptyRoom`/`pickerEnabled`/`pickerTooltip` variables with a single Dart 3 switch expression using record destructuring — all picker button state derived from one decision point.
- Fixed overflow in document picker dialog when error details are expanded (LayoutBuilder + SingleChildScrollView).

## Related

Backend root cause filed as enfold/soliplex#713 — `GET /rooms/{id}/documents` returns 500 instead of empty list for rooms with no RAG database on disk.

## Test plan

- [x] 3 new tests: error tooltip, warning color tint, no tint on success
- [x] All 62 chat_input tests pass
- [x] `flutter analyze --fatal-infos` — 0 issues
- [x] Verified visually on macOS — orange tint visible on error, button disabled on empty room, normal on success

🤖 Generated with [Claude Code](https://claude.com/claude-code)