### PR TITLE
fix(app): prevent token refresh from popping dialogs

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -71,7 +71,13 @@ class _SoliplexAppState extends ConsumerState<SoliplexApp>
     // Initialize logging system (creates sinks and applies config).
     ref.watch(logConfigControllerProvider);
 
-    final authState = ref.watch(authProvider);
+    // Only rebuild on auth loading vs. resolved — not on every token refresh.
+    // Previously this was ref.watch(authProvider), which caused SoliplexApp
+    // to rebuild on every token refresh — suspected of popping imperative
+    // routes (dialogs) via MaterialApp.router rebuild.
+    final isAuthLoading = ref.watch(
+      authProvider.select((state) => state is AuthLoading),
+    );
     final shellConfig = ref.watch(shellConfigProvider);
     final themeMode = ref.watch(themeModeProvider);
     final themeConfig = shellConfig.theme;
@@ -88,7 +94,7 @@ class _SoliplexAppState extends ConsumerState<SoliplexApp>
     // Don't construct routing until auth state is resolved.
     // This prevents building route widgets that would be discarded,
     // avoiding wasted work and premature provider side effects.
-    if (authState is AuthLoading) {
+    if (isAuthLoading) {
       return MaterialApp(
         title: shellConfig.appName,
         theme: lightTheme,

--- a/lib/features/room/room_screen.dart
+++ b/lib/features/room/room_screen.dart
@@ -299,10 +299,12 @@ class _RoomScreenState extends ConsumerState<RoomScreen> {
         (a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()),
       );
 
+    Loggers.room.debug('Room picker: opening (${sortedRooms.length} rooms)');
+    final openedAt = DateTime.now();
     final selectedId = await showDialog<String>(
       context: context,
-      builder: (context) {
-        final colorScheme = Theme.of(context).colorScheme;
+      builder: (dialogContext) {
+        final colorScheme = Theme.of(dialogContext).colorScheme;
 
         return AlertDialog(
           title: const Text('Switch Room'),
@@ -329,7 +331,7 @@ class _RoomScreenState extends ConsumerState<RoomScreen> {
                   trailing: isSelected
                       ? Icon(Icons.check, color: colorScheme.primary)
                       : null,
-                  onTap: () => Navigator.pop(context, room.id),
+                  onTap: () => Navigator.pop(dialogContext, room.id),
                 );
               },
             ),
@@ -337,6 +339,18 @@ class _RoomScreenState extends ConsumerState<RoomScreen> {
         );
       },
     );
+    final closedAfter = DateTime.now().difference(openedAt);
+    Loggers.room.debug(
+      'Room picker: closed after ${closedAfter.inMilliseconds}ms, '
+      'selectedId=$selectedId, mounted=$mounted',
+    );
+    if (selectedId == null && closedAfter.inMilliseconds < 300) {
+      Loggers.room.warning(
+        'Room picker: dismissed suspiciously fast '
+        '(${closedAfter.inMilliseconds}ms) — likely popped by navigation '
+        'rebuild, not user action',
+      );
+    }
 
     if (selectedId != null && mounted) {
       Loggers.room.info('Room switched to $selectedId');

--- a/lib/version.dart
+++ b/lib/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Generated from pubspec.yaml. Run `dart run tool/update_version.dart` after
 /// changing the version in pubspec.yaml.
-const String soliplexVersion = '0.66.0+26';
+const String soliplexVersion = '0.66.1+27';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Cross-platform Flutter frontend for Soliplex AI-powered RAG system
 publish_to: 'none'
 # To update version, run:
 # dart run tool/bump_version.dart <major|minor|patch|build>
-version: 0.66.0+26
+version: 0.66.1+27
 
 environment:
   sdk: '>=3.5.0 <4.0.0'


### PR DESCRIPTION
## Summary
- Use `authProvider.select` in `SoliplexApp` to only rebuild when auth loading state changes, not on every token refresh. Previously `ref.watch(authProvider)` caused full `MaterialApp.router` rebuilds that could pop imperative routes (dialogs) via GoRouter Navigator reconciliation.
- Add diagnostic logging to room picker dialog to capture open/close timing and flag suspiciously fast (<300ms) dismissals.

## Test plan
- [ ] Open room picker dialog on web — verify it stays open reliably
- [ ] Trigger token refresh while dialog is open — verify dialog is not dismissed
- [ ] Select a room from the picker — verify navigation works as before
- [ ] Check console logs for `Room picker:` entries confirming timing diagnostics
- [ ] Full test suite passes (1676 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)