### PR TITLE
Responsive AppBar for mobile & thinking section styling

### DIFF
--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -25,21 +25,17 @@ import 'package:soliplex_frontend/shared/widgets/shell_config.dart';
 
 /// Settings button for AppBar actions.
 ///
-/// Navigates to the settings screen when pressed.
-class _SettingsButton extends StatelessWidget {
-  const _SettingsButton();
-
-  @override
-  Widget build(BuildContext context) {
-    return Semantics(
-      label: 'Settings',
-      child: IconButton(
-        icon: const Icon(Icons.settings),
-        onPressed: () => context.push('/settings'),
-        tooltip: 'Open settings',
-      ),
-    );
-  }
+/// Returns a [Semantics]-wrapped [IconButton] directly so that
+/// [AppShell]'s mobile overflow menu can extract its properties.
+Widget _settingsButton(BuildContext context) {
+  return Semantics(
+    label: 'Settings',
+    child: IconButton(
+      icon: const Icon(Icons.settings),
+      onPressed: () => context.push('/settings'),
+      tooltip: 'Open settings',
+    ),
+  );
 }
 
 /// Back button for AppBar leading slot.
@@ -288,7 +284,9 @@ final routerProvider = Provider<GoRouter>((ref) {
             return _staticPage(
               title: const Text(''),
               body: const HomeScreen(),
-              actions: [if (features.enableSettings) const _SettingsButton()],
+              actions: [
+                if (features.enableSettings) _settingsButton(context),
+              ],
             );
           },
         ),
@@ -299,7 +297,9 @@ final routerProvider = Provider<GoRouter>((ref) {
           pageBuilder: (context, state) => _staticPage(
             title: const Text('Rooms'),
             body: const RoomsScreen(),
-            actions: [if (features.enableSettings) const _SettingsButton()],
+            actions: [
+              if (features.enableSettings) _settingsButton(context),
+            ],
           ),
         ),
       if (routeConfig.showRoomsRoute)

--- a/lib/features/chat/widgets/chat_message_widget.dart
+++ b/lib/features/chat/widgets/chat_message_widget.dart
@@ -405,9 +405,21 @@ class _ThinkingSectionState extends State<ThinkingSection> {
         children: [
           InkWell(
             onTap: () => setState(() => _isExpanded = !_isExpanded),
-            borderRadius: BorderRadius.circular(soliplexTheme.radii.md),
-            child: Padding(
+            borderRadius: BorderRadius.only(
+              topLeft: Radius.circular(soliplexTheme.radii.md),
+              topRight: Radius.circular(soliplexTheme.radii.md),
+            ),
+            child: Container(
               padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              decoration: _isExpanded
+                  ? BoxDecoration(
+                      border: Border(
+                        bottom: BorderSide(
+                          color: theme.colorScheme.outlineVariant,
+                        ),
+                      ),
+                    )
+                  : null,
               child: Row(
                 children: [
                   Icon(
@@ -445,7 +457,7 @@ class _ThinkingSectionState extends State<ThinkingSection> {
             ConstrainedBox(
               constraints: const BoxConstraints(maxHeight: 200),
               child: Padding(
-                padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+                padding: const EdgeInsets.all(12),
                 child: SingleChildScrollView(
                   child: SelectionArea(
                     child: Text(

--- a/lib/features/room/room_screen.dart
+++ b/lib/features/room/room_screen.dart
@@ -240,12 +240,6 @@ class _RoomScreenState extends ConsumerState<RoomScreen> {
     final roomsAsync = ref.watch(roomsProvider);
     final currentRoom = ref.watch(currentRoomProvider);
 
-    String trimRoomName(String name) {
-      const maxLength = 16;
-      if (name.length <= maxLength) return name;
-      return '${name.substring(0, maxLength - 3)}...';
-    }
-
     return roomsAsync.when(
       data: (rooms) => Semantics(
         label: 'Room selector, current: ${currentRoom?.name ?? 'none'}',
@@ -258,7 +252,7 @@ class _RoomScreenState extends ConsumerState<RoomScreen> {
               children: [
                 Flexible(
                   child: Text(
-                    trimRoomName(currentRoom?.name ?? 'Select Room'),
+                    currentRoom?.name ?? 'Select Room',
                     overflow: TextOverflow.ellipsis,
                   ),
                 ),

--- a/lib/shared/widgets/app_shell.dart
+++ b/lib/shared/widgets/app_shell.dart
@@ -53,6 +53,8 @@ class AppShell extends ConsumerWidget {
     final features = ref.watch(featuresProvider);
     final showInspector =
         features.enableHttpInspector && customEndDrawer == null;
+    final isMobile =
+        MediaQuery.of(context).size.width < SoliplexBreakpoints.tablet;
 
     return Scaffold(
       appBar: AppBar(
@@ -65,9 +67,10 @@ class AppShell extends ConsumerWidget {
               spacing: SoliplexSpacing.s2,
               children: [
                 if (config.leading != null) config.leading!,
-                if (shellConfig.showLogoInAppBar)
+                if (!isMobile && shellConfig.showLogoInAppBar)
                   _BrandLogo(config: shellConfig),
-                if (shellConfig.showLogoInAppBar &&
+                if (!isMobile &&
+                    shellConfig.showLogoInAppBar &&
                     shellConfig.showAppNameInAppBar)
                   Text(
                     shellConfig.appName,
@@ -88,18 +91,26 @@ class AppShell extends ConsumerWidget {
             padding: EdgeInsets.symmetric(horizontal: SoliplexSpacing.s1),
             child: ThemeToggleButton(),
           ),
-          for (final action in config.actions)
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                horizontal: SoliplexSpacing.s1,
+          if (isMobile) ...[
+            if (config.actions.isNotEmpty || showInspector)
+              _OverflowMenuButton(
+                actions: config.actions,
+                showInspector: showInspector,
               ),
-              child: action,
-            ),
-          if (showInspector)
-            const Padding(
-              padding: EdgeInsets.symmetric(horizontal: SoliplexSpacing.s1),
-              child: _InspectorButton(),
-            ),
+          ] else ...[
+            for (final action in config.actions)
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: SoliplexSpacing.s1,
+                ),
+                child: action,
+              ),
+            if (showInspector)
+              const Padding(
+                padding: EdgeInsets.symmetric(horizontal: SoliplexSpacing.s1),
+                child: _InspectorButton(),
+              ),
+          ],
         ],
       ),
       drawer: config.drawer != null
@@ -195,5 +206,61 @@ class _InspectorButton extends StatelessWidget {
         onPressed: () => Scaffold.of(context).openEndDrawer(),
       ),
     );
+  }
+}
+
+/// Overflow menu that collapses action buttons on mobile screens.
+///
+/// Extracts icon and label from [IconButton] actions (including those
+/// wrapped in [Semantics]) and renders them as [PopupMenuItem]s.
+class _OverflowMenuButton extends StatelessWidget {
+  const _OverflowMenuButton({
+    required this.actions,
+    required this.showInspector,
+  });
+
+  final List<Widget> actions;
+  final bool showInspector;
+
+  @override
+  Widget build(BuildContext context) {
+    return PopupMenuButton<VoidCallback>(
+      icon: const Icon(Icons.more_vert),
+      tooltip: 'More options',
+      onSelected: (callback) => callback(),
+      itemBuilder: (_) => [
+        for (final action in actions)
+          if (_extractIconButton(action) case final ib?)
+            PopupMenuItem<VoidCallback>(
+              value: ib.onPressed,
+              child: Row(
+                children: [
+                  ib.icon,
+                  const SizedBox(width: SoliplexSpacing.s3),
+                  Text(ib.tooltip ?? ''),
+                ],
+              ),
+            ),
+        if (showInspector)
+          PopupMenuItem<VoidCallback>(
+            value: () => Scaffold.of(context).openEndDrawer(),
+            child: const Row(
+              children: [
+                Icon(Icons.bug_report),
+                SizedBox(width: SoliplexSpacing.s3),
+                Text('HTTP inspector'),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+
+  IconButton? _extractIconButton(Widget widget) {
+    if (widget is IconButton) return widget;
+    if (widget is Semantics && widget.child is IconButton) {
+      return widget.child! as IconButton;
+    }
+    return null;
   }
 }


### PR DESCRIPTION
# Summary

Make the AppBar responsive on small screens by hiding branding and collapsing actions into an overflow menu, and improve the thinking section's expanded state styling.

## Changes

- Hide logo and app name below the tablet breakpoint (600px) in the `AppBar`
- Collapse `AppBar` action buttons (settings, info, quiz, inspector) into a three-dot overflow menu on mobile
- Keep theme toggle visible in the `AppBar` regardless of screen size
- Add `_OverflowMenuButton` widget that extracts `IconButton` properties to build popup menu items
- Convert `_SettingsButton` class to a `_settingsButton()` function so the overflow menu can introspect its `IconButton`
- Add bottom border divider to the thinking section header when expanded
- Round only the top corners of the thinking section's `InkWell` tap target

## Fixes

- Fix `RenderFlex` overflow (84px) in the `AppBar` Row on iPhone-width screens
- Fix room selector being unusable on mobile due to insufficient horizontal space
- Remove `trimRoomName()` 16-character truncation hack in favor of natural `TextOverflow.ellipsis`